### PR TITLE
Catkin tweaks for Archlinux

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -5,8 +5,14 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} ${catkin_EXTRAS_DIR}/python_version
 
 set(PYTHON_VERSION_XDOTY ${PYTHON_VERSION_XDOTY} CACHE STRING "python version")
 
-# this should actually be for anything non-dist-packages
+#This should be resolved automatically one day...
+option(NON_DEB_LAYOUT "ON for non deb python packages layout" OFF)
+
 if(APPLE)
+  set(NON_DEB_LAYOUT ON)
+endif()
+
+if(NON_DEB_LAYOUT)
   set(PYTHON_PACKAGES_DIR site-packages CACHE STRING "dist-packages or site-packages")
   set(SETUPTOOLS_ARG_EXTRA "" CACHE STRING "extra arguments to setuptools")
 else()

--- a/cmake/tests.cmake.in
+++ b/cmake/tests.cmake.in
@@ -110,7 +110,10 @@ function(add_nosetests dir)
   # Check that nosetests is installed.
   find_program(nosetests_path nosetests)
   if(NOT nosetests_path)
-    message(FATAL_ERROR "Can't find nosetests executable... try installing package 'python-nose'")
+    find_program(nosetests_path nosetests2)
+    if(NOT nosetests_path)
+      message(FATAL_ERROR "Can't find nosetests executable... try installing package 'python-nose'")
+    endif()
   endif()
 
   parse_arguments(_nose "WORKING_DIRECTORY" "" ${ARGN})


### PR DESCRIPTION
Added a cmake option for non deb python packages layout for those of us that need it but aren't apple.

Fixed problem with 'nosetests' not existing in archlinux under that name.
