### PR TITLE
Librt Check

### DIFF
--- a/cmake/tools/rt.cmake
+++ b/cmake/tools/rt.cmake
@@ -31,14 +31,12 @@
 # message("CMAKE_SYSTEM_LIBRARY_PATH: ${CMAKE_SYSTEM_LIBRARY_PATH}")
 # message("CMAKE_VERSION=${CMAKE_VERSION}")
 
-if(NOT APPLE)
+if(NOT (APPLE OR WIN32 OR MINGW))
   if (${CMAKE_VERSION} VERSION_LESS 2.8.4)
-    if(NOT (WIN32 OR MINGW))
-      # cmake later than 2.8.0 appears to have a better find_library
-      # that knows about the ABI of the compiler.  For lucid we just
-      # depend on the linker to find it for us.
-      set(RT_LIBRARY rt CACHE FILEPATH "Hacked find of rt for cmake < 2.8.4")
-    endif()
+    # cmake later than 2.8.0 appears to have a better find_library
+    # that knows about the ABI of the compiler.  For lucid we just
+    # depend on the linker to find it for us.
+    set(RT_LIBRARY rt CACHE FILEPATH "Hacked find of rt for cmake < 2.8.4")
   else()
     find_library(RT_LIBRARY rt)
     assert_file_exists(${RT_LIBRARY} "RT Library")


### PR DESCRIPTION
Properly avoid the librt check on win32/apple/mingw - missed it in part the first time around. This should be right now.
