### PR TITLE
Remove genpybindings and gentypelibxml from test.rosinstall

### DIFF
--- a/test/test.rosinstall
+++ b/test/test.rosinstall
@@ -29,16 +29,6 @@
     version: master
 
 - git:
-    uri: 'git://github.com/ros/genpybindings.git'
-    local-name: genpybindings
-    version: master
-
-- git:
-    uri: 'git://github.com/ros/gentypelibxml.git'
-    local-name: gentypelibxml
-    version: master
-
-- git:
     uri: 'git://github.com/ros/std_msgs.git'
     local-name: std_msgs
     version: master


### PR DESCRIPTION
These take a long time to build and are extras; it's easy to disable them, but I keep forgetting to, so I keep wasting time each time I setup a 'clean' checkout to test against.
