### PR TITLE
Windows update for debugging symbols, code reshuffle.

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -39,11 +39,12 @@ foreach(f
     catkin_workspace
     catkin_python_setup
     catkin_add_env_hooks
-    libraries
     rosbuild_compat
     platform/lsb
     platform/ubuntu
+    platform/windows
     tools/doxygen
+    tools/libraries
     tools/rt
     tools/threads
     tools/gtest

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -1,25 +1,3 @@
-
-# BUILD_SHARED_LIBS is a global cmake variable (usually defaults to on) 
-# that determines the build type of libraries:
-#   http://www.cmake.org/cmake/help/cmake-2-8-docs.html#variable:BUILD_SHARED_LIBS
-# It defaults to shared.
-#
-# Our only current major use case for static libraries is
-# via the mingw cross compiler, though embedded builds
-# could be feasibly built this way also (largely untested).
-
-# Cached variable
-option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
-
-function(configure_shared_library_build_settings)
-  if (BUILD_SHARED_LIBS)
-    message(STATUS "BUILD_SHARED_LIBS is on.")
-    add_definitions(-DROS_BUILD_SHARED_LIBS=1)
-  else()
-    message(STATUS "BUILD_SHARED_LIBS is off.")
-  endif()
-endfunction()
-
 # Windows/cmake make things difficult if building dll's. 
 # These use RUNTIME_OUTPUT_DIRECTORY (aka bin) and can't be 
 # distinguished from exe's. We want exe output directory to be
@@ -41,7 +19,8 @@ if (BUILD_SHARED_LIBS)
         # It is not imported, add our custom copy rule
         add_custom_command(TARGET ${ARGV0} POST_BUILD
                  #cmake -E copy_if_different ${ARGV0}.dll ${CMAKE_BINARY_DIR}/bin # Doesn't handle regexp, i.e. dll*
-                 COMMAND if exist "${PROJECT_BINARY_DIR}/bin/${ARGV0}.dll" ( cp bin/*dll* ${CMAKE_BINARY_DIR}/bin )
+                 # uglier than above, but bruce force copies all the windows rubbish as well (.pdb, .manifest, .txt etc).
+                 COMMAND if exist "${PROJECT_BINARY_DIR}/bin/${ARGV0}.dll" ( cp bin/${ARGV0}* ${CMAKE_BINARY_DIR}/bin )
                  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
                  )
         # Quite likely, linux guys hacking packages will not think to set the runtime destination to bin
@@ -54,8 +33,13 @@ if (BUILD_SHARED_LIBS)
                     ARCHIVE DESTINATION lib
                     LIBRARY DESTINATION lib 
             )
+          if( NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+            install(FILES ${CMAKE_BINARY_DIR}/bin/${ARGV0}.pdb DESTINATION bin)
+          endif() 
         endif()
       endif()
     endfunction()
+    # Almost impossible to do the same as above to install .pdb's for exe's as we do not know their 
+    # runtime destinations. Sometimes the runtime destination is bin, sometimes it is _pkg_name_/bin.
   endif(MSVC)
 endif(BUILD_SHARED_LIBS)

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -1,3 +1,13 @@
+# BUILD_SHARED_LIBS is a global cmake variable (usually defaults to on) 
+# that determines the build type of libraries:
+#   http://www.cmake.org/cmake/help/cmake-2-8-docs.html#variable:BUILD_SHARED_LIBS
+# It defaults to shared.
+
+# Make sure this is already defined as a cached variable (@sa libraries.cmake)
+if (NOT DEFINED BUILD_SHARED_LIBS)
+  option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
+endif()
+
 # Windows/cmake make things difficult if building dll's. 
 # These use RUNTIME_OUTPUT_DIRECTORY (aka bin) and can't be 
 # distinguished from exe's. We want exe output directory to be

--- a/cmake/tools/libraries.cmake
+++ b/cmake/tools/libraries.cmake
@@ -1,0 +1,22 @@
+
+# BUILD_SHARED_LIBS is a global cmake variable (usually defaults to on) 
+# that determines the build type of libraries:
+#   http://www.cmake.org/cmake/help/cmake-2-8-docs.html#variable:BUILD_SHARED_LIBS
+# It defaults to shared.
+#
+# Our only current major use case for static libraries is
+# via the mingw cross compiler, though embedded builds
+# could be feasibly built this way also (largely untested).
+
+# Cached variable
+option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
+
+function(configure_shared_library_build_settings)
+  if (BUILD_SHARED_LIBS)
+    message(STATUS "BUILD_SHARED_LIBS is on.")
+    add_definitions(-DROS_BUILD_SHARED_LIBS=1)
+  else()
+    message(STATUS "BUILD_SHARED_LIBS is off.")
+  endif()
+endfunction()
+

--- a/cmake/tools/libraries.cmake
+++ b/cmake/tools/libraries.cmake
@@ -1,4 +1,3 @@
-
 # BUILD_SHARED_LIBS is a global cmake variable (usually defaults to on) 
 # that determines the build type of libraries:
 #   http://www.cmake.org/cmake/help/cmake-2-8-docs.html#variable:BUILD_SHARED_LIBS
@@ -8,8 +7,10 @@
 # via the mingw cross compiler, though embedded builds
 # could be feasibly built this way also (largely untested).
 
-# Cached variable
-option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
+# Make sure this is already defined as a cached variable (@sa platform/windows.cmake)
+if (NOT DEFINED BUILD_SHARED_LIBS)
+  option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
+endif()
 
 function(configure_shared_library_build_settings)
   if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
This includes an update to get pdb symbols installed for libraries on windows. The case for executables is harder without too many infrastructure hacks.

It also cleans the root cmake directory a bit. Windows specific hacks to the platform directory and static/shared library handling macros to tools alongside things like the thread detection.
