### PR TITLE
Refactor and fix interrogate setup

### DIFF
--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -26,68 +26,71 @@ def samefile(path1, path2):
                  os.path.normcase(os.path.normpath(path2))
     return result
 
-
-def mysetup(*args, **kwargs):
-    if 'version' not in kwargs:
-        print("""
-    *** Unable to find 'version' in setup.py of %s
-""" % PACKAGE_NAME)
-        raise RuntimeError("version not found in setup.py")
-
-    with open(OUTFILE, 'w') as out:
-
-        print(r'set(%s_VERSION "%s")' % (PACKAGE_NAME, kwargs['version']),
-              file=out)
-        print(r'set(%s_SCRIPTS "%s")' % (PACKAGE_NAME,
-                                         ';'.join(kwargs.get('scripts', []))), file=out)
-
-        if 'package_dir' not in kwargs:
-            raise RuntimeError(r'package_dir not in setup.py', file=sys.stderr)
-
-        package_dir = kwargs['package_dir']
-        allprefix = package_dir.get('', None)
-
-        pkgs = kwargs.get('packages', [])
-
-        # Remove packages with '.' separators.  setuptools requires
-        # specifying submodules.  The symlink approach of catkin does not
-        # work with submodules.  In the common case, this does not matter
-        # as the submodule is within the containing module.  We verify
-        # this assumption, and if it passes, we remove submodule packages.
-        if not allprefix:
-            for pkg in pkgs:
-                splits = pkg.split('.')
-                # hack: ignore write-combining setup.py files for msg and srv
-                # files
-                if len(splits) > 1 and splits[1] not in ['msg', 'srv']:
-                    top_level = splits[0]
-                    top_level_dir = package_dir[top_level]
-                    expected_dir = os.path.join(top_level_dir, os.path.join(*splits[1:]))
-                    actual_dir = package_dir[pkg]
-                    if not samefile(expected_dir, actual_dir):
-                        raise RuntimeError("catkin_export_python does not support setup.py files that combine across multiple directories")
-
-        # If checks pass, remove all submodules
-        pkgs = [p for p in pkgs if '.' not in p]
-
-        resolved_pkgs = []
-        for pkg in pkgs:
-            if allprefix:
-                resolved_pkgs += [os.path.join(allprefix, pkg)]
-            else:
-                resolved_pkgs += [package_dir[pkg]]
-
-        print(r'set(%s_PACKAGES "%s")' % (PACKAGE_NAME, ';'.join(pkgs)), file=out)
-        print(r'set(%s_PACKAGE_DIRS "%s")' % (PACKAGE_NAME, ';'.join(resolved_pkgs).replace("\\", "/")), file=out)
-
-
 class Dummy:
-    pass
+    '''
+    Used as a replacement for modules setuptools and distutils.core,
+    defines a setup function.
+    '''
+
+    def setup(*args, **kwargs):
+        if 'version' not in kwargs:
+            print("""
+        *** Unable to find 'version' in setup.py of %s
+""" % PACKAGE_NAME)
+            raise RuntimeError("version not found in setup.py")
+
+        with open(OUTFILE, 'w') as out:
+
+            print(r'set(%s_VERSION "%s")' % (PACKAGE_NAME, kwargs['version']),
+                  file=out)
+            print(r'set(%s_SCRIPTS "%s")' % (PACKAGE_NAME,
+                                             ';'.join(kwargs.get('scripts', []))), file=out)
+
+            if 'package_dir' not in kwargs:
+                raise RuntimeError(r'package_dir not in setup.py', file=sys.stderr)
+
+            package_dir = kwargs['package_dir']
+            allprefix = package_dir.get('', None)
+
+            pkgs = kwargs.get('packages', [])
+
+            # Remove packages with '.' separators.  setuptools requires
+            # specifying submodules.  The symlink approach of catkin does not
+            # work with submodules.  In the common case, this does not matter
+            # as the submodule is within the containing module.  We verify
+            # this assumption, and if it passes, we remove submodule packages.
+            if not allprefix:
+                for pkg in pkgs:
+                    splits = pkg.split('.')
+                    # hack: ignore write-combining setup.py files for msg and srv
+                    # files
+                    if len(splits) > 1 and splits[1] not in ['msg', 'srv']:
+                        top_level = splits[0]
+                        top_level_dir = package_dir[top_level]
+                        expected_dir = os.path.join(top_level_dir,
+                                                    os.path.join(*splits[1:]))
+                        actual_dir = package_dir[pkg]
+                        if not samefile(expected_dir, actual_dir):
+                            raise RuntimeError(
+                                "catkin_export_python does not support setup.py files that combine across multiple directories")
+
+            # If checks pass, remove all submodules
+            pkgs = [p for p in pkgs if '.' not in p]
+
+            resolved_pkgs = []
+            for pkg in pkgs:
+                if allprefix:
+                    resolved_pkgs += [os.path.join(allprefix, pkg)]
+                else:
+                    resolved_pkgs += [package_dir[pkg]]
+
+            print(r'set(%s_PACKAGES "%s")' % (PACKAGE_NAME, ';'.join(pkgs)), file=out)
+            print(r'set(%s_PACKAGE_DIRS "%s")' % (PACKAGE_NAME, ';'.join(resolved_pkgs).replace("\\", "/")), file=out)
+
 
 
 def main():
     dummy = Dummy()
-    setattr(dummy, 'setup', mysetup)
 
     sys.modules['setuptools'] = dummy
     sys.modules['distutils.core'] = dummy

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -12,6 +12,7 @@ def _get_locations(pkgs, package_dir):
     based on setuptools logic and the package_dir dict, builds a dict
     of location roots for each pkg in pkgs.
     See http://docs.python.org/distutils/setupscript.html
+
     :returns: a dict {pkgname: root} for each pkgname in pkgs (and each of their parents)
     """
     # package_dir contains a dict {package_name: relativepath}
@@ -47,6 +48,7 @@ def _get_locations(pkgs, package_dir):
 def generate_cmake_file(package_name, version, scripts, package_dir, pkgs):
     """
     Generates lines to add to a cmake file which will set variables
+
     :param version: str, format 'int.int.int'
     :param scripts: [list of str]: relative paths to scripts
     :param package_dir: {modulename: path}
@@ -127,6 +129,9 @@ class Dummy:
 
 
 def main():
+    """
+    Script main, parses arguments and invokes Dummy.setup indirectly.
+    """
     parser = ArgumentParser(description='Utility to read setup.py values from cmake macros. Creates a file with CMake set commands setting variables.')
     parser.add_argument('package_name', help='Name of catkin package')
     parser.add_argument('setupfile_path', help='Full path to setup.py')

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -4,12 +4,7 @@ from __future__ import print_function
 import os
 import sys
 
-# print("%s" % sys.argv)
-PACKAGE_NAME = sys.argv[1]
-OUTFILE = sys.argv[3]
-#print("Interrogating setup.py for package %s into %s " % (PACKAGE_NAME, OUTFILE),
-#      file=sys.stderr)
-
+from argparse import ArgumentParser
 
 def samefile(path1, path2):
     """
@@ -26,71 +21,106 @@ def samefile(path1, path2):
                  os.path.normcase(os.path.normpath(path2))
     return result
 
+
+def generate_cmake_file(package_name, version, scripts, package_dir, pkgs):
+    """
+    Generates lines to add to a cmake file which will set variables
+    :param version: str, format 'int.int.int'
+    :param scripts: [list of str]: relative paths to scripts
+    :param package_dir: {modulename: path}
+    :pkgs: [list of str] python_packages declared in catkin package
+    """
+    result = []
+    result.append(r'set(%s_VERSION "%s")' % (package_name, version))
+    result.append(r'set(%s_SCRIPTS "%s")' % (package_name,
+                                     ';'.join(scripts)))
+    allprefix = package_dir.get('', None)
+
+    # Remove packages with '.' separators.  setuptools requires
+    # specifying submodules.  The symlink approach of catkin does not
+    # work with submodules.  In the common case, this does not matter
+    # as the submodule is within the containing module.  We verify
+    # this assumption, and if it passes, we remove submodule packages.
+    if not allprefix:
+        for pkg in pkgs:
+            splits = pkg.split('.')
+            # hack: ignore write-combining setup.py files for msg and srv
+            # files
+            if len(splits) > 1 and splits[1] not in ['msg', 'srv']:
+                top_level = splits[0]
+                top_level_dir = package_dir[top_level]
+                expected_dir = os.path.join(top_level_dir,
+                                            os.path.join(splits[1:]))
+                actual_dir = package_dir[pkg]
+                if not samefile(expected_dir, actual_dir):
+                    raise RuntimeError(
+                        "catkin_export_python does not support setup.py files that combine across multiple directories")
+
+    # If checks pass, remove all submodules
+    pkgs = [p for p in pkgs if '.' not in p]
+
+    resolved_pkgs = []
+    for pkg in pkgs:
+        if allprefix:
+            resolved_pkgs += [os.path.join(allprefix, pkg)]
+        else:
+            resolved_pkgs += [package_dir[pkg]]
+
+    result.append(r'set(%s_PACKAGES "%s")' % (package_name, ';'.join(pkgs)))
+    result.append(r'set(%s_PACKAGE_DIRS "%s")' % (package_name, ';'.join(resolved_pkgs).replace("\\", "/")))
+    return result
+
+
 class Dummy:
     '''
     Used as a replacement for modules setuptools and distutils.core,
     defines a setup function.
     '''
 
-    def setup(*args, **kwargs):
+    def __init__(self, package_name, outfile):
+        self.package_name = package_name
+        self.outfile = outfile
+
+    def setup(self, *args, **kwargs):
+        '''
+        Checks kwargs and writes a scriptfile
+        '''
         if 'version' not in kwargs:
-            print("""
-        *** Unable to find 'version' in setup.py of %s
-""" % PACKAGE_NAME)
+            sys.stderr.write("\n*** Unable to find 'version' in setup.py of %s" % self.package_name)
             raise RuntimeError("version not found in setup.py")
+        version = kwargs['version']
+        if 'package_dir' not in kwargs:
+            raise RuntimeError(r'package_dir not in setup.py')
+        package_dir = kwargs['package_dir']
 
-        with open(OUTFILE, 'w') as out:
+        pkgs = kwargs.get('packages', [])
+        scripts = kwargs.get('scripts', [])
 
-            print(r'set(%s_VERSION "%s")' % (PACKAGE_NAME, kwargs['version']),
-                  file=out)
-            print(r'set(%s_SCRIPTS "%s")' % (PACKAGE_NAME,
-                                             ';'.join(kwargs.get('scripts', []))), file=out)
-
-            if 'package_dir' not in kwargs:
-                raise RuntimeError(r'package_dir not in setup.py', file=sys.stderr)
-
-            package_dir = kwargs['package_dir']
-            allprefix = package_dir.get('', None)
-
-            pkgs = kwargs.get('packages', [])
-
-            # Remove packages with '.' separators.  setuptools requires
-            # specifying submodules.  The symlink approach of catkin does not
-            # work with submodules.  In the common case, this does not matter
-            # as the submodule is within the containing module.  We verify
-            # this assumption, and if it passes, we remove submodule packages.
-            if not allprefix:
-                for pkg in pkgs:
-                    splits = pkg.split('.')
-                    # hack: ignore write-combining setup.py files for msg and srv
-                    # files
-                    if len(splits) > 1 and splits[1] not in ['msg', 'srv']:
-                        top_level = splits[0]
-                        top_level_dir = package_dir[top_level]
-                        expected_dir = os.path.join(top_level_dir,
-                                                    os.path.join(*splits[1:]))
-                        actual_dir = package_dir[pkg]
-                        if not samefile(expected_dir, actual_dir):
-                            raise RuntimeError(
-                                "catkin_export_python does not support setup.py files that combine across multiple directories")
-
-            # If checks pass, remove all submodules
-            pkgs = [p for p in pkgs if '.' not in p]
-
-            resolved_pkgs = []
-            for pkg in pkgs:
-                if allprefix:
-                    resolved_pkgs += [os.path.join(allprefix, pkg)]
-                else:
-                    resolved_pkgs += [package_dir[pkg]]
-
-            print(r'set(%s_PACKAGES "%s")' % (PACKAGE_NAME, ';'.join(pkgs)), file=out)
-            print(r'set(%s_PACKAGE_DIRS "%s")' % (PACKAGE_NAME, ';'.join(resolved_pkgs).replace("\\", "/")), file=out)
-
+        result = generate_cmake_file(package_name=self.package_name,
+                                     version=version,
+                                     scripts=scripts,
+                                     package_dir=package_dir,
+                                     pkgs=pkgs)
+        with open(self.outfile, 'w') as out:
+            out.write('\n'.join(result))
 
 
 def main():
-    dummy = Dummy()
+    parser = ArgumentParser(description='Utility to read setup.py values from cmake macros. Creates a file with CMake set commands setting variables.')
+    parser.add_argument('package_name', help='Name of catkin package')
+    parser.add_argument('setupfile_path', help='Full path to setup.py')
+    parser.add_argument('outfile', help='Where to write result to')
+
+    args = parser.parse_args()
+
+    # print("%s" % sys.argv)
+    # PACKAGE_NAME = sys.argv[1]
+    # OUTFILE = sys.argv[3]
+    # print("Interrogating setup.py for package %s into %s " % (PACKAGE_NAME, OUTFILE),
+    #      file=sys.stderr)
+
+    dummy = Dummy(package_name = args.package_name,
+                  outfile = args.outfile)
 
     sys.modules['setuptools'] = dummy
     sys.modules['distutils.core'] = dummy
@@ -98,14 +128,14 @@ def main():
     # find the imports in setup.py relatively to make it work before installing catkin
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
 
-    # print("executing %s" % sys.argv[2])
+    # print("executing %s" % args.setupfile_path)
 
     # be sure you're in the directory containing
     # setup.py so the sys.path manipulation works,
     # so the import of __version__ works
-    os.chdir(os.path.dirname(os.path.abspath(sys.argv[2])))
+    os.chdir(os.path.dirname(os.path.abspath(args.setupfile_path)))
 
-    with open(sys.argv[2], 'r') as fh:
+    with open(args.setupfile_path, 'r') as fh:
         exec(fh.read())
 
 

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -6,9 +6,8 @@ import sys
 
 # print("%s" % sys.argv)
 PACKAGE_NAME = sys.argv[1]
-outfile = sys.argv[3]
-out = open(outfile, 'w')
-#print("Interrogating setup.py for package %s into %s " % (PACKAGE_NAME, outfile),
+OUTFILE = sys.argv[3]
+#print("Interrogating setup.py for package %s into %s " % (PACKAGE_NAME, OUTFILE),
 #      file=sys.stderr)
 
 
@@ -35,48 +34,51 @@ def mysetup(*args, **kwargs):
 """ % PACKAGE_NAME)
         raise RuntimeError("version not found in setup.py")
 
-    print(r'set(%s_VERSION "%s")' % (PACKAGE_NAME, kwargs['version']), file=out)
-    print(r'set(%s_SCRIPTS "%s")' % (PACKAGE_NAME,
-                                     ';'.join(kwargs.get('scripts', []))), file=out)
+    with open(OUTFILE, 'w') as out:
 
-    if 'package_dir' not in kwargs:
-        raise RuntimeError(r'package_dir not in setup.py', file=sys.stderr)
+        print(r'set(%s_VERSION "%s")' % (PACKAGE_NAME, kwargs['version']),
+              file=out)
+        print(r'set(%s_SCRIPTS "%s")' % (PACKAGE_NAME,
+                                         ';'.join(kwargs.get('scripts', []))), file=out)
 
-    package_dir = kwargs['package_dir']
-    allprefix = package_dir.get('', None)
+        if 'package_dir' not in kwargs:
+            raise RuntimeError(r'package_dir not in setup.py', file=sys.stderr)
 
-    pkgs = kwargs.get('packages', [])
+        package_dir = kwargs['package_dir']
+        allprefix = package_dir.get('', None)
 
-    # Remove packages with '.' separators.  setuptools requires
-    # specifying submodules.  The symlink approach of catkin does not
-    # work with submodules.  In the common case, this does not matter
-    # as the submodule is within the containing module.  We verify
-    # this assumption, and if it passes, we remove submodule packages.
-    if not allprefix:
+        pkgs = kwargs.get('packages', [])
+
+        # Remove packages with '.' separators.  setuptools requires
+        # specifying submodules.  The symlink approach of catkin does not
+        # work with submodules.  In the common case, this does not matter
+        # as the submodule is within the containing module.  We verify
+        # this assumption, and if it passes, we remove submodule packages.
+        if not allprefix:
+            for pkg in pkgs:
+                splits = pkg.split('.')
+                # hack: ignore write-combining setup.py files for msg and srv
+                # files
+                if len(splits) > 1 and splits[1] not in ['msg', 'srv']:
+                    top_level = splits[0]
+                    top_level_dir = package_dir[top_level]
+                    expected_dir = os.path.join(top_level_dir, os.path.join(*splits[1:]))
+                    actual_dir = package_dir[pkg]
+                    if not samefile(expected_dir, actual_dir):
+                        raise RuntimeError("catkin_export_python does not support setup.py files that combine across multiple directories")
+
+        # If checks pass, remove all submodules
+        pkgs = [p for p in pkgs if '.' not in p]
+
+        resolved_pkgs = []
         for pkg in pkgs:
-            splits = pkg.split('.')
-            # hack: ignore write-combining setup.py files for msg and srv
-            # files
-            if len(splits) > 1 and splits[1] not in ['msg', 'srv']:
-                top_level = splits[0]
-                top_level_dir = package_dir[top_level]
-                expected_dir = os.path.join(top_level_dir, os.path.join(*splits[1:]))
-                actual_dir = package_dir[pkg]
-                if not samefile(expected_dir, actual_dir):
-                    raise RuntimeError("catkin_export_python does not support setup.py files that combine across multiple directories")
+            if allprefix:
+                resolved_pkgs += [os.path.join(allprefix, pkg)]
+            else:
+                resolved_pkgs += [package_dir[pkg]]
 
-    # If checks pass, remove all submodules
-    pkgs = [p for p in pkgs if '.' not in p]
-
-    resolved_pkgs = []
-    for pkg in pkgs:
-        if allprefix:
-            resolved_pkgs += [os.path.join(allprefix, pkg)]
-        else:
-            resolved_pkgs += [package_dir[pkg]]
-
-    print(r'set(%s_PACKAGES "%s")' % (PACKAGE_NAME, ';'.join(pkgs)), file=out)
-    print(r'set(%s_PACKAGE_DIRS "%s")' % (PACKAGE_NAME, ';'.join(resolved_pkgs).replace("\\", "/")), file=out)
+        print(r'set(%s_PACKAGES "%s")' % (PACKAGE_NAME, ';'.join(pkgs)), file=out)
+        print(r'set(%s_PACKAGE_DIRS "%s")' % (PACKAGE_NAME, ';'.join(resolved_pkgs).replace("\\", "/")), file=out)
 
 
 class Dummy:

--- a/test/unit_tests/test_interrogate_setup.py
+++ b/test/unit_tests/test_interrogate_setup.py
@@ -8,7 +8,7 @@ imp.load_source('interrogate_setup_dot_py',
                 os.path.join(os.path.dirname(__file__),
                              '..', '..', 'cmake', 'interrogate_setup_dot_py.py'))
 
-from interrogate_setup_dot_py import Dummy, generate_cmake_file
+from interrogate_setup_dot_py import Dummy, generate_cmake_file, _get_locations
 
 
 class InterrogateSetupTest(unittest.TestCase):
@@ -22,11 +22,77 @@ class InterrogateSetupTest(unittest.TestCase):
         self.assertEqual(['set(pack1_VERSION "0.0.1")',
                           'set(pack1_SCRIPTS "")',
                           'set(pack1_PACKAGES "foo;bar")',
-                          'set(pack1_PACKAGE_DIRS "foopath/foo;foopath/bar")']
-, cmake_lines)
+                          'set(pack1_PACKAGE_DIRS "foopath/foo;foopath/bar")'],
+                         cmake_lines)
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=[],
+                                           package_dir={},
+                                           pkgs=['foo', 'bar', 'bar.sub']))
+        self.assertEqual(['set(pack1_VERSION "0.0.1")',
+                          'set(pack1_SCRIPTS "")',
+                          'set(pack1_PACKAGES "foo;bar")',
+                          'set(pack1_PACKAGE_DIRS "foo;bar")'],
+                         cmake_lines)
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=['bin/foo', 'nodes/bar'],
+                                           package_dir={},
+                                           pkgs=['foo', 'bar', 'bar.sub']))
+        self.assertEqual(['set(pack1_VERSION "0.0.1")',
+                          'set(pack1_SCRIPTS "bin/foo;nodes/bar")',
+                          'set(pack1_PACKAGES "foo;bar")',
+                          'set(pack1_PACKAGE_DIRS "foo;bar")'],
+                         cmake_lines)
 
+    def test_get_locations(self):
+        self.assertEqual({'foo': ''}, _get_locations(['foo'], {}))
+        self.assertEqual({'foo': 'src'}, _get_locations(['foo'],
+                                                        {'': 'src'}))
+        self.assertEqual({'foo': 'src', 'foo.bar': 'src'}, _get_locations(['foo.bar'],
+                                                                          {'': 'src'}))
+        self.assertEqual({'foo': 'src'}, _get_locations(['foo'],
+                                                        {'foo': 'src'}))
+        self.assertEqual({'foo': 'src', 'foo.bar': 'src'}, _get_locations(['foo.bar'],
+                                                                          {'foo': 'src'}))
 
+    def test_generate_cmake_file_noallprefix(self):
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=[],
+                                           package_dir={'foo': 'src',
+                                                        'bar': 'lib'},
+                                           pkgs=['foo', 'bar', 'bar.sub']))
+        self.assertEqual(['set(pack1_VERSION "0.0.1")',
+                          'set(pack1_SCRIPTS "")',
+                          'set(pack1_PACKAGES "foo;bar")',
+                          'set(pack1_PACKAGE_DIRS "src/foo;lib/bar")'],
+                         cmake_lines)
 
+    def test_generate_cmake_file_msg_srv(self):
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=[],
+                                           package_dir={'foo.msg': 'msg',
+                                                        'foo.srv': 'srv',
+                                                        '': 'src'},
+                                           pkgs=['foo.msg', 'foo.srv', 'foo']))
+        self.assertEqual(['set(pack1_VERSION "0.0.1")',
+                          'set(pack1_SCRIPTS "")',
+                          'set(pack1_PACKAGES "foo")',
+                          'set(pack1_PACKAGE_DIRS "src/foo")'],
+                         cmake_lines)
+
+    def test_generate_cmake_file_invalid(self):
+        self.assertRaises(RuntimeError,
+                          generate_cmake_file,
+                          package_name='pack1',
+                          version='0.0.1',
+                          scripts=[],
+                          package_dir={'foo.sub1': 'sub1',
+                                       'foo.sub2': 'somewhere',
+                                       '': 'src'},
+                          pkgs=['foo.sub2', 'foo.sub1', 'foo'])
 
     def test_interrogate_setup_py(self):
         try:
@@ -35,5 +101,35 @@ class InterrogateSetupTest(unittest.TestCase):
             dummy = Dummy('foo', outfile)
             self.assertRaises(RuntimeError, dummy.setup, version='0.1.1')
             self.assertRaises(RuntimeError, dummy.setup, package_dir={'': 'src'})
+            # simple setup
+            dummy.setup(version='0.1.1', package_dir={'': 'src'})
+            self.assertTrue(os.path.isfile(outfile))
+            with open(outfile, 'r') as fhand:
+                contents = fhand.read()
+            self.assertEqual("""set(foo_VERSION "0.1.1")
+set(foo_SCRIPTS "")
+set(foo_PACKAGES "")
+set(foo_PACKAGE_DIRS "")""", contents)
+            os.remove(outfile)
+            # packages and scripts
+            dummy.setup(version='0.1.1', package_dir={}, packages=['foo', 'bar'], scripts=['bin/foo', 'nodes/bar'])
+            self.assertTrue(os.path.isfile(outfile))
+            with open(outfile, 'r') as fhand:
+                contents = fhand.read()
+            self.assertEqual("""set(foo_VERSION "0.1.1")
+set(foo_SCRIPTS "bin/foo;nodes/bar")
+set(foo_PACKAGES "foo;bar")
+set(foo_PACKAGE_DIRS "foo;bar")""", contents)
+            os.remove(outfile)
+            # packages and package_dir
+            dummy.setup(version='0.1.1', package_dir={'foo': 'src', 'bar': 'lib'}, packages=['foo', 'bar'],)
+            self.assertTrue(os.path.isfile(outfile))
+            with open(outfile, 'r') as fhand:
+                contents = fhand.read()
+            self.assertEqual("""set(foo_VERSION "0.1.1")
+set(foo_SCRIPTS "")
+set(foo_PACKAGES "foo;bar")
+set(foo_PACKAGE_DIRS "src/foo;lib/bar")""", contents)
+            os.remove(outfile)
         finally:
             shutil.rmtree(rootdir)

--- a/test/unit_tests/test_interrogate_setup.py
+++ b/test/unit_tests/test_interrogate_setup.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+import tempfile
+import shutil
+
+import imp
+imp.load_source('interrogate_setup_dot_py',
+                os.path.join(os.path.dirname(__file__),
+                             '..', '..', 'cmake', 'interrogate_setup_dot_py.py'))
+
+from interrogate_setup_dot_py import Dummy, generate_cmake_file
+
+
+class InterrogateSetupTest(unittest.TestCase):
+
+    def test_generate_cmake_file(self):
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=[],
+                                           package_dir={'': 'foopath'},
+                                           pkgs=['foo', 'bar', 'bar.sub']))
+        self.assertEqual(['set(pack1_VERSION "0.0.1")',
+                          'set(pack1_SCRIPTS "")',
+                          'set(pack1_PACKAGES "foo;bar")',
+                          'set(pack1_PACKAGE_DIRS "foopath/foo;foopath/bar")']
+, cmake_lines)
+
+
+
+
+    def test_interrogate_setup_py(self):
+        try:
+            rootdir = tempfile.mkdtemp()
+            outfile = os.path.join(rootdir, 'out.cmake')
+            dummy = Dummy('foo', outfile)
+            self.assertRaises(RuntimeError, dummy.setup, version='0.1.1')
+            self.assertRaises(RuntimeError, dummy.setup, package_dir={'': 'src'})
+        finally:
+            shutil.rmtree(rootdir)


### PR DESCRIPTION
interrogate_setup_dot_py hacks into setuptools, and the code for that should be extra clean and unit testable
Refactored the code to be that, added unit tests.

Also modified the code beyond refactoring, as the logic used for package_dir in setup.py seemed flawed to me (broke unit test for corner cases). See commit messages.

Based on ros/catkin#176
