### PR TITLE
Symlink fix

### DIFF
--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -25,28 +25,28 @@ def _symlink_toplevel_cmake(src, dst):
     return True
 
 
-#
-# Create a toplevel CMakeLists.txt in the root of a workspace.
-#
-# The toplevel.cmake file is looked up either in the catkin
-# workspaces contained in the CMAKE_PREFIX_PATH or relative to this
-# file.  Then it tries to create a symlink first and if that fails
-# copies the file.
-#
-# It installs ``manifest.xml`` to ``share/${PROJECT_NAME}``.
-#
-# .. note:: The symlink is absolute when catkin is found via the
-#   environment (since that indicates a different workspace and it
-#   may change relative location to the workspace referenced as a
-#   parameter). The symlink is relative when the toplevel.cmake of
-#   this catkin instance is used since it is part of the
-#   to-be-initialized workspace.
-#
-# :param workspace_dir: the path to the workspace where the
-#   CMakeLists.txt should be created
-# :type workspace_dir: string
-#
 def init_workspace(workspace_dir):
+    """
+    Create a toplevel CMakeLists.txt in the root of a workspace.
+
+    The toplevel.cmake file is looked up either in the catkin
+    workspaces contained in the CMAKE_PREFIX_PATH or relative to this
+    file.  Then it tries to create a symlink first and if that fails
+    copies the file.
+
+    It installs ``manifest.xml`` to ``share/${PROJECT_NAME}``.
+
+    .. note:: The symlink is absolute when catkin is found via the
+    environment (since that indicates a different workspace and it
+    may change relative location to the workspace referenced as a
+    parameter). The symlink is relative when the toplevel.cmake of
+    this catkin instance is used since it is part of the
+    to-be-initialized workspace.
+
+    :param workspace_dir: the path to the workspace where the
+    CMakeLists.txt should be created
+    :type workspace_dir: string
+    """
     # verify that destination file does not exist
     dst = os.path.join(workspace_dir, 'CMakeLists.txt')
     if os.path.exists(dst):

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -18,13 +18,13 @@ def _symlink_or_copy(src, dst):
     try:
         os.symlink(src, dst)
         print('Creating symlink "%s" pointing to "%s"' % (dst, src))
-    except Exception:
+    except Exception as excsym:
         # try to copy file
         try:
             shutil.copyfile(src, dst)
             print('Copying file from "%s" to "%s"' % (src, dst))
-        except:
-            raise RuntimeError('Could neither symlink nor copy file "%s" to "%s"' % (src, dst))
+        except Exception as exccp:
+            raise RuntimeError('Could neither symlink nor copy file "%s" to "%s"\n%s\n%s' % (src, dst, str(excsym), str(exccp)))
     return True
 
 

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -7,9 +7,6 @@ def _symlink_or_copy(src, dst):
     """
     Creates a symlink at dst to src, or if not possible, attempts to copy.
     """
-    if not os.path.exists(src):
-        return False
-
     # update relative source to be relative from destination
     if not os.path.isabs(src):
         src = os.path.relpath(src, os.path.dirname(dst))
@@ -25,7 +22,6 @@ def _symlink_or_copy(src, dst):
             print('Copying file from "%s" to "%s"' % (src, dst))
         except Exception as exccp:
             raise RuntimeError('Could neither symlink nor copy file "%s" to "%s"\n%s\n%s' % (src, dst, str(excsym), str(exccp)))
-    return True
 
 
 def init_workspace(workspace_dir):
@@ -55,6 +51,7 @@ def init_workspace(workspace_dir):
     if os.path.exists(dst):
         raise RuntimeError('File "%s" already exists' % dst)
 
+    src_file_path = None
     # get all cmake prefix paths
     env_name = 'CMAKE_PREFIX_PATH'
     if env_name in os.environ and os.environ[env_name] != '':
@@ -74,36 +71,38 @@ def init_workspace(workspace_dir):
         if data == '':
             # try from install space
             src = os.path.join(workspace, 'share', 'catkin', 'cmake', 'toplevel.cmake')
-            success = _symlink_or_copy(src, dst)
-            if success:
-                return
+            if os.path.exists(src):
+                src_file_path = src
+                break
             else:
                 checked.append(src)
         else:
             # try from all source spaces
             for source_path in data.split(';'):
                 src = os.path.join(source_path, 'catkin', 'cmake', 'toplevel.cmake')
-                success = _symlink_or_copy(src, dst)
-                if success:
-                    return
+                if os.path.exists(src):
+                    src_file_path = src
+                    break
                 else:
                     checked.append(src)
 
-    # try to find toplevel file in relative locations
-    relative_cmake_paths = []
-    # when catkin is in source space
-    relative_cmake_paths.append(os.path.join('..', '..', 'cmake'))
-    # when catkin is installed (with Python code in lib/pythonX.Y/[dist|site]-packages)
-    relative_cmake_paths.append(os.path.join('..', '..', '..', '..', 'share', 'catkin', 'cmake'))
-    # when catkin is installed (with Python code in lib/site-packages)
-    relative_cmake_paths.append(os.path.join('..', '..', '..', 'share', 'catkin', 'cmake'))
-    for relative_cmake_path in relative_cmake_paths:
-        src = os.path.relpath(os.path.join(os.path.dirname(__file__), relative_cmake_path, 'toplevel.cmake'))
-        if os.path.exists(src):
-            success = _symlink_or_copy(src, dst)
-            if success:
-                return
-        else:
-            checked.append(src)
+    if src_file_path is None:
+        # try to find toplevel file in relative locations
+        relative_cmake_paths = []
+        # when catkin is in source space
+        relative_cmake_paths.append(os.path.join('..', '..', 'cmake'))
+        # when catkin is installed (with Python code in lib/pythonX.Y/[dist|site]-packages)
+        relative_cmake_paths.append(os.path.join('..', '..', '..', '..', 'share', 'catkin', 'cmake'))
+        # when catkin is installed (with Python code in lib/site-packages)
+        relative_cmake_paths.append(os.path.join('..', '..', '..', 'share', 'catkin', 'cmake'))
+        for relative_cmake_path in relative_cmake_paths:
+            src = os.path.relpath(os.path.join(os.path.dirname(__file__), relative_cmake_path, 'toplevel.cmake'))
+            if os.path.exists(src):
+                src_file_path = src
+                break
+            else:
+                checked.append(src)
 
-    raise RuntimeError('Could neither find file "toplevel.cmake" in any workspace nor relative, checked the following paths:\n%s' % ('\n'.join(checked)))
+    if src_file_path is None:
+        raise RuntimeError('Could neither find file "toplevel.cmake" in any workspace nor relative, checked the following paths:\n%s' % ('\n'.join(checked)))
+    success = _symlink_or_copy(src_file_path, dst)

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -57,7 +57,10 @@ def init_workspace(workspace_dir):
 
     # get all cmake prefix paths
     env_name = 'CMAKE_PREFIX_PATH'
-    paths = [path for path in os.environ[env_name].split(os.pathsep)] if env_name in os.environ and os.environ[env_name] != '' else []
+    if env_name in os.environ and os.environ[env_name] != '':
+        paths = [path for path in os.environ[env_name].split(os.pathsep)]
+    else:
+        paths =[]
     # remove non-workspace paths
     workspaces = [path for path in paths if os.path.exists(os.path.join(path, '.CATKIN_WORKSPACE'))]
 

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -3,7 +3,10 @@ import os
 import shutil
 
 
-def _symlink_toplevel_cmake(src, dst):
+def _symlink_or_copy(src, dst):
+    """
+    Creates a symlink at dst to src, or if not possible, attempts to copy.
+    """
     if not os.path.exists(src):
         return False
 
@@ -68,7 +71,7 @@ def init_workspace(workspace_dir):
         if data == '':
             # try from install space
             src = os.path.join(workspace, 'share', 'catkin', 'cmake', 'toplevel.cmake')
-            success = _symlink_toplevel_cmake(src, dst)
+            success = _symlink_or_copy(src, dst)
             if success:
                 return
             else:
@@ -77,7 +80,7 @@ def init_workspace(workspace_dir):
             # try from all source spaces
             for source_path in data.split(';'):
                 src = os.path.join(source_path, 'catkin', 'cmake', 'toplevel.cmake')
-                success = _symlink_toplevel_cmake(src, dst)
+                success = _symlink_or_copy(src, dst)
                 if success:
                     return
                 else:
@@ -94,7 +97,7 @@ def init_workspace(workspace_dir):
     for relative_cmake_path in relative_cmake_paths:
         src = os.path.relpath(os.path.join(os.path.dirname(__file__), relative_cmake_path, 'toplevel.cmake'))
         if os.path.exists(src):
-            success = _symlink_toplevel_cmake(src, dst)
+            success = _symlink_or_copy(src, dst)
             if success:
                 return
         else:

--- a/test/unit_tests/test_init_workspace.py
+++ b/test/unit_tests/test_init_workspace.py
@@ -1,0 +1,63 @@
+import sys
+import os
+from os.path import join
+import unittest
+import tempfile
+import shutil
+
+from catkin.init_workspace import init_workspace, _symlink_or_copy
+
+
+class InitWorkspaceTest(unittest.TestCase):
+
+    def test_symlink_or_copy(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            os.makedirs(join(root_dir, 'subdir'))
+            os.makedirs(join(root_dir, 'subdir2'))
+            with open(join(root_dir, 'subdir', 'foo'), 'ab') as fhand:
+                fhand.write('content'.encode('UTF-8'))
+
+            _symlink_or_copy(join(root_dir, 'subdir', 'foo'), join(root_dir, 'foolink'))
+            _symlink_or_copy(join(root_dir, 'subdir', 'foo'), join(root_dir, 'subdir', 'foolink'))
+            _symlink_or_copy(os.path.relpath(join(root_dir, 'subdir', 'foo'), os.getcwd()), join(root_dir, 'foolinkrel'))
+
+            self.assertEqual(join(root_dir, 'subdir', 'foo'),
+                             os.readlink(join(root_dir, 'foolink')))
+            self.assertEqual(join(root_dir, 'subdir', 'foo'),
+                             os.readlink(join(root_dir, 'subdir', 'foolink')))
+            self.assertEqual(os.path.relpath(join(root_dir, 'subdir', 'foo'), os.getcwd()),
+                             os.readlink(join(root_dir, 'foolinkrel')))
+
+        finally:
+            # pass
+            shutil.rmtree(root_dir)
+
+
+    def test_init_workspace(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            os.makedirs(join(root_dir, 'ws1'))
+            os.makedirs(join(root_dir, 'ws1', 'catkin'))
+            os.makedirs(join(root_dir, 'ws1', 'catkin', 'cmake'))
+            with open(join(root_dir, 'ws1', 'catkin', 'cmake', 'toplevel.cmake'), 'ab') as fhand:
+                fhand.write(''.encode('UTF-8'))
+            with open(join(root_dir, 'ws1', '.CATKIN_WORKSPACE'), 'ab') as fhand:
+                fhand.write(''.encode('UTF-8'))
+            os.makedirs(join(root_dir, 'ws2'))
+            with open(join(root_dir, 'ws2', '.CATKIN_WORKSPACE'), 'ab') as fhand:
+                fhand.write(''.encode('UTF-8'))
+
+            init_workspace(join(root_dir, 'ws1'))
+            init_workspace(join(root_dir, 'ws2'))
+
+            # in same workspace symlink should be relative
+            self.assertEqual(join('catkin', 'cmake', 'toplevel.cmake'),
+                             os.readlink(join(root_dir, 'ws1', 'CMakeLists.txt')))
+            # outside workspace, path should be absolute
+            self.assertTrue(os.path.samefile(join(os.path.dirname(__file__), '..', '..', 'cmake', 'toplevel.cmake'),
+                             os.readlink(join(root_dir, 'ws2', 'CMakeLists.txt'))))
+
+        finally:
+            # pass
+            shutil.rmtree(root_dir)


### PR DESCRIPTION
(This is an attempt to create a pull request from a fork non-master branch to the main master branch.)

The logic for creating CMakeLists.txt still seems to be flawed. I wrote a unit test for init_workspace and noticed the docstring of init_workspace specified something different from the latest implementation.

So the attached patch changes the logic to:
when linking to toplevel.cmake within workspace use relative path.
Else use absolute path.

Also there was a problem if a user created a workspace with catkin somewhere, using an installed catkin version instead of the catkin version in his workspace. In that case, the init_workspace function would create an absolute link to the installed catkin, not a relative link to the workspace one.

[The more I see this, the less I think it is a good idea to ever allow catkin to live in the same workspace it is used in, as this will always cause non-future-proof hacks.]

Anyway, the patch also detects catkin in the dest workspace via the line in the patch:
workspaces = ['current:' + workspace_dir]

BTW: The whole CATKIN_WORKSPACES logic does not seem to be documented anywhere, I just assumed from the code that this is what is planned.
