### PR TITLE
Dependencies with pkg-config

### DIFF
--- a/bin/em/rules.cmake.em
+++ b/bin/em/rules.cmake.em
@@ -15,6 +15,7 @@ export CMAKE_PREFIX_PATH=@(INSTALL_PREFIX)
 #  https://code.ros.org/trac/ros/ticket/2977
 #  https://code.ros.org/trac/ros/ticket/3842
 export LDFLAGS=
+export PKG_CONFIG_PATH=@(INSTALL_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
 
 %:
 	dh  $@@

--- a/bin/em/rules.cmake.em
+++ b/bin/em/rules.cmake.em
@@ -15,7 +15,7 @@ export CMAKE_PREFIX_PATH=@(INSTALL_PREFIX)
 #  https://code.ros.org/trac/ros/ticket/2977
 #  https://code.ros.org/trac/ros/ticket/3842
 export LDFLAGS=
-export PKG_CONFIG_PATH=@(INSTALL_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+export PKG_CONFIG_PATH=@(INSTALL_PREFIX)/lib/pkgconfig
 
 %:
 	dh  $@@


### PR DESCRIPTION
pkg-config is unable to find dependencies during .deb building because PKG_CONFIG_PATH is not set. I added this to the rules file for cmake. It may make sense to add this environment variable for other sets of rules too.
