### PR TITLE
multiple minor fixes and code style to all python scripts

### DIFF
--- a/bin/catkin_build_isolated
+++ b/bin/catkin_build_isolated
@@ -12,15 +12,20 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
     from catkin.builder import build_workspace_in_isolation
 
-parser = argparse.ArgumentParser(description='Builds all catkin packages in isolation in topological order.')
-parser.add_argument('sourcespace', nargs='?', default='.', help='The path to an existing folder (default: .)')
-parser.add_argument('buildspace', nargs='?', default='.', help='The path where the build folder is created (default: .)')
-args = parser.parse_args()
 
-# verify that sourcespace folder exists
-sourcespace = os.path.abspath(args.sourcespace)
-if not os.path.isdir(sourcespace):
-    print('Sourcespace "%s" does not exist' % sourcespace, file=sys.stderr)
-    exit(1)
+def main():
+    parser = argparse.ArgumentParser(description='Builds all catkin packages in isolation in topological order.')
+    parser.add_argument('sourcespace', nargs='?', default='.', help='The path to an existing folder (default: .)')
+    parser.add_argument('buildspace', nargs='?', default='.', help='The path where the build folder is created (default: .)')
+    args = parser.parse_args()
 
-build_workspace_in_isolation(sourcespace, args.buildspace)
+    # verify that sourcespace folder exists
+    sourcespace = os.path.abspath(args.sourcespace)
+    if not os.path.isdir(sourcespace):
+        sys.exit('Sourcespace "%s" does not exist' % sourcespace)
+
+    build_workspace_in_isolation(sourcespace, args.buildspace)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/catkin_find
+++ b/bin/catkin_find
@@ -6,36 +6,40 @@ import sys
 
 from catkin.find_in_workspaces import find_in_workspaces
 
-parser = argparse.ArgumentParser(description='Searches the catkin workspaces for project-specific files/folders.')
-parser.add_argument('project', nargs='?', help='The project to find a path for')
-parser.add_argument('path', nargs='?', help='The relative path of a project file/folder (a prefix is sufficient)')
-parser.add_argument('--first-only', action='store_true', help='Flag if only the first result should be returned (default is all)')
-group = parser.add_argument_group('Search folders', 'Restrict the folders to search in')
-group.add_argument('--bin', action='store_true', help='Search in "bin" folder')
-group.add_argument('--etc', action='store_true', help='Search in "etc(/PROJECT)" folder')
-group.add_argument('--include', action='store_true', help='Search in "include(/PROJECT)" folder')
-group.add_argument('--lib', action='store_true', help='Search in "lib" folder')
-group.add_argument('--libexec', action='store_true', help='Search in "lib/PROJECT" folder')
-group.add_argument('--share', action='store_true', help='Search in "share(/PROJECT)" folder (and source of PROJECT if not installed)')
-args = parser.parse_args()
 
-try:
-    # keep order of folders to search in
-    search_dirs = []
-    all_search_dirs = ['--bin', '--etc', '--include', '--lib', '--libexec', '--share']
-    for arg in sys.argv[1:]:
-        if arg in all_search_dirs:
-            search_dirs.append(arg[2:])
-    (results, checked) = find_in_workspaces(search_dirs, args.project, args.path)
+def parse_args(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description='Searches the catkin workspaces for project-specific files/folders.')
+    parser.add_argument('project', nargs='?', help='The project to find a path for')
+    parser.add_argument('path', nargs='?', help='The relative path of a project file/folder (a prefix is sufficient)')
+    parser.add_argument('--first-only', action='store_true', help='Flag if only the first result should be returned (default is all)')
+    group = parser.add_argument_group('Search folders', 'Restrict the folders to search in')
+    group.add_argument('--bin', action='store_true', help='Search in "bin" folder')
+    group.add_argument('--etc', action='store_true', help='Search in "etc(/PROJECT)" folder')
+    group.add_argument('--include', action='store_true', help='Search in "include(/PROJECT)" folder')
+    group.add_argument('--lib', action='store_true', help='Search in "lib" folder')
+    group.add_argument('--libexec', action='store_true', help='Search in "lib/PROJECT" folder')
+    group.add_argument('--share', action='store_true', help='Search in "share(/PROJECT)" folder (and source of PROJECT if not installed)')
+    args = parser.parse_args()
 
-    if args.first_only:
-        if len(results) > 1:
-            raise RuntimeError('Could not find unique path, the following paths are matching:\n%s' % '\n'.join(results))
-        elif len(results) == 0:
-            raise RuntimeError('Could not find any path, checked the following paths:\n%s' % '\n'.join(checked))
-        print(results[0])
-        exit(0)
-    print('\n'.join(results))
-except Exception as e:
-    print(str(e), file=sys.stderr)
-    exit(1)
+def main():
+    args = parse_args()
+    try:
+        # keep order of folders to search in
+        search_dirs = []
+        all_search_dirs = ['--bin', '--etc', '--include', '--lib', '--libexec', '--share']
+        for arg in sys.argv[1:]:
+            if arg in all_search_dirs:
+                search_dirs.append(arg[2:])
+        (results, checked) = find_in_workspaces(search_dirs, args.project, args.path)
+
+        if args.first_only:
+            if len(results) > 1:
+                raise RuntimeError('Could not find unique path, the following paths are matching:\n%s' % '\n'.join(results))
+            elif len(results) == 0:
+                raise RuntimeError('Could not find any path, checked the following paths:\n%s' % '\n'.join(checked))
+            print(results[0])
+            exit(0)
+        print('\n'.join(results))
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        exit(1)

--- a/bin/catkin_find
+++ b/bin/catkin_find
@@ -38,8 +38,12 @@ def main():
             elif len(results) == 0:
                 raise RuntimeError('Could not find any path, checked the following paths:\n%s' % '\n'.join(checked))
             print(results[0])
-            exit(0)
-        print('\n'.join(results))
+        else:
+            print('\n'.join(results))
+
     except Exception as e:
-        print(str(e), file=sys.stderr)
-        exit(1)
+        sys.exit(str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/catkin_init_workspace
+++ b/bin/catkin_init_workspace
@@ -12,18 +12,24 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
     from catkin.init_workspace import init_workspace
 
-parser = argparse.ArgumentParser(description='Initializes a catkin workspace by creating a top-level CMakeLists.txt.')
-parser.add_argument('workspace', nargs='?', default='.', help='The path to an existing folder (default: .)')
-args = parser.parse_args()
 
-# verify that workspace folder exists
-workspace = os.path.abspath(args.workspace)
-if not os.path.isdir(workspace):
-    print('Workspace "%s" does not exist' % workspace, file=sys.stderr)
-    exit(1)
+def main():
+    parser = argparse.ArgumentParser(description='Initializes a catkin workspace by creating a top-level CMakeLists.txt.')
+    parser.add_argument('workspace', nargs='?', default='.', help='The path to an existing folder (default: .)')
+    args = parser.parse_args()
 
-try:
-    init_workspace(workspace)
-except Exception as e:
-    print(str(e), file=sys.stderr)
-    exit(2)
+    # verify that workspace folder exists
+    workspace = os.path.abspath(args.workspace)
+    if not os.path.isdir(workspace):
+        print('Workspace "%s" does not exist' % workspace, file=sys.stderr)
+        exit(1)
+
+    try:
+        init_workspace(workspace)
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/catkin_init_workspace
+++ b/bin/catkin_init_workspace
@@ -21,13 +21,12 @@ def main():
     # verify that workspace folder exists
     workspace = os.path.abspath(args.workspace)
     if not os.path.isdir(workspace):
-        print('Workspace "%s" does not exist' % workspace, file=sys.stderr)
-        exit(1)
+        parser.error('Workspace "%s" does not exist' % workspace)
 
     try:
         init_workspace(workspace)
     except Exception as e:
-        print(str(e), file=sys.stderr)
+        sys.stderr.write(str(e))
         exit(2)
 
 

--- a/bin/catkin_package_version
+++ b/bin/catkin_package_version
@@ -14,28 +14,33 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
     from catkin.package_version import bump_version, update_versions
 
-parser = argparse.ArgumentParser(description='Show or bump the version number in package.xml files.')
-parser.add_argument('path', nargs='?', default='.', help='The path to a parent folder which contains package.xml files (default: .)')
-parser.add_argument('--bump', choices=('major', 'minor', 'patch'), help='Which part of the version number to bump?')
-args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser(description='Show or bump the version number in package.xml files.')
+    parser.add_argument('path', nargs='?', default='.', help='The path to a parent folder which contains package.xml files (default: .)')
+    parser.add_argument('--bump', choices=('major', 'minor', 'patch'), help='Which part of the version number to bump?')
+    args = parser.parse_args()
 
-try:
-    packages = find_packages(args.path)
-    version = verify_equal_package_versions(packages.values())
-except Exception as e:
-    print(str(e), file=sys.stderr)
-    sys.exit(1)
-
-# only print the version number
-if args.bump is None:
-    print(version)
-
-else:
-    # bump the version number
     try:
-        new_version = bump_version(version, args.bump)
-        update_versions(packages.keys(), new_version)
+        packages = find_packages(args.path)
+        version = verify_equal_package_versions(packages.values())
     except Exception as e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
-    print('%s -> %s' % (version, new_version))
+
+    # only print the version number
+    if args.bump is None:
+        print(version)
+
+    else:
+        # bump the version number
+        try:
+            new_version = bump_version(version, args.bump)
+            update_versions(packages.keys(), new_version)
+        except Exception as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+        print('%s -> %s' % (version, new_version))
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/catkin_package_version
+++ b/bin/catkin_package_version
@@ -24,8 +24,7 @@ def main():
         packages = find_packages(args.path)
         version = verify_equal_package_versions(packages.values())
     except Exception as e:
-        print(str(e), file=sys.stderr)
-        sys.exit(1)
+        sys.exit(str(e))
 
     # only print the version number
     if args.bump is None:
@@ -37,8 +36,7 @@ def main():
             new_version = bump_version(version, args.bump)
             update_versions(packages.keys(), new_version)
         except Exception as e:
-            print(str(e), file=sys.stderr)
-            sys.exit(1)
+            sys.exit(str(e))
         print('%s -> %s' % (version, new_version))
 
 

--- a/bin/catkin_prepare_release
+++ b/bin/catkin_prepare_release
@@ -26,16 +26,13 @@ def main():
         old_version = verify_equal_package_versions(packages.values())
         new_version = bump_version(old_version, 'patch')
     except Exception as e:
-        print(str(e), file=sys.stderr)
-        sys.exit(1)
+        sys.exit(str(e))
 
     vcs_type = get_repository_type(path)
     if vcs_type is None:
-        print('Could not determine repository type of "%s"' % path, file=sys.stderr)
-        exit(1)
+        sys.exit('Could not determine repository type of "%s"' % path)
 
-    print('Execute the following commands:')
-    print('')
+    print('Execute the following commands:\n')
 
     # bump version number
     script = os.path.relpath(os.path.join(os.path.dirname(__file__), 'catkin_package_version'))
@@ -66,7 +63,7 @@ def main():
         elif os.path.dirname(url).endswidth('/branches'):
             base_url = os.path.dirname(url)[:9]
         else:
-            print('Could not determine base URL of SVN repository "%s"' % url, file=sys.stderr)
+            sys.stderr.write('Could not determine base URL of SVN repository "%s"' % url)
             exit(1)
         tag_url = '%s/tags/%s' % (base_url, new_version)
         cmd = 'svn cp -m "tagging %s" %s %s' % (new_version, url, tag_url)

--- a/bin/catkin_prepare_release
+++ b/bin/catkin_prepare_release
@@ -16,57 +16,62 @@ except ImportError:
     from catkin.package_version import bump_version
     from catkin.workspace_vcs import get_repository_type, vcs_remotes
 
-parser = argparse.ArgumentParser(description='Outputs the commands to bump the version number, commit the modified package.xml files and create a tag in the repository.')
-args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser(description='Outputs the commands to bump the version number, commit the modified package.xml files and create a tag in the repository.')
+    args = parser.parse_args()
 
-path = '.'
-try:
-    packages = find_packages(path)
-    old_version = verify_equal_package_versions(packages.values())
-    new_version = bump_version(old_version, 'patch')
-except Exception as e:
-    print(str(e), file=sys.stderr)
-    sys.exit(1)
+    path = '.'
+    try:
+        packages = find_packages(path)
+        old_version = verify_equal_package_versions(packages.values())
+        new_version = bump_version(old_version, 'patch')
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
 
-vcs_type = get_repository_type(path)
-if vcs_type is None:
-    print('Could not determine repository type of "%s"' % path, file=sys.stderr)
-    exit(1)
-
-print('Execute the following commands:')
-print('')
-
-# bump version number
-script = os.path.relpath(os.path.join(os.path.dirname(__file__), 'catkin_package_version'))
-cmd = '%s --bump patch %s' % (script, path)
-print(cmd)
-
-# commit modified package.xml
-package_xmls = [os.path.join(p, 'package.xml') for p in packages.keys()]
-cmd = '%s commit -m "%s" %s' % (vcs_type, new_version, ' '.join(package_xmls))
-print(cmd)
-# push changes
-if vcs_type in ['bzr', 'git', 'hg']:
-    cmd = '%s push' % vcs_type
-    print(cmd)
-
-# tag version
-if vcs_type in ['bzr', 'git', 'hg']:
-    cmd = '%s tag %s' % (vcs_type, new_version)
-    print(cmd)
-    cmd = '%s push' % vcs_type
-    if vcs_type == 'git':
-        cmd += ' --tags'
-    print(cmd)
-elif vcs_type == 'svn':
-    url = vcs_remotes(path, 'svn')[5:]
-    if url.endswith('/trunk'):
-        base_url = url[:-6]
-    elif os.path.dirname(url).endswidth('/branches'):
-        base_url = os.path.dirname(url)[:9]
-    else:
-        print('Could not determine base URL of SVN repository "%s"' % url, file=sys.stderr)
+    vcs_type = get_repository_type(path)
+    if vcs_type is None:
+        print('Could not determine repository type of "%s"' % path, file=sys.stderr)
         exit(1)
-    tag_url = '%s/tags/%s' % (base_url, new_version)
-    cmd = 'svn cp -m "tagging %s" %s %s' % (new_version, url, tag_url)
+
+    print('Execute the following commands:')
+    print('')
+
+    # bump version number
+    script = os.path.relpath(os.path.join(os.path.dirname(__file__), 'catkin_package_version'))
+    cmd = '%s --bump patch %s' % (script, path)
     print(cmd)
+
+    # commit modified package.xml
+    package_xmls = [os.path.join(p, 'package.xml') for p in packages.keys()]
+    cmd = '%s commit -m "%s" %s' % (vcs_type, new_version, ' '.join(package_xmls))
+    print(cmd)
+    # push changes
+    if vcs_type in ['bzr', 'git', 'hg']:
+        cmd = '%s push' % vcs_type
+        print(cmd)
+
+    # tag version
+    if vcs_type in ['bzr', 'git', 'hg']:
+        cmd = '%s tag %s' % (vcs_type, new_version)
+        print(cmd)
+        cmd = '%s push' % vcs_type
+        if vcs_type == 'git':
+            cmd += ' --tags'
+        print(cmd)
+    elif vcs_type == 'svn':
+        url = vcs_remotes(path, 'svn')[5:]
+        if url.endswith('/trunk'):
+            base_url = url[:-6]
+        elif os.path.dirname(url).endswidth('/branches'):
+            base_url = os.path.dirname(url)[:9]
+        else:
+            print('Could not determine base URL of SVN repository "%s"' % url, file=sys.stderr)
+            exit(1)
+        tag_url = '%s/tags/%s' % (base_url, new_version)
+        cmd = 'svn cp -m "tagging %s" %s %s' % (new_version, url, tag_url)
+        print(cmd)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -12,22 +12,28 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
     from catkin.test_results import print_summary, test_results
 
-env_name = 'CATKIN_TEST_RESULTS_DIR'
-test_results_dir = os.environ[env_name] if env_name in os.environ else False
 
-parser = argparse.ArgumentParser(description='Outputs a summary of the test results.')
-parser.add_argument('test_results_dir', nargs='?' if test_results_dir else None, default=test_results_dir, help='The path to the test results (necessary when the environment variable "%s" is not defined)' % env_name)
-args = parser.parse_args()
+def main():
+    env_name = 'CATKIN_TEST_RESULTS_DIR'
+    test_results_dir = os.environ[env_name] if env_name in os.environ else False
 
-# verify that workspace folder exists
-test_results_dir = os.path.abspath(args.test_results_dir)
-if not os.path.isdir(test_results_dir):
-    print('Test results directory "%s" does not exist' % test_results_dir, file=sys.stderr)
-    exit(1)
+    parser = argparse.ArgumentParser(description='Outputs a summary of the test results.')
+    parser.add_argument('test_results_dir', nargs='?' if test_results_dir else None, default=test_results_dir, help='The path to the test results (necessary when the environment variable "%s" is not defined)' % env_name)
+    args = parser.parse_args()
 
-try:
-    results = test_results(test_results_dir)
-    print_summary(results)
-except Exception as e:
-    print(str(e), file=sys.stderr)
-    exit(2)
+    # verify that workspace folder exists
+    test_results_dir = os.path.abspath(args.test_results_dir)
+    if not os.path.isdir(test_results_dir):
+        print('Test results directory "%s" does not exist' % test_results_dir, file=sys.stderr)
+        exit(1)
+
+    try:
+        results = test_results(test_results_dir)
+        print_summary(results)
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -24,14 +24,13 @@ def main():
     # verify that workspace folder exists
     test_results_dir = os.path.abspath(args.test_results_dir)
     if not os.path.isdir(test_results_dir):
-        print('Test results directory "%s" does not exist' % test_results_dir, file=sys.stderr)
-        exit(1)
+        sys.exit('Test results directory "%s" does not exist' % test_results_dir)
 
     try:
         results = test_results(test_results_dir)
         print_summary(results)
     except Exception as e:
-        print(str(e), file=sys.stderr)
+        sys.stderr.write(str(e))
         exit(2)
 
 

--- a/bin/catkin_topological_order
+++ b/bin/catkin_topological_order
@@ -20,20 +20,20 @@ def main():
     parser.add_argument('--only-names', action='store_true', help='Only output the project names')
     args = parser.parse_args()
 
+    # verify reasonable argument combination
+    if args.only_folders and args.only_names:
+        parser.error('Use either "--only-folders" or "--only-names" but not both')
+
     # verify that workspace folder exists
     workspace = os.path.abspath(args.workspace)
     if not os.path.isdir(workspace):
-        print('Workspace "%s" does not exist' % workspace, file=sys.stderr)
-        exit(1)
-
-    # verify reasonable argument combination
-    if args.only_folders and args.only_names:
-        print('Use either "--only-folders" or "--only-names" but not both', file=sys.stderr)
-        exit(2)
+        sys.exit('Workspace "%s" does not exist' % workspace)
 
     ordered_projects = topological_order(workspace)
     if not ordered_projects:
-        print('Workspace "%s" seems to not contain any projects.  Have you passed the correct path to a catkin workspace?' % workspace, file=sys.stderr)
+        sys.stderr.write('Workspace "%s" seems to not contain any projects.'
+                         ' Have you passed the correct path to a '
+                         'catkin workspace?' % workspace)
         exit(3)
 
     for (path, package) in ordered_projects:

--- a/bin/catkin_topological_order
+++ b/bin/catkin_topological_order
@@ -7,36 +7,39 @@ import sys
 
 try:
     from catkin_pkg.topological_order import topological_order
-except ImportError as e:
-    e.args = ['%s\nCould not find Python module "catkin_pkg". Have you installed the Debian package "python-catkin-pkg"?' % (e.message)]
-    raise
+except ImportError:
+    # find the import relatively to make it work before installing catkin
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
+    from catkin_pkg.topological_order import topological_order
 
-parser = argparse.ArgumentParser(description='Outputs the catkin projects of a workspace in topological order.')
-parser.add_argument('workspace', nargs='?', default='.', help='The path to a workspace (default: .)')
-parser.add_argument('--only-folders', action='store_true', help='Only output the project folders')
-parser.add_argument('--only-names', action='store_true', help='Only output the project names')
-args = parser.parse_args()
 
-# verify that workspace folder exists
-workspace = os.path.abspath(args.workspace)
-if not os.path.isdir(workspace):
-    print('Workspace "%s" does not exist' % workspace, file=sys.stderr)
-    exit(1)
+def main():
+    parser = argparse.ArgumentParser(description='Outputs the catkin projects of a workspace in topological order.')
+    parser.add_argument('workspace', nargs='?', default='.', help='The path to a workspace (default: .)')
+    parser.add_argument('--only-folders', action='store_true', help='Only output the project folders')
+    parser.add_argument('--only-names', action='store_true', help='Only output the project names')
+    args = parser.parse_args()
 
-# verify reasonable argument combination
-if args.only_folders and args.only_names:
-    print('Use either "--only-folders" or "--only-names" but not both', file=sys.stderr)
-    exit(2)
+    # verify that workspace folder exists
+    workspace = os.path.abspath(args.workspace)
+    if not os.path.isdir(workspace):
+        print('Workspace "%s" does not exist' % workspace, file=sys.stderr)
+        exit(1)
 
-ordered_projects = topological_order(workspace)
-if not ordered_projects:
-    print('Workspace "%s" seems to not contain any projects.  Have you passed the correct path to a catkin workspace?' % workspace, file=sys.stderr)
-    exit(3)
+    # verify reasonable argument combination
+    if args.only_folders and args.only_names:
+        print('Use either "--only-folders" or "--only-names" but not both', file=sys.stderr)
+        exit(2)
 
-for (path, package) in ordered_projects:
-    if args.only_folders:
-        print('%s' % path)
-    elif args.only_names:
-        print('%s' % package.name)
-    else:
-        print('%s %s' % (package.name, path))
+    ordered_projects = topological_order(workspace)
+    if not ordered_projects:
+        print('Workspace "%s" seems to not contain any projects.  Have you passed the correct path to a catkin workspace?' % workspace, file=sys.stderr)
+        exit(3)
+
+    for (path, package) in ordered_projects:
+        if args.only_folders:
+            print('%s' % path)
+        elif args.only_names:
+            print('%s' % package.name)
+        else:
+            print('%s %s' % (package.name, path))

--- a/bin/catkin_ws
+++ b/bin/catkin_ws
@@ -45,7 +45,7 @@ def main():
             if output != '':
                 print(output)
         except Exception as e:
-            print(str(e), file=sys.stderr)
+            sys.exit(str(e))
 
 
 if __name__ == '__main__':

--- a/bin/catkin_ws
+++ b/bin/catkin_ws
@@ -12,35 +12,41 @@ except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
     from catkin.workspace_vcs import find_repositories, vcs_branch, vcs_diff, vcs_pull, vcs_push, vcs_remotes, vcs_status
 
-parser = argparse.ArgumentParser(description='Perform a VCS command on all repositories in the current directory.')
-parser.add_argument('path', nargs='?', default='.', help='The parent path of the repositories (default: .)')
-parser.add_argument('command', choices=('branch', 'diff', 'pull', 'remotes', 'status'), help='The command to execute')
-args = parser.parse_args()
 
-repositories = find_repositories(args.path)
+def main():
+    parser = argparse.ArgumentParser(description='Perform a VCS command on all repositories in the current directory.')
+    parser.add_argument('path', nargs='?', default='.', help='The parent path of the repositories (default: .)')
+    parser.add_argument('command', choices=('branch', 'diff', 'pull', 'remotes', 'status'), help='The command to execute')
+    args = parser.parse_args()
 
-if args.command == 'branch':
-    vcs_command = vcs_branch
-elif args.command == 'diff':
-    vcs_command = vcs_diff
-elif args.command == 'pull':
-    vcs_command = vcs_pull
-elif args.command == 'push':
-    vcs_command = vcs_push
-elif args.command == 'remotes':
-    vcs_command = vcs_remotes
-elif args.command == 'status':
-    vcs_command = vcs_status
-else:
-    raise RuntimeError('Unknown command "%s"' % args.command)
+    repositories = find_repositories(args.path)
 
-for subfolder in sorted(repositories.keys()):
-    vcs_type = repositories[subfolder]
-    print('===  %s (%s) ===' % (subfolder, vcs_type))
-    try:
-        output = vcs_command(os.path.join(args.path, subfolder), vcs_type)
-        output = output.rstrip(os.linesep)
-        if output != '':
-            print(output)
-    except Exception as e:
-        print(str(e), file=sys.stderr)
+    if args.command == 'branch':
+        vcs_command = vcs_branch
+    elif args.command == 'diff':
+        vcs_command = vcs_diff
+    elif args.command == 'pull':
+        vcs_command = vcs_pull
+    elif args.command == 'push':
+        vcs_command = vcs_push
+    elif args.command == 'remotes':
+        vcs_command = vcs_remotes
+    elif args.command == 'status':
+        vcs_command = vcs_status
+    else:
+        raise RuntimeError('Unknown command "%s"' % args.command)
+
+    for subfolder in sorted(repositories.keys()):
+        vcs_type = repositories[subfolder]
+        print('===  %s (%s) ===' % (subfolder, vcs_type))
+        try:
+            output = vcs_command(os.path.join(args.path, subfolder), vcs_type)
+            output = output.rstrip(os.linesep)
+            if output != '':
+                print(output)
+        except Exception as e:
+            print(str(e), file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -83,21 +83,26 @@ class Dummy:
     pass
 
 
-d = Dummy()
-setattr(d, 'setup', mysetup)
+def main():
+    dummy = Dummy()
+    setattr(dummy, 'setup', mysetup)
 
-sys.modules['setuptools'] = d
-sys.modules['distutils.core'] = d
+    sys.modules['setuptools'] = dummy
+    sys.modules['distutils.core'] = dummy
 
-# find the imports in setup.py relatively to make it work before installing catkin
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
+    # find the imports in setup.py relatively to make it work before installing catkin
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
 
-# print("executing %s" % sys.argv[2])
+    # print("executing %s" % sys.argv[2])
 
-# be sure you're in the directory containing
-# setup.py so the sys.path manipulation works,
-# so the import of __version__ works
-os.chdir(os.path.dirname(os.path.abspath(sys.argv[2])))
+    # be sure you're in the directory containing
+    # setup.py so the sys.path manipulation works,
+    # so the import of __version__ works
+    os.chdir(os.path.dirname(os.path.abspath(sys.argv[2])))
 
-with open(sys.argv[2], 'r') as fh:
-    exec(fh.read())
+    with open(sys.argv[2], 'r') as fh:
+        exec(fh.read())
+
+
+if __name__ == '__main__':
+    main()

--- a/cmake/parse_package_xml.py
+++ b/cmake/parse_package_xml.py
@@ -5,17 +5,23 @@ import sys
 
 from catkin_pkg.package import parse_package
 
-package = parse_package(sys.argv[1])
 
-values = {}
-values['VERSION'] = '"%s"' % package.version
+def main():
+    package = parse_package(sys.argv[1])
 
-values['MAINTAINER'] = '"%s"' % (', '.join([str(m) for m in package.maintainers]))
+    values = {}
+    values['VERSION'] = '"%s"' % package.version
 
-values['BUILD_DEPENDS'] = ' '.join(['"%s"' % str(d) for d in package.build_depends])
-values['RUN_DEPENDS'] = ' '.join(['"%s"' % str(d) for d in package.run_depends])
+    values['MAINTAINER'] = '"%s"' % (', '.join([str(m) for m in package.maintainers]))
 
-with open(sys.argv[2], 'w') as ofile:
-    print(r'set(_CATKIN_CURRENT_PACKAGE "%s")' % package.name, file=ofile)
-    for k, v in values.items():
-        print('set(%s_%s %s)' % (package.name, k, v), file=ofile)
+    values['BUILD_DEPENDS'] = ' '.join(['"%s"' % str(d) for d in package.build_depends])
+    values['RUN_DEPENDS'] = ' '.join(['"%s"' % str(d) for d in package.run_depends])
+
+    with open(sys.argv[2], 'w') as ofile:
+        print(r'set(_CATKIN_CURRENT_PACKAGE "%s")' % package.name, file=ofile)
+        for k, v in values.items():
+            print('set(%s_%s %s)' % (package.name, k, v), file=ofile)
+
+
+if __name__ == '__main__':
+    main()

--- a/cmake/python_version.py
+++ b/cmake/python_version.py
@@ -1,4 +1,11 @@
 from __future__ import print_function
 from sys import version_info as v
-# don't use version.major, version.minor, this is pys >= 2.7
-print("%u.%u" % (v[0], v[1]))
+
+def main():
+    """Prints python version to stdout"""
+    # don't use version.major, version.minor, this is pys >= 2.7
+    print("%u.%u" % (v[0], v[1]))
+
+
+if __name__ == '__main__':
+    main()

--- a/cmake/test/run_tests.py
+++ b/cmake/test/run_tests.py
@@ -8,48 +8,54 @@ from xml.etree.ElementTree import ElementTree, ParseError
 
 from catkin.tidy_xml import tidy_xml
 
-parser = argparse.ArgumentParser(description='Runs the test command passed as an argument and verifies that the expected result file has been generated.')
-parser.add_argument('command', nargs='+', help='The test command to execute')
-parser.add_argument('--results', help='The path to the xunit result file')
-parser.add_argument('--working-dir', nargs='?', help='The working directory for the executed command')
-args = parser.parse_args()
 
-# if result file exists remove it before test execution
-if os.path.exists(args.results):
-    os.remove(args.results)
-# if placeholder (indicating previous failure) exists remove it before test execution
-placeholder = os.path.join(os.path.dirname(args.results), 'MISSING-%s' % os.path.basename(args.results))
-if os.path.exists(placeholder):
-    os.remove(placeholder)
-
-print('-- run_tests.py: execute commands%s%s' % (' with working directory "%s"' % args.working_dir if args.working_dir is not None else '', (''.join(['\n  %s' % cmd for cmd in args.command]))))
-for cmd in args.command:
-    subprocess.call(cmd, cwd=args.working_dir, shell=True)
-
-print('-- run_tests.py: verify result "%s"' % args.results)
-
-if os.path.exists(args.results):
-    # if result file exists ensure that it contains valid xml
-    try:
-        root = ElementTree(None, args.results)
-    except ParseError as e:
-        #print('Invalid XML in result file "%s"' % args.results)
-        tidy_xml(args.results)
+def main():
+    parser = argparse.ArgumentParser(description='Runs the test command passed as an argument and verifies that the expected result file has been generated.')
+    parser.add_argument('command', nargs='+', help='The test command to execute')
+    parser.add_argument('--results', help='The path to the xunit result file')
+    parser.add_argument('--working-dir', nargs='?', help='The working directory for the executed command')
+    args = parser.parse_args()
+    
+    # if result file exists remove it before test execution
+    if os.path.exists(args.results):
+        os.remove(args.results)
+    # if placeholder (indicating previous failure) exists remove it before test execution
+    placeholder = os.path.join(os.path.dirname(args.results), 'MISSING-%s' % os.path.basename(args.results))
+    if os.path.exists(placeholder):
+        os.remove(placeholder)
+    
+    print('-- run_tests.py: execute commands%s%s' % (' with working directory "%s"' % args.working_dir if args.working_dir is not None else '', (''.join(['\n  %s' % cmd for cmd in args.command]))))
+    for cmd in args.command:
+        subprocess.call(cmd, cwd=args.working_dir, shell=True)
+    
+    print('-- run_tests.py: verify result "%s"' % args.results)
+    
+    if os.path.exists(args.results):
+        # if result file exists ensure that it contains valid xml
         try:
             root = ElementTree(None, args.results)
         except ParseError as e:
-            print('Invalid XML in result file "%s" (even after trying to tidy it) ' % args.results)
-else:
-    # if result file does not exist create placeholder which indicates failure
-    print('Cannot find results, writing failure results to "%s"' % placeholder)
-    # create folder if necessary
-    if not os.path.exists(os.path.dirname(args.results)):
-        os.makedirs(os.path.dirname(args.results))
-    with open(placeholder, 'w') as f:
-        data = {'test': os.path.basename(args.results), 'test_file': args.results}
-        f.write('''<?xml version="1.0" encoding="UTF-8"?>
+            #print('Invalid XML in result file "%s"' % args.results)
+            tidy_xml(args.results)
+            try:
+                root = ElementTree(None, args.results)
+            except ParseError as e:
+                print('Invalid XML in result file "%s" (even after trying to tidy it) ' % args.results)
+    else:
+        # if result file does not exist create placeholder which indicates failure
+        print('Cannot find results, writing failure results to "%s"' % placeholder)
+        # create folder if necessary
+        if not os.path.exists(os.path.dirname(args.results)):
+            os.makedirs(os.path.dirname(args.results))
+        with open(placeholder, 'w') as f:
+            data = {'test': os.path.basename(args.results), 'test_file': args.results}
+            f.write('''<?xml version="1.0" encoding="UTF-8"?>
 <testsuite tests="1" failures="1" time="1" errors="0" name="%(test)s">
   <testcase name="test_ran" status="run" time="1" classname="Results">
     <failure message="Unable to find test results for %(test)s, test did not run.\nExpected results in %(test_file)s" type=""/>
   </testcase>
 </testsuite>''' % data)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Generally tried to tidy up python code, making it suitable for unit testing
Some commit have multi-line explanations and details
catkin-build-debs-of-workspace got some attention despite not being used and installed, because some users / developers may still find it in the source.

2 commits are a bit annoying to review, the adding of main() where the whitespace should maybe be checked (though I was careful)
and the refactoring of download_checkmd5, as I moved from 2-space to 4 space, and also restructured a lot in the next commit.
