### PR TITLE
fix mock resources

### DIFF
--- a/test/mock_resources/src-fail/badly_specified_changelog/package.xml
+++ b/test/mock_resources/src-fail/badly_specified_changelog/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>badly_specified_changelog</name>
   <version>0.0.0</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src-fail/noproject/package.xml
+++ b/test/mock_resources/src-fail/noproject/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>noproject</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/catkin_test/a/package.xml
+++ b/test/mock_resources/src/catkin_test/a/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>a</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/catkin_test/b/package.xml
+++ b/test/mock_resources/src/catkin_test/b/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>b</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/catkin_test/c/package.xml
+++ b/test/mock_resources/src/catkin_test/c/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>c</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/catkin_test/catkin_test/package.xml
+++ b/test/mock_resources/src/catkin_test/catkin_test/package.xml
@@ -1,0 +1,20 @@
+<package>
+  <name>catkin_test</name>
+  <version>3.4.5</version>
+  <description>foo</description>
+  <author>Somebody</author>
+  <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
+  <license>Unknown</license>
+  <url/>
+
+  <run_depends>catkin</run_depends>
+  <run_depends>gencpp</run_depends>
+  <run_depends>genmsg</run_depends>
+  <run_depends>genpy</run_depends>
+  <run_depends>std_msgs</run_depends>
+  <run_depends>ros_comm</run_depends>
+  <export>
+    <metapackage/>
+  </export>
+
+</package>

--- a/test/mock_resources/src/catkin_test/d/package.xml
+++ b/test/mock_resources/src/catkin_test/d/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>d</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/catkin_test/quux_msgs/package.xml
+++ b/test/mock_resources/src/catkin_test/quux_msgs/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>quux_msgs</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/catkin_test/quux_user/package.xml
+++ b/test/mock_resources/src/catkin_test/quux_user/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>quux_user</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/nolangs/package.xml
+++ b/test/mock_resources/src/nolangs/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>nolangs</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/python_test_a/package.xml
+++ b/test/mock_resources/src/python_test_a/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>python_test_a</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>

--- a/test/mock_resources/src/ros_user/package.xml
+++ b/test/mock_resources/src/ros_user/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>ros_user</name>
   <version>3.4.5</version>
-  <description/>
+  <description>foo</description>
   <author>Somebody</author>
   <maintainer email="Somebody@somewhere.org">Somebody</maintainer>
   <license>Unknown</license>


### PR DESCRIPTION
package.xml validation has changed in catkin_pkg, which causes integration tests to fail, this pull requests adapts the mock files used in the tests to not fail
