### PR TITLE
Windows buildspace environment update

### DIFF
--- a/cmake/catkin_add_env_hooks.cmake
+++ b/cmake/catkin_add_env_hooks.cmake
@@ -62,13 +62,14 @@ function(catkin_generic_hooks)
   configure_file(${catkin_EXTRAS_DIR}/templates/env.sh.buildspace.in
     ${CMAKE_BINARY_DIR}/env.sh)
 
-  # TODO: windows .bat versions, currently only for buildspace
-  configure_file(${catkin_EXTRAS_DIR}/templates/setup.bat.buildspace.in
-    ${CMAKE_BINARY_DIR}/setup.bat)
-
-  configure_file(${catkin_EXTRAS_DIR}/templates/env.bat.buildspace.in
-    ${CMAKE_BINARY_DIR}/env.bat)
-
+  if(MSVC)
+    # TODO: windows .bat versions, currently only for buildspace
+    configure_file(${catkin_EXTRAS_DIR}/templates/setup.bat.buildspace.in
+      ${CMAKE_BINARY_DIR}/setup.bat)
+    configure_file(${catkin_EXTRAS_DIR}/templates/env.bat.buildspace.in
+      ${CMAKE_BINARY_DIR}/env.bat)
+  endif(MSVC)
+  
   if(catkin_SOURCE_DIR) #TODO FIXME these should only be installed if this is catkin?
     install(PROGRAMS
       ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.sh

--- a/cmake/templates/env.bat.buildspace.in
+++ b/cmake/templates/env.bat.buildspace.in
@@ -5,7 +5,7 @@
 )
 
 :EnterBuildEnvironment
-@echo "Entering build environment at@CMAKE_BINARY_DIR@"
+@echo "Entering build environment at @CMAKE_BINARY_DIR@"
 cmd /K @CMAKE_BINARY_DIR@/setup.bat
 @echo "Exiting build environment at @CMAKE_BINARY_DIR@"
 @goto End

--- a/cmake/templates/env.bat.buildspace.in
+++ b/cmake/templates/env.bat.buildspace.in
@@ -1,5 +1,17 @@
-@set PYTHONPATH=@CMAKE_BINARY_DIR@/gen/py;%PYTHONPATH%
-@set PATH=@CMAKE_BINARY_DIR@/bin;@catkin_SOURCE_DIR@/bin;%PATH%
-@set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@
-@set CATKIN_SOURCE_DIR=@CMAKE_SOURCE_DIR@
+@if "%1"=="" (
+  goto EnterBuildEnvironment
+) else ( 
+  goto EnterExecutionEnvironment
+)
+
+:EnterBuildEnvironment
+@echo "Entering build environment at@CMAKE_BINARY_DIR@"
+cmd /K @CMAKE_BINARY_DIR@/setup.bat
+@echo "Exiting build environment at @CMAKE_BINARY_DIR@"
+@goto End
+
+:EnterExecutionEnvironment
 @%*
+@goto End
+
+:End

--- a/cmake/templates/setup.bat.buildspace.in
+++ b/cmake/templates/setup.bat.buildspace.in
@@ -1,4 +1,23 @@
+@set CATKIN_SHELL=bat
 @set PYTHONPATH=@CMAKE_BINARY_DIR@/gen/py;%PYTHONPATH%
 @set PATH=@CMAKE_BINARY_DIR@/bin;@catkin_SOURCE_DIR@/bin;%PATH%
 @set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@
 @set CATKIN_SOURCE_DIR=@CMAKE_SOURCE_DIR@
+
+@REM We should eventually do catkin's env-hooks properly.
+@REM Refer to setup.sh.buildspace.in for example code on how to bring them in.
+
+@REM These should go in a catkin/00.catkin.buildspace.bat.in
+
+@set ROSDEPS_ROOT=@ROSDEPS_ROOT@
+@if DEFINED ROSDEPS_ROOT set PATH=%ROSDEPS_ROOT%/bin;%ROSDEPS_ROOT%/lib;%PATH%
+
+@REM These are compatible and should go in build/etc/catkin/profile.d/10.ros.buildspace.all
+@REM Actually it would go in 10.ros.buildsspace.bat.in and the .all should get split up
+
+@set ROS_TEST_RESULTS_DIR=@CMAKE_BINARY_DIR@/test_results
+@set ROS_PACKAGE_PATH=@CMAKE_SOURCE_DIR@
+@set ROS_DISTRO=fuerte
+@if NOT DEFINED ROS_MASTER_URI (
+  set ROS_MASTER_URI=http://localhost:11311
+)


### PR DESCRIPTION
Updating buildspace env.bat and setup.bat to align with current catkin (previously a bit old, gnarly and broken).

Some of the variables going into it need to go into the environment hooks (e.g. ros/env-hooks/10.ros.buildspace.xxx) but we'll patch them upstream later when we're a bit more sure of what needs to go into them.

`python rosmaster` now works!
