### PR TITLE
Make catkin-build-deb-of-workspace Shell script robust

### DIFF
--- a/bin/catkin-build-debs-of-workspace
+++ b/bin/catkin-build-debs-of-workspace
@@ -17,6 +17,17 @@ done
 if [ -n "$1" ] ; then echo "$0 takes no arguments"; exit 1 ; fi
 
 
+echo "!!!!!!!!!!!!!!! DO NOT PROCEED UNLESS YOU KNOW WHAT YOU ARE DOING !!!!!!!!!"
+echo "This script runs git clean (which removes untracked files forever) and runs sudo commands to install linux packages."
+echo -n "Please confirm (y or n) :"
+read CONFIRM
+case $CONFIRM in
+    y|Y|YES|yes|Yes) ;;
+    *) echo Aborting - you entered $CONFIRM
+        exit
+        ;;
+esac
+
 TOP=$(dirname $0)
 work=`pwd`
 distro=$(lsb_release -cs)

--- a/bin/catkin-build-debs-of-workspace
+++ b/bin/catkin-build-debs-of-workspace
@@ -1,4 +1,22 @@
-#!/usr/bin/env bash -ex
+#! /usr/bin/env bash -ex
+
+ARGS=$(getopt -o "h" --long "help" \
+  -n $0 -- "$@")
+if [ $? != 0 ] ; then exit 1 ; fi
+eval set -- "$ARGS"
+
+while true ; do
+	case "$1" in
+    # -- is artefact from getopt
+		--) shift ; break ;;
+		-h|--help) echo "$0 iterates over all catkin projects and runs git buildpackage with suitable options, installs dependencies" ; exit 0 ;;
+		*) echo "Internal error!" ; exit 1 ;;
+	esac
+done
+
+if [ -n "$1" ] ; then echo "$0 takes no arguments"; exit 1 ; fi
+
+
 TOP=$(dirname $0)
 work=`pwd`
 distro=$(lsb_release -cs)


### PR DESCRIPTION
Even if this script is not going to be released, new catkin developers may still stumble on it, so this pull request just makes it a bit more safe and robust.

Based on latest master
