### PR TITLE
Find root path fixes

### DIFF
--- a/cmake/templates/pkg-config.cmake.installable.in
+++ b/cmake/templates/pkg-config.cmake.installable.in
@@ -44,7 +44,8 @@ endif()
 set(@PACKAGE_NAME@_CONFIG_INCLUDED TRUE)
 
 if (NOT "X@PACKAGE_INCLUDE_DIRS@" STREQUAL "X")
-  set(@PACKAGE_NAME@_INCLUDE_DIRS @PKG_INCLUDE_PREFIX@/include) #TODO FIX this.
+  find_file(@PACKAGE_NAME@_INCLUDE_DIRS include PATHS @PKG_INCLUDE_PREFIX@
+            NO_DEFAULT_PATH)
 endif()
 
 foreach(lib @PACKAGE_LIBRARIES@)
@@ -75,5 +76,7 @@ if(@PACKAGE_NAME@_LIBRARIES)
 endif()
 
 foreach(extra @PACKAGE_CFG_EXTRAS@)
-  include(@PKG_CMAKE_DIR@/${extra})
+  set(_extra_inc _extra_inc-NOTFOUND)
+  find_file(_extra_inc ${extra} PATHS @PKG_CMAKE_DIR@ NO_DEFAULT_PATH)
+  include(${_extra_inc})
 endforeach()

--- a/cmake/tests.cmake.in
+++ b/cmake/tests.cmake.in
@@ -30,11 +30,11 @@ function(catkin_initialize_tests)
   if(catkin_SOURCE_DIR)
     find_program_required(CHECK_TEST_RAN_EXE check_test_ran.py
                           PATHS @PROJECT_SOURCE_DIR@/cmake
-                          NO_DEFAULT_PATH)
+                          NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   else()
     find_program_required(CHECK_TEST_RAN_EXE check_test_ran.py
                           PATHS @CMAKE_INSTALL_PREFIX@/share/catkin/cmake
-                          NO_DEFAULT_PATH)
+                          NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   endif()
 endfunction()
 


### PR DESCRIPTION
Fix cross-compilation builds that make use of `CMAKE_FIND_ROOT_PATH` by using `find_file()` etc. to locate files and directories that may be within a cross-compilation root environment, and by suppressing searches in the cross-compilation root for things that won't be there (such as files in the source tree).
