### PR TITLE
Find modules...and specifically a bzip2 find module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ configure_file(cmake/tests.cmake.in
 
 include(${catkin_EXTRAS_DIR}/all.cmake)
 
-list(APPEND CMAKE_MODULE_PATH ${catkin_EXTRAS_DIR}/Modules)
-
 add_subdirectory(env-hooks)
 add_subdirectory(bin)
 catkin_generic_hooks()

--- a/cmake/Modules/FindBZip2.cmake
+++ b/cmake/Modules/FindBZip2.cmake
@@ -1,0 +1,28 @@
+# - Try to find BZip2
+# Once done this will define
+#
+#  BZIP2_FOUND - system has BZip2
+#  BZIP2_INCLUDE_DIR - the BZip2 include directory
+#  BZIP2_LIBRARIES - Link these to use BZip2
+#  BZIP2_NEED_PREFIX - this is set if the functions are prefixed with BZ2_
+#
+# This differs from the original script by introducing 
+# BZIP2_ROOT to help it find the package when it is installed
+# on a system with no standard search directories (windoze).
+
+FIND_PATH(BZIP2_INCLUDE_DIR bzlib.h PATHS ${BZIP2_ROOT}/include )
+
+FIND_LIBRARY(BZIP2_LIBRARIES NAMES bz2 bzip2 PATHS ${BZIP2_ROOT}/lib)
+
+# handle the QUIETLY and REQUIRED arguments and set BZip2_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(BZip2 DEFAULT_MSG BZIP2_LIBRARIES BZIP2_INCLUDE_DIR)
+
+IF (BZIP2_FOUND)
+   INCLUDE(CheckLibraryExists)
+   CHECK_LIBRARY_EXISTS(${BZIP2_LIBRARIES} BZ2_bzCompressInit "" BZIP2_NEED_PREFIX)
+ENDIF (BZIP2_FOUND)
+
+MARK_AS_ADVANCED(BZIP2_INCLUDE_DIR BZIP2_LIBRARIES)
+

--- a/toplevel.cmake
+++ b/toplevel.cmake
@@ -18,6 +18,7 @@ if (IS_DIRECTORY ${CMAKE_SOURCE_DIR}/catkin)
   set(CATKIN_BUILD_PROJECTS "ALL" CACHE STRING
     "List of projects to build, or ALL for all.  Use to completely exclude certain projects from cmake traversal.")
   add_subdirectory(catkin)
+  list(APPEND CMAKE_MODULE_PATH ${catkin_EXTRAS_DIR}/Modules)
 else()
   find_package(catkin)
 endif()


### PR DESCRIPTION
I couldn't find a standard place for cmake find modules within the new catkin system so I took what was partially there and modified it a bit. It originally added the cmake/Modules directory to the CMAKE_MODULE_PATH, but the scope of the modified path only holds whilst inside the catkin package. 
Instead, I append it from the toplevel cmake - so that the catkin/cmake/Modules can be used by everyone. 

This works for the short term - long term is the catkin package the right place for an extensive library of find-xxx cmake modules?

The bzip2 find module above - it is a modified version of the official bzip2 module which fails on windows. There is no standard include/lib paths there and the module has no BZIP2_ROOT style helper variables.
