### PR TITLE
Nosetests in Archlinux is called nosetests2. Adjust test for presence...

### DIFF
--- a/cmake/tests.cmake.in
+++ b/cmake/tests.cmake.in
@@ -109,7 +109,11 @@ function(add_nosetests dir)
   # Check that nosetests is installed.
   find_program(nosetests_path nosetests)
   if(NOT nosetests_path)
-    message(FATAL_ERROR "Can't find nosetests executable... try installing package 'python-nose'")
+    # Maybe it has version style naming
+    find_program(nosetests_path nosetests2)
+      if(NOT nosetests_path)
+        message(FATAL_ERROR "Can't find nosetests executable... try installing package 'python-nose'")
+    endif()
   endif()
 
   parse_arguments(_nose "WORKING_DIRECTORY" "" ${ARGN})


### PR DESCRIPTION
...accordingly.

Resubmit of a fix previously submitted in a combined patch. Allows nosetests to be found under archlinux.
