### PR TITLE
Windoze updates enabling the install space

### DIFF
--- a/cmake/catkin_add_env_hooks.cmake
+++ b/cmake/catkin_add_env_hooks.cmake
@@ -41,26 +41,6 @@ endfunction()
 
 
 function(catkin_generic_hooks)
-  foreach(shell sh bash zsh)
-    configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.buildspace.in
-      ${CMAKE_BINARY_DIR}/setup.${shell})
-
-    configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.installable.in
-      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.${shell})
-
-    if(catkin_SOURCE_DIR) #TODO FIXME these should only be installed if this is catkin?
-      install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.${shell}
-        DESTINATION ${CMAKE_INSTALL_PREFIX}
-        )
-    endif()
-  endforeach()
-
-  configure_file(${catkin_EXTRAS_DIR}/templates/env.sh.installable.in
-    ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.sh)
-
-  configure_file(${catkin_EXTRAS_DIR}/templates/env.sh.buildspace.in
-    ${CMAKE_BINARY_DIR}/env.sh)
 
   if(MSVC)
     # TODO: windows .bat versions, currently only for buildspace
@@ -68,15 +48,43 @@ function(catkin_generic_hooks)
       ${CMAKE_BINARY_DIR}/setup.bat)
     configure_file(${catkin_EXTRAS_DIR}/templates/env.bat.buildspace.in
       ${CMAKE_BINARY_DIR}/env.bat)
-  endif(MSVC)
-  
-  if(catkin_SOURCE_DIR) #TODO FIXME these should only be installed if this is catkin?
+    configure_file(${catkin_EXTRAS_DIR}/templates/setup.bat.installable.in
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.bat)
+    configure_file(${catkin_EXTRAS_DIR}/templates/env.bat.installable.in
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.bat)
+    install(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.bat
+              DESTINATION ${CMAKE_INSTALL_PREFIX}
+    )
     install(PROGRAMS
-      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.sh
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.bat
       DESTINATION ${CMAKE_INSTALL_PREFIX}
     )
-  endif()
-
+  else(MSVC) # Not msvc
+    foreach(shell sh bash zsh)
+      configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.buildspace.in
+        ${CMAKE_BINARY_DIR}/setup.${shell})
+      configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.installable.in
+        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.${shell})
+      if(catkin_SOURCE_DIR) #TODO FIXME these should only be installed if this is catkin?
+        install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.${shell}
+          DESTINATION ${CMAKE_INSTALL_PREFIX}
+          )
+      endif()
+    endforeach()
+    configure_file(${catkin_EXTRAS_DIR}/templates/env.sh.installable.in
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.sh)
+    configure_file(${catkin_EXTRAS_DIR}/templates/env.sh.buildspace.in
+      ${CMAKE_BINARY_DIR}/env.sh)
+    if(catkin_SOURCE_DIR) #TODO FIXME these should only be installed if this is catkin?
+      install(PROGRAMS
+        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/env.sh
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+      )
+    endif()
+  endif(MSVC)
+  
   configure_file(${catkin_EXTRAS_DIR}/templates/rosinstall.installable.in
     ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/.rosinstall)
 

--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -32,13 +32,20 @@ function(catkin_python_setup)
   if(EXISTS ${${pkg_name}_SOURCE_DIR}/${SETUP_PY_FILE})
     assert(INSTALLED_PYTHONPATH)
     set(INSTALL_CMD_WORKING_DIRECTORY ${${pkg_name}_SOURCE_DIR})
-    set(INSTALL_SCRIPT
-      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/python_distutils_install.sh)
-
-    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.sh.in
-      ${INSTALL_SCRIPT}
-      @ONLY)
-
+    if(MSVC)
+      set(INSTALL_SCRIPT
+        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/python_distutils_install.bat)
+      configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.bat.in
+        ${INSTALL_SCRIPT}
+        @ONLY)
+    else()
+      set(INSTALL_SCRIPT
+        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/python_distutils_install.sh)
+      configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.sh.in
+        ${INSTALL_SCRIPT}
+        @ONLY)
+    endif()
+    
     configure_file(${catkin_EXTRAS_DIR}/templates/safe_execute_install.cmake.in
       ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/safe_execute_install.cmake)
 

--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -33,6 +33,8 @@ function(catkin_python_setup)
     assert(INSTALLED_PYTHONPATH)
     set(INSTALL_CMD_WORKING_DIRECTORY ${${pkg_name}_SOURCE_DIR})
     if(MSVC)
+      # Need to convert install prefix to native path for python setuptools --prefix (its fussy about \'s)
+      file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} PYTHON_INSTALL_PREFIX)
       set(INSTALL_SCRIPT
         ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/python_distutils_install.bat)
       configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.bat.in

--- a/cmake/libraries.cmake
+++ b/cmake/libraries.cmake
@@ -44,6 +44,17 @@ if (BUILD_SHARED_LIBS)
                  COMMAND if exist "${PROJECT_BINARY_DIR}/bin/${ARGV0}.dll" ( cp bin/*dll* ${CMAKE_BINARY_DIR}/bin )
                  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
                  )
+        # Quite likely, linux guys hacking packages will not think to set the runtime destination to bin
+        # for dll's and this will create a huge headache in porting. Just do it here for now.
+        # From cmake docs - 'Installing a target with EXCLUDE_FROM_ALL set to true has undefined behavior.'
+        get_target_property(${ARGV0}_EXCLUDE_FROM_INSTALL ${ARGV0} EXCLUDE_FROM_ALL)
+        if ( NOT ${${ARGV0}_EXCLUDE_FROM_INSTALL} )  
+            install(TARGETS ${ARGV0}
+                    RUNTIME DESTINATION bin
+                    ARCHIVE DESTINATION lib
+                    LIBRARY DESTINATION lib 
+            )
+        endif()
       endif()
     endfunction()
   endif(MSVC)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -8,7 +8,7 @@ set(PYTHON_VERSION_XDOTY ${PYTHON_VERSION_XDOTY} CACHE STRING "python version")
 #This should be resolved automatically one day...
 option(SETUPTOOLS_DEB_LAYOUT "ON for debian style python packages layout" ON)
 
-if(APPLE)
+if(APPLE OR MSVC)
   set(SETUPTOOLS_DEB_LAYOUT OFF)
 endif()
 
@@ -20,7 +20,14 @@ else()
   set(SETUPTOOLS_ARG_EXTRA "" CACHE STRING "extra arguments to setuptools")
 endif()
 
-set(INSTALLED_PYTHONPATH ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_XDOTY}/${PYTHON_PACKAGES_DIR}
-  CACHE INTERNAL "This needs to be in pythonpath when setup.py install is called.  And it needs to match.  But setuptools won't tell us where it will install things.")
+# Windows setuptools installs to Lib/site-packages not Lib/python2.7/site-packages 
+# Or is this SETUPTOOLS_DEB_LAYOUT dependant?
+if(MSVC)
+  set(INSTALLED_PYTHONPATH ${CMAKE_INSTALL_PREFIX}/lib/${PYTHON_PACKAGES_DIR}
+    CACHE INTERNAL "This needs to be in pythonpath when setup.py install is called.  And it needs to match.  But setuptools won't tell us where it will install things.")
+else()
+  set(INSTALLED_PYTHONPATH ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_XDOTY}/${PYTHON_PACKAGES_DIR}
+    CACHE INTERNAL "This needs to be in pythonpath when setup.py install is called.  And it needs to match.  But setuptools won't tell us where it will install things.")
+endif()
 
 

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -17,7 +17,8 @@ if(SETUPTOOLS_DEB_LAYOUT)
   set(SETUPTOOLS_ARG_EXTRA "--install-layout=deb" CACHE STRING "extra arguments to setuptools")
 else()
   set(PYTHON_PACKAGES_DIR site-packages CACHE STRING "dist-packages or site-packages")
-  set(SETUPTOOLS_ARG_EXTRA "" CACHE STRING "extra arguments to setuptools")
+  file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/bin PYTHON_INSTALL_PREFIX) # setuptools is fussy about windows paths
+  set(SETUPTOOLS_ARG_EXTRA "--install-scripts=${PYTHON_INSTALL_PREFIX}" CACHE STRING "extra arguments to setuptools")
 endif()
 
 # Windows setuptools installs to Lib/site-packages not Lib/python2.7/site-packages 

--- a/cmake/templates/env.bat.installable.in
+++ b/cmake/templates/env.bat.installable.in
@@ -1,0 +1,19 @@
+@echo off
+if "%1"=="" (
+  goto EnterBuildEnvironment
+) else ( 
+  goto EnterExecutionEnvironment
+)
+
+:EnterBuildEnvironment
+echo "Entering build environment at @CMAKE_INSTALL_PREFIX@"
+cmd /K @CMAKE_INSTALL_PREFIX@/setup.bat
+echo "Exiting build environment at @CMAKE_INSTALL_PREFIX@"
+goto End
+
+:EnterExecutionEnvironment
+call @CMAKE_INSTALL_PREFIX@/setup.bat
+%*
+goto End
+
+:End

--- a/cmake/templates/python_distutils_install.bat.in
+++ b/cmake/templates/python_distutils_install.bat.in
@@ -1,3 +1,20 @@
 @echo off
 
 echo "Python distutils install : on windows this is still just an empty stub that needs feeding."
+
+if DEFINED DESTDIR (
+  echo "Destdir.............%DESTDIR%"
+  set DESTDIR_ARG=--root=%DESTDIR%
+)
+echo "Destir..............%DESTDIR%"
+echo "Destdir arg.........%DESTDIR_ARG%"
+echo "Install cmd working dir........@INSTALL_CMD_WORKING_DIRECTORY@"
+echo "Setuptools arg extra.......@SETUPTOOLS_ARG_EXTRA@"
+echo "CMake Install Prefix.......@CMAKE_INSTALL_PREFIX@"
+
+cd @INSTALL_CMD_WORKING_DIRECTORY@
+
+REM mkdir @CMAKE_INSTALL_PREFIX@/lib/site-packages
+REM Missing @SETUPTOOLS_ARG_EXTRA@ after DESTDIR_ARG
+cmd /V:on /C "set PYTHONPATH=@INSTALLED_PYTHONPATH@;@CMAKE_BINARY_DIR@/gen/py;%PYTHONPATH% && set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@ && @PYTHON_EXECUTABLE@ @CMAKE_CURRENT_SOURCE_DIR@/setup.py install %DESTDIR_ARG% --prefix=@PYTHON_INSTALL_PREFIX@"
+

--- a/cmake/templates/python_distutils_install.bat.in
+++ b/cmake/templates/python_distutils_install.bat.in
@@ -1,20 +1,11 @@
 @echo off
 
-echo "Python distutils install : on windows this is still just an empty stub that needs feeding."
-
 if DEFINED DESTDIR (
   echo "Destdir.............%DESTDIR%"
   set DESTDIR_ARG=--root=%DESTDIR%
 )
-echo "Destir..............%DESTDIR%"
-echo "Destdir arg.........%DESTDIR_ARG%"
-echo "Install cmd working dir........@INSTALL_CMD_WORKING_DIRECTORY@"
-echo "Setuptools arg extra.......@SETUPTOOLS_ARG_EXTRA@"
-echo "CMake Install Prefix.......@CMAKE_INSTALL_PREFIX@"
 
 cd @INSTALL_CMD_WORKING_DIRECTORY@
 
-REM mkdir @CMAKE_INSTALL_PREFIX@/lib/site-packages
-REM Missing @SETUPTOOLS_ARG_EXTRA@ after DESTDIR_ARG
-cmd /V:on /C "set PYTHONPATH=@INSTALLED_PYTHONPATH@;@CMAKE_BINARY_DIR@/gen/py;%PYTHONPATH% && set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@ && @PYTHON_EXECUTABLE@ @CMAKE_CURRENT_SOURCE_DIR@/setup.py install %DESTDIR_ARG% --prefix=@PYTHON_INSTALL_PREFIX@"
+cmd /V:on /C "set PYTHONPATH=@INSTALLED_PYTHONPATH@;@CMAKE_BINARY_DIR@/gen/py;%PYTHONPATH% && set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@ && @PYTHON_EXECUTABLE@ @CMAKE_CURRENT_SOURCE_DIR@/setup.py install %DESTDIR_ARG% @SETUPTOOLS_ARG_EXTRA@ --prefix=@PYTHON_INSTALL_PREFIX@"
 

--- a/cmake/templates/python_distutils_install.bat.in
+++ b/cmake/templates/python_distutils_install.bat.in
@@ -1,0 +1,3 @@
+@echo off
+
+echo "Python distutils install : on windows this is still just an empty stub that needs feeding."

--- a/cmake/templates/setup.bat.installable.in
+++ b/cmake/templates/setup.bat.installable.in
@@ -4,7 +4,7 @@ set CATKIN_SHELL=bat
 
 REM path segment PREFIX/lib/pythonX.Y/[dist|site]-packages in PYTHONPATH is calculated
 REM by us... this appears to be what setuptools does under --install-layout=deb
-set PYTHONPATH=@CMAKE_INSTALL_PREFIX@/lib/python@PYTHON_VERSION_XDOTY@/@PYTHON_PACKAGES_DIR@;%PYTHONPATH%
+set PYTHONPATH=@CMAKE_INSTALL_PREFIX@/lib/@PYTHON_PACKAGES_DIR@;%PYTHONPATH%
 set PATH=@CMAKE_INSTALL_PREFIX@/bin;%PATH%
 set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@
 set CATKIN_SOURCE_DIR=@CMAKE_SOURCE_DIR@

--- a/cmake/templates/setup.bat.installable.in
+++ b/cmake/templates/setup.bat.installable.in
@@ -5,7 +5,7 @@ set CATKIN_SHELL=bat
 REM path segment PREFIX/lib/pythonX.Y/[dist|site]-packages in PYTHONPATH is calculated
 REM by us... this appears to be what setuptools does under --install-layout=deb
 set PYTHONPATH=@CMAKE_INSTALL_PREFIX@/lib/python@PYTHON_VERSION_XDOTY@/@PYTHON_PACKAGES_DIR@;%PYTHONPATH%
-set PATH=@CMAKE_INSTALL_PREFIX@/bin:%PATH%
+set PATH=@CMAKE_INSTALL_PREFIX@/bin;%PATH%
 set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@
 set CATKIN_SOURCE_DIR=@CMAKE_SOURCE_DIR@
 

--- a/cmake/templates/setup.bat.installable.in
+++ b/cmake/templates/setup.bat.installable.in
@@ -1,0 +1,32 @@
+@echo off
+
+set CATKIN_SHELL=bat
+
+REM path segment PREFIX/lib/pythonX.Y/[dist|site]-packages in PYTHONPATH is calculated
+REM by us... this appears to be what setuptools does under --install-layout=deb
+set PYTHONPATH=@CMAKE_INSTALL_PREFIX@/lib/python@PYTHON_VERSION_XDOTY@/@PYTHON_PACKAGES_DIR@;%PYTHONPATH%
+set PATH=@CMAKE_INSTALL_PREFIX@/bin:%PATH%
+set CATKIN_BINARY_DIR=@CMAKE_BINARY_DIR@
+set CATKIN_SOURCE_DIR=@CMAKE_SOURCE_DIR@
+
+REM the first  path: to have custom cmake modules inside Modules (e.g. Eigen)
+REM the second path: this is so that find_package works well...
+set CMAKE_PREFIX_PATH=@CMAKE_INSTALL_PREFIX@/share/catkin/cmake/Modules:@CMAKE_INSTALL_PREFIX@:%CMAKE_PREFIX_PATH%
+
+set PKG_CONFIG_PATH=@CMAKE_INSTALL_PREFIX@/lib/pkgconfig:%PKG_CONFIG_PATH%
+
+set ROSDEPS_ROOT=@ROSDEPS_ROOT@
+if DEFINED ROSDEPS_ROOT set PATH=%ROSDEPS_ROOT%/bin;%ROSDEPS_ROOT%/lib;%PATH%
+
+REM These are compatible and should go in @CMAKE_INSTALL_PREFIX@/etc/catkin/profile.d/xxx
+REM Namely, 10.ros.all
+REM Actually it would go in 10.ros.bat.in and the .all should get split up
+
+set ROS_ROOT=@CMAKE_INSTALL_PREFIX@/share/ros
+set ROS_PACKAGE_PATH=@CMAKE_INSTALL_PREFIX@/share;@CMAKE_INSTALL_PREFIX@/stacks
+@if NOT DEFINED ROS_MASTER_URI (
+  set ROS_MASTER_URI=http://localhost:11311
+)
+set ROS_ETC_DIR=@CMAKE_INSTALL_PREFIX@/etc/ros
+set ROS_DISTRO=fuerte
+


### PR DESCRIPTION
Sets up the environment env/setup files for the install space. Also gets python doing its thing right on windows. 
- python distutils script added
- windows peculiarities for python handled in the cmake
- install locations pointing to the right places

The last one is a bit odd - windows python setuptools installs to lib/site-packages and not lib/python2.7/site-packages or lib/python2.7/dist-packages.

Are the latter two options strictly because of the install-layout=deb option to python setuptools? The dist-packages is not so important, but am curious why it doesn't do the python2.7.

There is also a patch coming to genpy to help this.
