### PR TITLE
stack.yaml updates

### DIFF
--- a/bin/catkin_util.sh
+++ b/bin/catkin_util.sh
@@ -104,6 +104,7 @@ read_stack_yaml ()
 
     PACKAGE_NAME=$(/bin/echo $TXT | perl -ne '/Catkin-ProjectName:\s+([^\s]+)/ && print $1')
 
+    CHECKOUT_TAG=$(/bin/echo $TXT | perl -ne '/Tag:\s+([^\s]+)/ && print $1')
 }
 
 prompt_continue()

--- a/bin/git-catkin-import-upstream
+++ b/bin/git-catkin-import-upstream
@@ -38,7 +38,13 @@ fi
 
 UPSTREAM_CLONE=$TMPDIR/upstream
 repo_clone $UPSTREAM_TYPE $UPSTREAM_REPO $UPSTREAM_CLONE
-read_stack_yaml $UPSTREAM_CLONE/stack.yaml
+if [ -e $UPSTREAM_CLONE/stack.yaml ]
+then
+    read_stack_yaml $UPSTREAM_CLONE/stack.yaml
+else
+    read_stack_yaml stack.yaml
+fi
+
 status "Upstream's stack.yaml has version ${boldon}$VERSION_FULL${reset}"
 status "Upstream's name is ${boldon}$PACKAGE_NAME${reset}"
 
@@ -48,7 +54,15 @@ TARBALL=$TARBALL_PREFIX.tar.gz
 (
     # set -x
     cd $UPSTREAM_CLONE
-    repo_export $UPSTREAM_TYPE $UPSTREAM_CLONE $TARBALL_PREFIX $VERSION_FULL
+    if [ "$CHECKOUT_TAG" != "" ]
+    then
+	status "Cloning tag $CHECKOUT_TAG"
+	repo_export $UPSTREAM_TYPE $UPSTREAM_CLONE $TARBALL_PREFIX $CHECKOUT_TAG
+    else
+	status "Cloning tag $VERSION_FULL"
+	repo_export $UPSTREAM_TYPE $UPSTREAM_CLONE $TARBALL_PREFIX $VERSION_FULL
+    fi
+    exit
 )
 
 LASTTAG=$(git for-each-ref --sort='*authordate' --format='%(refname:short)' refs/tags/upstream | tail -1)


### PR DESCRIPTION
For 3rd party repos it is convenient to have the stack.yaml located only on github, not in upstream. This is used in OMPL, and I believe PCL as well.

In addition, it is important not to make too many assumptions about the tag names in upstream. For that, I added an optional Tag: element to stack.yaml, which is used by catkin-import-upstream.
