### PR TITLE
Test fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 catkin
-========
+======
 
 Catkin is a collection of cmake macros and associated python code used
 to build some parts of `ROS <http://www.ros.org>`_

--- a/test/checks/test-nocatkin.rosinstall
+++ b/test/checks/test-nocatkin.rosinstall
@@ -1,7 +1,7 @@
-- git:
-    uri: 'git://github.com/willowgarage/catkin-debs.git'
-    local-name: catkin-debs
-    version: master
+# - git:
+#     uri: 'git://github.com/willowgarage/catkin-debs.git'
+#     local-name: catkin_debs
+#     version: master
 
 - git:
     uri: 'git://github.com/ros/genmsg.git'

--- a/test/local_tests/test_with_mock_workspace.py
+++ b/test/local_tests/test_with_mock_workspace.py
@@ -30,7 +30,7 @@ class MockTest(AbstractCatkinWorkspaceTest):
         dstdir = os.path.join(self.workspacedir, 'nolangs')
         shutil.copytree(os.path.join(MOCK_DIR, 'src', 'nolangs'), dstdir)
 
-        out = self.cmake(CATKIN_WHITELIST_STACKS='nolangs',
+        out = self.cmake(CATKIN_WHITELIST_PACKAGES='nolangs',
                          CATKIN_DPKG_BUILDPACKAGE_FLAGS='-d;-S;-us;-uc')
         self.assertTrue(os.path.exists(self.builddir + "/nolangs"))
         self.assertFalse(os.path.exists(self.builddir + "/std_msgs"))
@@ -52,7 +52,7 @@ class MockTest(AbstractCatkinWorkspaceTest):
         dstdir = os.path.join(self.workspacedir, 'noproject')
         shutil.copytree(os.path.join(MOCK_DIR, 'src-fail', 'noproject'), dstdir)
         # test with whitelist
-        out = self.cmake(CATKIN_WHITELIST_STACKS='catkin')
+        out = self.cmake(CATKIN_WHITELIST_PACKAGES='catkin')
         out = succeed(MAKE_CMD + ["install"], cwd=self.builddir)
 
         shutil.rmtree(self.builddir)
@@ -63,7 +63,7 @@ class MockTest(AbstractCatkinWorkspaceTest):
                          expect=fail)
         print("failed as expected, out=", out)
 
-        assert 'catkin_project() CATKIN_CURRENT_STACK is not set.' in out
+        assert 'catkin_project() CATKIN_CURRENT_PACKAGE is not set.' in out
         # assert 'You must call project() with the same name before.' in out
 
     # Test was not finished apparently

--- a/test/mock_resources/src-fail/badly_specified_changelog/CMakeLists.txt
+++ b/test/mock_resources/src-fail/badly_specified_changelog/CMakeLists.txt
@@ -3,5 +3,4 @@ cmake_minimum_required(VERSION 2.8)
 project(badly_specified_changelog)
 find_package(catkin)
 
-project(badly_specified_changelog)
-catkin_project(badly_specified_changelog)
+catkin_package()

--- a/test/mock_resources/src-fail/badly_specified_changelog/package.xml
+++ b/test/mock_resources/src-fail/badly_specified_changelog/package.xml
@@ -1,6 +1,6 @@
-<stack>
-  <name>nolangs</name>
-  <version>3.4.5</version>
+<package>
+  <name>badly_specified_changelog</name>
+  <version>0.0.0</version>
   <description/>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
@@ -9,7 +9,4 @@
   <url/>
 
   <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-</stack>
+</package>

--- a/test/mock_resources/src-fail/noproject/CMakeLists.txt
+++ b/test/mock_resources/src-fail/noproject/CMakeLists.txt
@@ -3,5 +3,5 @@ cmake_minimum_required(VERSION 2.8)
 # project(noproject)
 find_package(catkin)
 
-catkin_project(noproject)
+catkin_package()
 

--- a/test/mock_resources/src-fail/noproject/package.xml
+++ b/test/mock_resources/src-fail/noproject/package.xml
@@ -1,0 +1,12 @@
+<package>
+  <name>noproject</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <copyright>Someone</copyright>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+</package>

--- a/test/mock_resources/src/catkin_test/a/CMakeLists.txt
+++ b/test/mock_resources/src/catkin_test/a/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 project(a)
-catkin_project(a
+find_package(catkin REQUIRED COMPONENTS genmsg std_msgs)
+
+catkin_package(
   INCLUDE_DIRS include
   LIBRARIES a
 #  PYTHONPATH src
   )
-
-find_package(catkin REQUIRED)
 
 add_library(a SHARED lib.cpp)
 

--- a/test/mock_resources/src/catkin_test/a/package.xml
+++ b/test/mock_resources/src/catkin_test/a/package.xml
@@ -1,0 +1,19 @@
+<package>
+  <name>a</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <build_depends>std_msgs</build_depends>
+  <build_depends>ros_comm</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/catkin_test/b/CMakeLists.txt
+++ b/test/mock_resources/src/catkin_test/b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 project(b)
-catkin_project(b
+find_package(catkin REQUIRED)
+catkin_package(
   INCLUDE_DIRS include
   LIBRARIES b
   )
 
-find_package(catkin REQUIRED)
 find_package(a)
 include_directories(${a_INCLUDE_DIRS})
 

--- a/test/mock_resources/src/catkin_test/b/package.xml
+++ b/test/mock_resources/src/catkin_test/b/package.xml
@@ -1,11 +1,10 @@
-<stack>
-  <name>catkin_test</name>
+<package>
+  <name>b</name>
   <version>3.4.5</version>
   <description/>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>
-  <copyright>Someone</copyright>
   <url/>
 
   <build_depends>catkin</build_depends>
@@ -14,4 +13,7 @@
   <build_depends>genpy</build_depends>
   <build_depends>std_msgs</build_depends>
   <build_depends>ros_comm</build_depends>
-</stack>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/catkin_test/c/CMakeLists.txt
+++ b/test/mock_resources/src/catkin_test/c/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 project(c)
-catkin_project(c
+find_package(catkin REQUIRED)
+
+catkin_package(
   INCLUDE_DIRS include
   LIBRARIES c-one c-two
   )
 
-find_package(catkin REQUIRED)
 find_package(a)
 include_directories(${a_INCLUDE_DIRS})
 

--- a/test/mock_resources/src/catkin_test/c/package.xml
+++ b/test/mock_resources/src/catkin_test/c/package.xml
@@ -1,0 +1,19 @@
+<package>
+  <name>c</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <build_depends>std_msgs</build_depends>
+  <build_depends>ros_comm</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/catkin_test/d/CMakeLists.txt
+++ b/test/mock_resources/src/catkin_test/d/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 project(d)
-catkin_project(d
+find_package(catkin REQUIRED)
+
+catkin_package(
   INCLUDE_DIRS include
   LIBRARIES d
   )
 
-find_package(catkin REQUIRED)
 find_package(c)
 find_package(b)
 find_package(a)

--- a/test/mock_resources/src/catkin_test/d/package.xml
+++ b/test/mock_resources/src/catkin_test/d/package.xml
@@ -1,0 +1,19 @@
+<package>
+  <name>d</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <build_depends>std_msgs</build_depends>
+  <build_depends>ros_comm</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/catkin_test/quux_msgs/CMakeLists.txt
+++ b/test/mock_resources/src/catkin_test/quux_msgs/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 project(quux_msgs)
-catkin_project(${PROJECT_NAME})
+find_package(catkin REQUIRED)
 
- find_package(catkin REQUIRED)
+catkin_package()
+
 
 find_package(genmsg REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/test/mock_resources/src/catkin_test/quux_msgs/package.xml
+++ b/test/mock_resources/src/catkin_test/quux_msgs/package.xml
@@ -1,0 +1,19 @@
+<package>
+  <name>quux_msgs</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <build_depends>std_msgs</build_depends>
+  <build_depends>ros_comm</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/catkin_test/quux_user/CMakeLists.txt
+++ b/test/mock_resources/src/catkin_test/quux_user/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(quux_user)
+find_package(catkin REQUIRED)
 
+catkin_package()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 find_package(quux_msgs)

--- a/test/mock_resources/src/catkin_test/quux_user/package.xml
+++ b/test/mock_resources/src/catkin_test/quux_user/package.xml
@@ -1,0 +1,19 @@
+<package>
+  <name>quux_user</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <build_depends>std_msgs</build_depends>
+  <build_depends>ros_comm</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/nolangs/CMakeLists.txt
+++ b/test/mock_resources/src/nolangs/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 project(nolangs)
 find_package(catkin REQUIRED)
+catkin_package()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
@@ -11,4 +12,3 @@ add_executable(nolangs_exec
 install(TARGETS nolangs_exec
   RUNTIME DESTINATION bin)
 
-catkin_project(nolangs)

--- a/test/mock_resources/src/nolangs/package.xml
+++ b/test/mock_resources/src/nolangs/package.xml
@@ -1,6 +1,6 @@
-<stack>
-  <name>badly_specified_changelog</name>
-  <version>0.0.0</version>
+<package>
+  <name>nolangs</name>
+  <version>3.4.5</version>
   <description/>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
@@ -9,4 +9,7 @@
   <url/>
 
   <build_depends>catkin</build_depends>
-</stack>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+</package>

--- a/test/mock_resources/src/python_test_a/package.xml
+++ b/test/mock_resources/src/python_test_a/package.xml
@@ -1,12 +1,17 @@
-<stack>
-  <name>noproject</name>
+<package>
+  <name>python_test_a</name>
   <version>3.4.5</version>
   <description/>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>
-  <copyright>Someone</copyright>
   <url/>
 
   <build_depends>catkin</build_depends>
-</stack>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/mock_resources/src/ros_user/package.xml
+++ b/test/mock_resources/src/ros_user/package.xml
@@ -1,0 +1,22 @@
+<package>
+  <name>ros_user</name>
+  <version>3.4.5</version>
+  <description/>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <build_depends>catkin</build_depends>
+  <build_depends>gencpp</build_depends>
+  <build_depends>genmsg</build_depends>
+  <build_depends>genpy</build_depends>
+  <build_depends>cpp_common</build_depends>
+  <build_depends>rostime</build_depends>
+  <build_depends>roscpp_traits</build_depends>
+  <build_depends>roscpp_serialization</build_depends>
+  <build_depends>sensor_msgs</build_depends>
+  <export>
+  </export>
+
+</package>

--- a/test/network_tests/test.rosinstall
+++ b/test/network_tests/test.rosinstall
@@ -29,10 +29,10 @@
     local-name: langs
     version: master
 
-- git:
-    uri: 'git://github.com/ros/langs-dev.git'
-    local-name: langs-dev
-    version: master
+# - git:
+#     uri: 'git://github.com/ros/langs-dev.git'
+#     local-name: langs-dev
+#     version: master
 
 - git:
     uri: 'git://github.com/ros/std_msgs.git'


### PR DESCRIPTION
This is a first batch to fix the catkin tests after the changes made towards a package.xml

It should fix all tests in test/unit_tests (run by extending PYTHONPATH and the nosetests test/unit-tests)

the caktin integration tests in test/network_tests should work once this bug gets fixed:
https://github.com/ros/common_msgs/issues/1
Remember that you may need to delete test/tmp if you have not run tests in a long time.

A test test/local_tests discovered a new minor bug in catkin that I cannot easily resolve, maybe someone else will see the solution immediately, so I do not start to search:

If you use an invalid CMakeLists.txt without 
project(foo),
like catkin/test/mock_resource/src-fail/noproject/CMakeLists.txt

then in catkin_package_xml the lines:
  if(NOT PROJECT_NAME)
    message(FATAL_ERROR "catkin_package_xml() PROJECT_NAME is not set. You must call project() before you can call catkin_package_xml().")
  endif()
should generate this error. However, the error does not appear, as 
PROJECT_NAME seems to have the value "Project"
a non-descript error happens as a consequence

That's what you get with
$ nosetests test/local-tests
