### PR TITLE
automated API generation for cmake macros and functions

### DIFF
--- a/cmake/catkin_stack.cmake
+++ b/cmake/catkin_stack.cmake
@@ -1,3 +1,13 @@
+#
+#   `Required for all stacks.  No parameters.`
+#
+#   Reads the :ref:`stack.xml` from the current source dir and makes
+#   the version number available to cmake via ``stackname_VERSION``;
+#   does the same for other fields in the `stack.xml`.  Also sets
+#   ``CATKIN_CURRENT_STACK``.  You must call `catkin_stack()` once
+#   in each stack's CMakeLists.txt, before any calls to `catkin_project()`,
+#   to ensure that auto-generated pkg-config and CMake files get correct
+#   version information.
 function(catkin_stack)
   debug_message(10 "catkin_stack() called in file ${CMAKE_CURRENT_LIST_FILE}")
 

--- a/cmake/catkin_workspace.cmake
+++ b/cmake/catkin_workspace.cmake
@@ -1,3 +1,12 @@
+#
+#   `No parameters.`
+#
+#   Called only in catkin's ``toplevel.cmake``, normally symlinked to
+#   from the workspace level directory (which contains multiple
+#   stacks).  This provokes the traversal of the stack directories
+#   based on the dependencies specified in the ``build_depends`` field of
+#   their respective ``stack.xml`` files.
+#
 function(catkin_workspace)
   debug_message(10 "catkin_workspace() called in file '${CMAKE_CURRENT_LIST_FILE}'")
 

--- a/cmake/install_matching_to_share.cmake
+++ b/cmake/install_matching_to_share.cmake
@@ -1,3 +1,32 @@
+#
+#   :param globexpr: Glob expression (shell style)
+#
+#   For each file `F` in subdirectories of ``CMAKE_CURRENT_SOURCE_DIR``
+#   that (recursively) match globbing expression `globexpr`, install
+#   `F` to ``share/P/F``, where ``P`` is the name of the parent
+#   directory of `F`
+#
+#   .. rubric:: Example
+#
+#   For a directory containing::
+#
+#     src/
+#       CMakeLists.txt
+#       foo/
+#         bar.txt
+#       shimmy/
+#         baz/
+#           bam.txt
+#
+#   A call to ``install_matching_to_share(b??.txt)`` in
+#   ``src/CMakeLists.txt`` will create an installation of::
+#
+#     <CMAKE_INSTALL_PREFIX>/
+#       share/
+#         foo/
+#           bar.txt
+#         baz/
+#           bam.txt
 function(install_matching_to_share GLOBEXPR)
   file(GLOB_RECURSE globbed
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/cmake/rosbuild_compat.cmake
+++ b/cmake/rosbuild_compat.cmake
@@ -44,10 +44,24 @@ function(rosbuild_download_test_data)
   message(STATUS "    >> Rosbuild-compat: rosbuild_download_test_data ${ARGN}")
 endfunction()
 
+
+#
+#   :param FILE: name of pyunit test file
+#
+#   Add file to test list and run under `rosunit` at testing time.
 function(rosbuild_add_pyunit)
   message(STATUS "    >> Rosbuild-compat: rosbuild_add_pyunit ${ARGN}")
 endfunction()
 
+#
+#   :param EXE: executable name
+#   :param FILES: list of gtest .cpp files
+#   :param TIMEOUT: The timeout in seconds (defaults to 60s)
+#   :param WORKING_DIRECTORY: The working directory
+#
+#   Add an executable `EXE` build from `FILES` and link to gtest.  Run under
+#   `rosunit` when test target is built.
+#
 function(rosbuild_add_gtest TARGET)
   message(STATUS "    >> Rosbuild-compat: rosbuild_add_gtest ${ARGN}")
   add_executable(${TARGET} ${catkin_EXTRAS_DIR}/dummy_main.cpp)

--- a/cmake/stamp.cmake
+++ b/cmake/stamp.cmake
@@ -1,3 +1,10 @@
+#
+#   :param path:  file name
+#
+#   Uses ``configure_file`` to generate a file ``filepath.stamp`` hidden
+#   somewhere in the build tree.  This will cause cmake to rebuild its
+#   cache when ``filepath`` is modified.
+#
 function(stamp path)
   get_filename_component(filename ${path} NAME)
   configure_file(${path}

--- a/cmake/test/append_test_to_cache.cmake
+++ b/cmake/test/append_test_to_cache.cmake
@@ -1,5 +1,15 @@
-# macro to ensure that ${PROJECT_NAME}_CACHE gets set in a higher scope
-# where we can check it later
+#   macro to ensure that ${PROJECT_NAME}_CACHE gets set in a higher scope
+#   where we can check it later
+#
+#   `Internal use.`
+#
+#   :param CACHENAME: Name of cache.
+#   :param [args]:    Command to be appended to cache file.
+#
+#   Use this when you want to append to a file that is recreated at
+#   each cmake run.  ``CACHENAME`` need not be globally unique.  File
+#   will be located in the ``PROJECT_BINARY_DIR`` cmake files directory
+#   (`CMakeFiles`) as ``${PROJECT_NAME}.${CACHENAME}``.
 macro(append_test_to_cache CACHENAME)
   set(cachefile ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}.${CACHENAME})
   if(NOT ${PROJECT_NAME}_CACHE)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -36,38 +36,41 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-html:
+cmakeapi:
+	python generate_macros_rst.py -o macros2.rst
+
+html: cmakeapi
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
+dirhtml: cmakeapi
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml:
+singlehtml: cmakeapi
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-pickle:
+pickle: cmakeapi
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json:
+json: cmakeapi
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp:
+htmlhelp: cmakeapi
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-qthelp:
+qthelp: cmakeapi
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -76,7 +79,7 @@ qthelp:
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/catkin.qhc"
 
-devhelp:
+devhelp: cmakeapi
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -85,46 +88,46 @@ devhelp:
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/catkin"
 	@echo "# devhelp"
 
-epub:
+epub: cmakeapi
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex:
+latex: cmakeapi
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf:
+latexpdf: cmakeapi
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	make -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-text:
+text: cmakeapi
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
-man:
+man: cmakeapi
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
-changes:
+changes: cmakeapi
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-linkcheck:
+linkcheck: cmakeapi
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-doctest:
+doctest: python read file
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."

--- a/doc/generate_macros_rst.py
+++ b/doc/generate_macros_rst.py
@@ -1,0 +1,95 @@
+import sys
+import os
+import re
+from optparse import OptionParser
+
+"""Simple superficial API doc generator for .cmake files"""
+
+def generate(path, filename):
+    """
+    generate crawls over path, looking for files named *.cmake,
+    indexing functions and macros with docstings, and writing the
+    result to filename.
+
+    Each of the crawled files is traversed line by line, looking for
+    lines like function(...) or macro(...)  for each of these, an
+    entry is added to the overall result in reStructured text syntax
+    for Sphinx documentation
+    """
+    # print(path, filename)
+    macro_files = []
+    rst_txt = ['Automated macro reference\n',
+               '=========================\n\n']
+
+    for (parentdir, _, files) in os.walk(path):
+        # if os.path.basename(parentdir) != 'cmake':
+        #     continue
+        for filename2 in files:
+            if not filename2.endswith('.cmake'):
+                continue
+            fullpath = (os.path.join(parentdir, filename2))
+            relpath = os.path.relpath(fullpath, path)
+            macro_files.append((fullpath, relpath))
+
+    for (macro_file, relpath) in macro_files:
+        lastblock = []
+        with open(macro_file, 'r') as fhand:
+            contents = fhand.readlines()
+        for line in contents:
+            if line.startswith('#'):
+                # careful to not strip '\n' in empty comment lines
+                lastblock.append(line.lstrip('#'))
+            else:
+                declaration = re.match("[a-zA-Z]+\([a-zA-Z_ ]+\)", line)
+                if declaration is None:
+                    lastblock = []
+                else:
+                    tokens = line.split('(')
+                    dec_type = tokens[0].strip()
+                    dec_args = tokens[1].strip().rstrip(')').split(' ')
+                    
+                    
+                    if dec_type == 'function':
+                        # directives defined in catkin-sphinx
+                        dec_line = '.. cmake:macro:: '+dec_args[0]
+                    elif dec_type == 'macro':
+                        dec_line = '.. cmake:macro:: '+dec_args[0]
+                    else:
+                        dec_line = None
+
+                    if dec_line is None:
+                        lastblock = []
+                    else:
+                        # print(line, dec_type, dec_args)
+                        dec_line += '(%s)\n\n'%', '.join(dec_args[1:])
+                        rst_txt.append(dec_line)
+                        rst_txt.append('   defined in %s\n\n'%relpath)
+                        
+                        if lastblock != []:
+                            rst_txt.extend(lastblock)
+                            lastblock = []
+                        else:
+                            rst_txt.append("   No docstring\n")
+                        rst_txt.append('\n\n')
+
+    with open(filename, 'w') as fhand:
+        fhand.write(''.join(rst_txt))
+
+    return 0
+
+if __name__ == "__main__":
+    parser = OptionParser(usage="%s path [path] [options]"%sys.argv[0])
+    parser.add_option("-o", "--ouput", dest="output", default="macros.rst",
+                      help="output filename",
+                      action="store")
+    options, args = parser.parse_args()
+    if len(args) > 1:
+        parser.usage()
+        sys.exit(1)
+    if len(args) > 0:
+        path = args[0]
+    else:
+        path = os.path.dirname(os.getcwd())
+
+    sys.exit(generate(path, options.output))
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,6 +31,7 @@ Contents
    stack_xml
    layout
    macros
+   macros2
    environment
    variables
    code_generation

--- a/doc/macros.rst
+++ b/doc/macros.rst
@@ -63,28 +63,6 @@ Catkin cmake macro reference
    ``setup.py`` is interrogated by catkin and used during
    installation.  See :ref:`setup_dot_py_handling`.
 
-.. cmake:macro:: catkin_stack()
-
-   `Required for all stacks.  No parameters.`
-
-   Reads the :ref:`stack.xml` from the current source dir and makes
-   the version number available to cmake via ``stackname_VERSION``;
-   does the same for other fields in the `stack.xml`.  Also sets
-   ``CATKIN_CURRENT_STACK``.  You must call `catkin_stack()` once
-   in each stack's CMakeLists.txt, before any calls to `catkin_project()`,
-   to ensure that auto-generated pkg-config and CMake files get correct
-   version information.
-
-.. cmake:macro:: catkin_workspace()
-
-   `No parameters.`
-
-   Called only in catkin's ``toplevel.cmake``, normally symlinked to
-   from the workspace level directory (which contains multiple
-   stacks).  This provokes the traversal of the stack directories
-   based on the dependencies specified in the ``build_depends`` field of
-   their respective ``stack.xml`` files.
-
 Documentation Macros
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -110,78 +88,6 @@ Documentation Macros
    ``*-sphinx-deploy``  targets which rsync  the documentation  to the
    provided  location  (value  may  contain ``user@``:  it  is  passed
    directly to cmake)
-
-
-Testing macros
-^^^^^^^^^^^^^^
-
-.. cmake:macro:: initialize_tests()
-
-   Initialize.  Tests.
-
-.. cmake:macro:: append_test_to_cache(CACHENAME [args])
-
-   `Internal use.`
-
-   :param CACHENAME: Name of cache.
-   :param [args]:    Command to be appended to cache file.
-
-   Use this when you want to append to a file that is recreated at
-   each cmake run.  ``CACHENAME`` need not be globally unique.  File
-   will be located in the ``PROJECT_BINARY_DIR`` cmake files directory
-   (`CMakeFiles`) as ``${PROJECT_NAME}.${CACHENAME}``.
-
-.. cmake:macro:: add_pyunit(FILE)
-
-   :param FILE: name of pyunit test file
-
-   Add file to test list and run under `rosunit` at testing time.
-
-
-.. cmake:macro:: add_gtest(EXE FILES [parameters])
-
-   :param EXE: executable name
-   :param FILES: list of gtest .cpp files
-   :param TIMEOUT: The timeout in seconds (defaults to 60s)
-   :param WORKING_DIRECTORY: The working directory
-
-   Add an executable `EXE` build from `FILES` and link to gtest.  Run under
-   `rosunit` when test target is built.
-
-
-Convenience macros
-^^^^^^^^^^^^^^^^^^
-
-.. cmake:macro:: install_matching_to_share(globexpr)
-
-   :param globexpr: Glob expression (shell style)
-
-   For each file `F` in subdirectories of ``CMAKE_CURRENT_SOURCE_DIR``
-   that (recursively) match globbing expression `globexpr`, install
-   `F` to ``share/P/F``, where ``P`` is the name of the parent
-   directory of `F`
-
-   .. rubric:: Example
-
-   For a directory containing::
-
-     src/
-       CMakeLists.txt
-       foo/
-         bar.txt
-       shimmy/
-         baz/
-           bam.txt
-
-   A call to ``install_matching_to_share(b??.txt)`` in
-   ``src/CMakeLists.txt`` will create an installation of::
-
-     <CMAKE_INSTALL_PREFIX>/
-       share/
-         foo/
-           bar.txt
-         baz/
-           bam.txt
 
 
 .. cmake:macro:: catkin_add_env_hooks(fileprefix SHELLS shell1 shell2...)
@@ -214,10 +120,5 @@ Convenience macros
    the event of collision.
 
 
-.. cmake:macro:: stamp(filepath)
 
-   :param filepath:  file name
 
-   Use ``configure_file`` to generate a file ``filepath.stamp`` hidden
-   somewhere in the build tree.  This will cause cmake to rebuild its
-   cache when ``filepath`` is modified.


### PR DESCRIPTION
I prefer the docs to be part of the code, and html docs be generated from that. Commit does all that, using a small python script to parse cmake files (not parsing cmake syntax, just looking for comments and keywords)

The result is a generated macros2.rst, which is roughly equivalent to macros.rst, except for items in macros.rst which i could not find in the code. Leftovers are in macros.rst.
