### PR TITLE
Init workspace for fuerte

### DIFF
--- a/bin/catkin_init_workspace
+++ b/bin/catkin_init_workspace
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import argparse
+import os
+import sys
+
+try:
+    from catkin.init_workspace import init_workspace
+except ImportError:
+    # find the import relatively to make it work before installing catkin
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'python'))
+    from catkin.init_workspace import init_workspace
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Initializes a catkin workspace by creating a top-level CMakeLists.txt.')
+    parser.add_argument('workspace', nargs='?', default='.', help='The path to an existing folder (default: .)')
+    args = parser.parse_args()
+
+    # verify that workspace folder exists
+    workspace = os.path.abspath(args.workspace)
+    if not os.path.isdir(workspace):
+        parser.error('Workspace "%s" does not exist' % workspace)
+
+    try:
+        init_workspace(workspace)
+    except Exception as e:
+        sys.stderr.write(str(e))
+        exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -1,0 +1,101 @@
+from __future__ import print_function
+import os
+import shutil
+from catkin.workspace import get_source_paths, get_workspaces
+
+def _symlink_or_copy(src, dst):
+    """
+    Creates a symlink at dst to src, or if not possible, attempts to copy.
+    """
+    # try to symlink file
+    try:
+        os.symlink(src, dst)
+        print('Creating symlink "%s" pointing to "%s"' % (dst, src))
+    except Exception as ex_symlink:
+        # try to copy file
+        try:
+            shutil.copyfile(src, dst)
+            print('Copying file from "%s" to "%s"' % (src, dst))
+        except Exception as ex_copy:
+            raise RuntimeError('Could neither symlink nor copy file "%s" to "%s":\n- %s\n- %s' % (src, dst, str(ex_symlink), str(ex_copy)))
+
+
+def init_workspace(workspace_dir):
+    """
+    Create a toplevel CMakeLists.txt in the root of a workspace.
+
+    The toplevel.cmake file is looked up either in the catkin
+    workspaces contained in the CMAKE_PREFIX_PATH or relative to this
+    file.  Then it tries to create a symlink first and if that fails
+    copies the file.
+
+    It installs ``manifest.xml`` to ``share/${PROJECT_NAME}``.
+
+    .. note:: The symlink is absolute when catkin is found outside
+      the workspace_dir (since that indicates a different workspace
+      and it may change relative location to the workspace referenced
+      as a parameter). The symlink is relative when catkin is part of
+      the to-be-initialized workspace.
+
+    :param workspace_dir: the path to the workspace where the
+      CMakeLists.txt should be created
+    :type workspace_dir: string
+    """
+    # verify that destination file does not exist
+    dst = os.path.join(workspace_dir, 'CMakeLists.txt')
+    if os.path.exists(dst):
+        raise RuntimeError('File "%s" already exists' % dst)
+
+    src_file_path = None
+    checked = []
+
+    # look in to-be-initialized workspace first
+    src = os.path.join(workspace_dir, 'catkin', 'cmake', 'toplevel.cmake')
+    if os.path.isfile(src):
+        src_file_path = os.path.relpath(src, workspace_dir)
+    else:
+        checked.append(src)
+
+    # search for toplevel file in all workspaces
+    if src_file_path is None:
+        workspaces = get_workspaces()
+        for workspace in workspaces:
+            source_paths = get_source_paths(workspace)
+            if len(source_paths) == 0:
+                # try from install space
+                src = os.path.join(workspace, 'catkin', 'cmake', 'toplevel.cmake')
+                if os.path.isfile(src):
+                    src_file_path = src
+                    break
+                else:
+                    checked.append(src)
+            else:
+                # try from all source spaces
+                for source_path in source_paths:
+                    src = os.path.join(source_path, 'catkin', 'cmake', 'toplevel.cmake')
+                    if os.path.isfile(src):
+                        src_file_path = src
+                        break
+                    else:
+                        checked.append(src)
+
+    # search for toplevel file in relative locations
+    if src_file_path is None:
+        relative_cmake_paths = []
+        # when catkin is in source space
+        relative_cmake_paths.append(os.path.join('..', '..', 'cmake'))
+        # when catkin is installed (with Python code in lib/pythonX.Y/[dist|site]-packages)
+        relative_cmake_paths.append(os.path.join('..', '..', '..', '..', 'share', 'catkin', 'cmake'))
+        # when catkin is installed (with Python code in lib/site-packages)
+        relative_cmake_paths.append(os.path.join('..', '..', '..', 'share', 'catkin', 'cmake'))
+        for relative_cmake_path in relative_cmake_paths:
+            src = os.path.abspath(os.path.join(os.path.dirname(__file__), relative_cmake_path, 'toplevel.cmake'))
+            if os.path.isfile(src):
+                src_file_path = src
+                break
+            else:
+                checked.append(src)
+
+    if src_file_path is None:
+        raise RuntimeError('Could neither find file "toplevel.cmake" in any workspace nor relative, checked the following paths:\n%s' % ('\n'.join(checked)))
+    _symlink_or_copy(src_file_path, dst)

--- a/python/catkin/workspace.py
+++ b/python/catkin/workspace.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+import os
+
+CATKIN_WORKSPACE_MARKER_FILE = '.CATKIN_WORKSPACE'
+
+
+def get_workspaces(_environ=os.environ):
+    """
+    Based on CMAKE_PREFIX_PATH return all catkin workspaces
+
+    :param _environ: environment module to use, ``dict``
+    """
+    # get all cmake prefix paths
+    env_name = 'CMAKE_PREFIX_PATH'
+    paths = [path for path in _environ[env_name].split(os.pathsep)] if env_name in _environ and _environ[env_name] != '' else []
+    # remove non-workspace paths
+    workspaces = [path for path in paths if os.path.isfile(os.path.join(path, CATKIN_WORKSPACE_MARKER_FILE))]
+    return workspaces
+
+
+def get_source_paths(workspace):
+    """
+    reads catkin workspace files and returns the list of all declared
+    source paths
+
+    :param workspace: path to catkin workspace folder, ``str``
+    """
+    # determine source spaces
+    data = ''
+    filename = os.path.join(workspace, CATKIN_WORKSPACE_MARKER_FILE)
+    if not os.path.isfile(filename):
+        raise ValueError('Not a catkin workspace: "%s", missing file %s' % (workspace, filename))
+    with open(filename) as f:
+        data = f.read()
+
+    if data == '':
+        source_paths = []
+    else:
+        source_paths = data.split(';')
+    return source_paths

--- a/test/unit_tests/test_init_workspace.py
+++ b/test/unit_tests/test_init_workspace.py
@@ -1,0 +1,65 @@
+import sys
+import os
+from os.path import join
+import unittest
+import tempfile
+import shutil
+
+try:
+    from catkin.init_workspace import init_workspace, _symlink_or_copy
+except ImportError as impe:
+    raise ImportError('Please adjust your pythonpath before running this test: %s' % str(impe))
+
+class InitWorkspaceTest(unittest.TestCase):
+
+    def test_symlink_or_copy(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            os.makedirs(join(root_dir, 'subdir'))
+            os.makedirs(join(root_dir, 'subdir2'))
+            with open(join(root_dir, 'subdir', 'foo'), 'ab') as fhand:
+                fhand.write('content'.encode('UTF-8'))
+
+            _symlink_or_copy(join(root_dir, 'subdir', 'foo'), join(root_dir, 'foolink'))
+            _symlink_or_copy(join(root_dir, 'subdir', 'foo'), join(root_dir, 'subdir', 'foolink'))
+            _symlink_or_copy(os.path.relpath(join(root_dir, 'subdir', 'foo'), os.getcwd()), join(root_dir, 'foolinkrel'))
+
+            self.assertEqual(join(root_dir, 'subdir', 'foo'),
+                             os.readlink(join(root_dir, 'foolink')))
+            self.assertEqual(join(root_dir, 'subdir', 'foo'),
+                             os.readlink(join(root_dir, 'subdir', 'foolink')))
+            self.assertEqual(os.path.relpath(join(root_dir, 'subdir', 'foo'), os.getcwd()),
+                             os.readlink(join(root_dir, 'foolinkrel')))
+
+        finally:
+            # pass
+            shutil.rmtree(root_dir)
+
+
+    def test_init_workspace(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            os.makedirs(join(root_dir, 'ws1'))
+            os.makedirs(join(root_dir, 'ws1', 'catkin'))
+            os.makedirs(join(root_dir, 'ws1', 'catkin', 'cmake'))
+            with open(join(root_dir, 'ws1', 'catkin', 'cmake', 'toplevel.cmake'), 'ab') as fhand:
+                fhand.write(''.encode('UTF-8'))
+            with open(join(root_dir, 'ws1', '.CATKIN_WORKSPACE'), 'ab') as fhand:
+                fhand.write(''.encode('UTF-8'))
+            os.makedirs(join(root_dir, 'ws2'))
+            with open(join(root_dir, 'ws2', '.CATKIN_WORKSPACE'), 'ab') as fhand:
+                fhand.write(''.encode('UTF-8'))
+
+            init_workspace(join(root_dir, 'ws1'))
+            init_workspace(join(root_dir, 'ws2'))
+
+            # in same workspace symlink should be relative
+            self.assertEqual(join('catkin', 'cmake', 'toplevel.cmake'),
+                             os.readlink(join(root_dir, 'ws1', 'CMakeLists.txt')))
+            # outside workspace, path should be absolute
+            self.assertTrue(os.path.samefile(join(os.path.dirname(__file__), '..', '..', 'cmake', 'toplevel.cmake'),
+                             os.readlink(join(root_dir, 'ws2', 'CMakeLists.txt'))))
+
+        finally:
+            # pass
+            shutil.rmtree(root_dir)

--- a/test/unit_tests/test_workspace.py
+++ b/test/unit_tests/test_workspace.py
@@ -1,0 +1,53 @@
+import os
+import unittest
+import tempfile
+import shutil
+
+try:
+    from catkin.workspace import get_workspaces, get_source_paths
+
+    from catkin.workspace import CATKIN_WORKSPACE_MARKER_FILE
+except ImportError as impe:
+    raise ImportError(
+        'Please adjust your pythonpath before running this test: %s' % str(impe))
+
+
+class WorkspaceTest(unittest.TestCase):
+
+    def test_get_workspaces(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            ws1 = os.path.join(root_dir, 'ws1')
+            ws2 = os.path.join(root_dir, 'ws2')
+            os.makedirs(ws1)
+            os.makedirs(ws2)
+            with open(os.path.join(ws1, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
+                fhand.write('loc1;loc2')
+            with open(os.path.join(ws2, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
+                fhand.write('loc3;loc4')
+            self.assertEqual([], get_workspaces(_environ={}))
+            self.assertEqual([], get_workspaces(_environ={'CMAKE_PREFIX_PATH': ''}))
+            self.assertEqual([], get_workspaces(_environ={}))
+            self.assertEqual([ws1], get_workspaces(_environ={'CMAKE_PREFIX_PATH': ws1}))
+            self.assertEqual([], get_workspaces(_environ={}))
+            self.assertEqual([], get_workspaces(_environ={'CMAKE_PREFIX_PATH': 'nowhere'}))
+            self.assertEqual([ws2, ws1], get_workspaces(_environ={'CMAKE_PREFIX_PATH': ws2 + os.pathsep + ws1}))
+        finally:
+            shutil.rmtree(root_dir)
+
+    def test_get_source_paths(self):
+        try:
+            root_dir = tempfile.mkdtemp()
+            ws1 = os.path.join(root_dir, 'ws1')
+            ws2 = os.path.join(root_dir, 'ws2')
+            os.makedirs(ws1)
+            os.makedirs(ws2)
+            with open(os.path.join(ws1, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
+                fhand.write('loc1;loc2')
+            with open(os.path.join(ws2, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
+                fhand.write('')
+            self.assertEqual(['loc1', 'loc2'], get_source_paths(ws1))
+            self.assertEqual([], get_source_paths(ws2))
+            self.assertRaises(ValueError, get_source_paths, root_dir)
+        finally:
+            shutil.rmtree(root_dir)


### PR DESCRIPTION
fix for #170, adds catkin_init_workspace to fuerte, for consistent workspace setup in fuerte and groovy.

Copied the file without changes, not sure whether all search cases make sense in fuerte, but this makes it easier to backport future patches.

This pull request is based on ros/catkin#202,
so commits belonging to ros/catkin#202 may show until the other pull request was merged. Only the last commit is relevant for this pull request.
