### PR TITLE
Fix issues with zsh and setup.sh

### DIFF
--- a/cmake/templates/setup.zsh.in
+++ b/cmake/templates/setup.zsh.in
@@ -2,4 +2,6 @@
 # generated from catkin/cmake/templates/setup.zsh.in
 
 CATKIN_SHELL=zsh
+emulate sh # emulate POSIX
 . "@SETUP_DIR@/setup.sh"
+emulate zsh # back to zsh mode


### PR DESCRIPTION
Because zsh doesn't automatically make arrays on newlines, sourcing the "setup.zsh" file results in an error, and all of the files that should be sourced from the `PREFIX/etc/catkin/profile.d` don't get sourced, with an error similar to:

```
/home/jamuraa/ros-groovy/setup.sh:.:104: no such file or directory: /home/jamuraa/ros-groovy/etc/catkin/profile.d/05.catkin-test-results.sh\n/home/jamuraa/ros-groovy/etc/catkin/profile.d/10.rosconsole.sh\n/home/jamuraa/ros-groovy/etc/catkin/profile.d/10.roslaunch.sh\n/home/jamuraa/ros-groovy/etc/catkin/profile.d/10.ros.sh
```

This pull request fixes the problem by putting zsh into POSIX emulation mode before executing setup.sh, and switching back to zsh mode when done.
