### PR TITLE
Python3 compatibility

### DIFF
--- a/cmake/templates/__init__.py.in
+++ b/cmake/templates/__init__.py.in
@@ -30,7 +30,7 @@ del path
 del src_init_file
 
 for __execfile in __execfiles:
-    execfile(__execfile)
+    exec(compile(open(__execfile).read(), __execfile, 'exec'))
 if __execfiles:
     del __execfile
 del __execfiles


### PR DESCRIPTION
The execfile command used in the **init**.py files autogenerated by catkin does not work in Python 3.  This pull request replaces that command with a version that works in both 2.7 and 3.
