### PR TITLE
Bugfix to correctly repair scope for shared library settings

### DIFF
--- a/cmake/catkin_workspace.cmake
+++ b/cmake/catkin_workspace.cmake
@@ -12,6 +12,9 @@ function(catkin_workspace)
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+  # libraries.cmake
+  configure_shared_library_build_settings()
+
   em_expand(
     ${catkin_EXTRAS_DIR}/templates/topologically_traverse.py.in
     ${CMAKE_CURRENT_BINARY_DIR}/topologically_traverse.py

--- a/cmake/libraries.cmake
+++ b/cmake/libraries.cmake
@@ -8,11 +8,15 @@
 # via the mingw cross compiler, though embedded builds
 # could be feasibly built this way also (largely untested).
 
+# Cached variable
 option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
 
-if (BUILD_SHARED_LIBS)
-  add_definitions(-DROS_BUILD_SHARED_LIBS=1)
-else()
-  message(STATUS "BUILD_STATIC_LIBS is off.")
-endif()
+function(configure_shared_library_build_settings)
+  if (BUILD_SHARED_LIBS)
+    message(STATUS "BUILD_SHARED_LIBS is on.")
+    add_definitions(-DROS_BUILD_SHARED_LIBS=1)
+  else()
+    message(STATUS "BUILD_SHARED_LIBS is off.")
+  endif()
+endfunction()
 


### PR DESCRIPTION
The original libraries variable settings were put in libraries.cmake, but except for the cached variable, these get lost inside catkin's scope.

It needs to be put inside a function and called from catkin_workspace to keep the variables throughout the project traversal.

Fixed and tested on windows/msvc.
