### PR TITLE
Test and refactor setup py

### DIFF
--- a/cmake/templates/script.py.in
+++ b/cmake/templates/script.py.in
@@ -1,3 +1,5 @@
 #!/usr/bin/env python
+# creates a relay to a python script source file, acting as that file.
+# The purpose is that of a symlink
 with open("@PYTHON_SCRIPT@", 'r') as fh:
     exec(fh.read())

--- a/cmake/templates/setup.py
+++ b/cmake/templates/setup.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import sys
 
+'''This file provides setup.sh with commands to query catkin workspaces'''
 
 def get_reversed_workspaces(value):
     '''Return a newline separated list of workspaces in CMAKE_PREFIX_PATH in reverse order and remove any occurrences of VALUE.'''

--- a/cmake/templates/setup.py
+++ b/cmake/templates/setup.py
@@ -47,19 +47,19 @@ def prefix_env(name, new_paths_str):
     return prefix_str
 
 
-def remove_from_env(name, value):
-    '''For each catkin workspace in CMAKE_PREFIX_PATH remove the first subfolder VALUE from env[NAME] and return the updated value of the environment variable.'''
-    items = os.environ[name].split(os.pathsep) if name in os.environ and os.environ[name] != '' else []
-    env_name = 'CMAKE_PREFIX_PATH'
-    paths = [path for path in os.environ[env_name].split(os.pathsep)] if env_name in os.environ and os.environ[env_name] != '' else []
-    for path in paths:
-        if not os.path.exists(os.path.join(path, '.CATKIN_WORKSPACE')):
-            continue
+def remove_from_env(name, subfolder):
+    '''
+    For each catkin workspace in CMAKE_PREFIX_PATH remove the first subfolder SUBFOLDER from env[NAME] and return the updated value of the environment variable.
+
+    :param subfolder: str subfoldername that may start with '/'
+    '''
+    env_paths = [path for path in os.environ.get(name, '').split(os.pathsep) if path]
+    for ws_path in get_workspaces():
         try:
-            items.remove(path + value)
+            env_paths.remove(os.path.join(ws_path, subfolder.lstrip('/')))
         except ValueError:
             pass
-    return os.pathsep.join(items)
+    return os.pathsep.join(env_paths)
 
 
 def _parse_arguments():

--- a/cmake/templates/setup.py
+++ b/cmake/templates/setup.py
@@ -7,13 +7,26 @@ import sys
 
 '''This file provides setup.sh with commands to query catkin workspaces'''
 
-def get_reversed_workspaces(value):
-    '''Return a newline separated list of workspaces in CMAKE_PREFIX_PATH in reverse order and remove any occurrences of VALUE.'''
+CATKIN_WORKSPACE_MARKER_FILE = '.CATKIN_WORKSPACE'
+
+
+def get_workspaces():
+    """
+    Based on CMAKE_PREFIX_PATH return all catkin workspaces
+
+    :param _environ: environment module to use, ``dict``
+    """
+    # get all cmake prefix paths
     env_name = 'CMAKE_PREFIX_PATH'
-    paths = [path for path in reversed(os.environ[env_name].split(os.pathsep))] if env_name in os.environ and os.environ[env_name] != '' else []
-    paths = [path for path in paths if os.path.exists(os.path.join(path, '.CATKIN_WORKSPACE'))]
-    if value is not None:
-        paths = [path for path in paths if path != value]
+    paths = [path for path in os.environ.get(env_name, '').split(os.pathsep) if path]
+    # remove non-workspace paths
+    workspaces = [path for path in paths if os.path.isfile(os.path.join(path, CATKIN_WORKSPACE_MARKER_FILE))]
+    return workspaces
+
+
+def get_reversed_workspaces(exclude=None):
+    '''Return a newline separated list of workspaces in CMAKE_PREFIX_PATH in reverse order and remove any occurrences of EXCLUDE.'''
+    paths = [p for p in reversed(get_workspaces()) if p != exclude]
     return '\n'.join(paths)
 
 

--- a/cmake/templates/setup.py
+++ b/cmake/templates/setup.py
@@ -30,18 +30,21 @@ def get_reversed_workspaces(exclude=None):
     return '\n'.join(paths)
 
 
-def prefix_env(name, value):
-    '''Return the prefix to prepend VALUE to the environment variable NAME without duplicate or empty items.'''
-    items = os.environ[name].split(os.pathsep) if name in os.environ and os.environ[name] != '' else []
-    prefix = []
-    values = [v for v in value.split(os.pathsep) if v != '']
-    for v in values:
-        if v not in items and v not in prefix:
-            prefix.append(v)
-    prefix = os.pathsep.join(prefix)
-    if prefix != '' and items:
-        prefix += os.pathsep
-    return prefix
+def prefix_env(name, new_paths_str):
+    '''
+    Return the prefix to prepend to the environment variable NAME, adding any path in NEW_PATHS_STR without creating duplicate or empty items.
+    '''
+    environ_paths = [i for i in os.environ.get(name, '').split(os.pathsep) if i]
+    checked_paths = []
+    new_paths = [v for v in new_paths_str.split(os.pathsep) if v != '']
+    for path in new_paths:
+        # exclude any path already in env and any path we already added
+        if path not in environ_paths and path not in checked_paths:
+            checked_paths.append(path)
+    prefix_str = os.pathsep.join(checked_paths)
+    if prefix_str != '' and environ_paths:
+        prefix_str += os.pathsep
+    return prefix_str
 
 
 def remove_from_env(name, value):

--- a/python/catkin/workspace.py
+++ b/python/catkin/workspace.py
@@ -4,7 +4,7 @@ import os
 CATKIN_WORKSPACE_MARKER_FILE = '.CATKIN_WORKSPACE'
 
 
-def get_workspaces(_environ=os.environ):
+def get_workspaces():
     """
     Based on CMAKE_PREFIX_PATH return all catkin workspaces
 
@@ -12,7 +12,7 @@ def get_workspaces(_environ=os.environ):
     """
     # get all cmake prefix paths
     env_name = 'CMAKE_PREFIX_PATH'
-    paths = [path for path in _environ[env_name].split(os.pathsep)] if env_name in _environ and _environ[env_name] != '' else []
+    paths = [path for path in os.environ.get(env_name, '').split(os.pathsep) if path]
     # remove non-workspace paths
     workspaces = [path for path in paths if os.path.isfile(os.path.join(path, CATKIN_WORKSPACE_MARKER_FILE))]
     return workspaces

--- a/test/unit_tests/test_setup_util.py
+++ b/test/unit_tests/test_setup_util.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+import tempfile
+import shutil
+
+import imp
+imp.load_source('setup_util',
+                os.path.join(os.path.dirname(__file__),
+                             '..', '..', 'cmake', 'templates', 'setup.py'))
+
+import setup_util
+from setup_util import get_reversed_workspaces, CATKIN_WORKSPACE_MARKER_FILE
+
+
+class SetupUtilTest(unittest.TestCase):
+
+    def test_get_reversed_workspaces(self):
+        try:
+            mock_env = {}
+            rootdir = tempfile.mkdtemp()
+            setup_util.os.environ = mock_env
+            self.assertEqual('', get_reversed_workspaces())
+            self.assertEqual('', get_reversed_workspaces('foo'))
+            foows = os.path.join(rootdir, 'foo')
+            os.makedirs(foows)
+            with open(os.path.join(foows, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
+                fhand.write('')
+            barws = os.path.join(rootdir, 'bar')
+            os.makedirs(barws)
+            with open(os.path.join(barws, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
+                fhand.write('')
+            nows = os.path.join(rootdir, 'nows')
+            os.makedirs(nows)
+            mock_env = {'CMAKE_PREFIX_PATH': os.pathsep.join([nows, foows, barws, 'invalid'])}
+            setup_util.os.environ = mock_env
+            self.assertEqual('\n'.join([barws, foows]), get_reversed_workspaces())
+            self.assertEqual(barws, get_reversed_workspaces(foows))
+            self.assertEqual(foows, get_reversed_workspaces(barws))
+        finally:
+            shutil.rmtree(rootdir)
+            setup_util.os.environ = os.environ
+

--- a/test/unit_tests/test_setup_util.py
+++ b/test/unit_tests/test_setup_util.py
@@ -9,7 +9,7 @@ imp.load_source('setup_util',
                              '..', '..', 'cmake', 'templates', 'setup.py'))
 
 import setup_util
-from setup_util import get_reversed_workspaces, CATKIN_WORKSPACE_MARKER_FILE
+from setup_util import get_reversed_workspaces, prefix_env, CATKIN_WORKSPACE_MARKER_FILE
 
 
 class SetupUtilTest(unittest.TestCase):
@@ -40,3 +40,21 @@ class SetupUtilTest(unittest.TestCase):
             shutil.rmtree(rootdir)
             setup_util.os.environ = os.environ
 
+    def test_prefix_env(self):
+        try:
+            mock_env = {}
+            setup_util.os.environ = mock_env
+            self.assertEqual('',
+                             prefix_env('varname', ''))
+            self.assertEqual(os.pathsep.join(['foo', 'bar']),
+                             prefix_env('varname', 'foo:bar'))
+            mock_env = {'varname': os.pathsep.join(['baz', 'bar', 'bam'])}
+            setup_util.os.environ = mock_env
+            self.assertEqual('',
+                             prefix_env('varname', ''))
+            self.assertEqual('foo' + os.pathsep,
+                             prefix_env('varname', 'foo:bar'))
+            self.assertEqual(os.pathsep.join(['foo', 'lim']) + os.pathsep,
+                             prefix_env('varname', 'foo:lim:foo:lim'))
+        finally:
+            setup_util.os.environ = os.environ

--- a/test/unit_tests/test_workspace.py
+++ b/test/unit_tests/test_workspace.py
@@ -7,6 +7,7 @@ try:
     from catkin.workspace import get_workspaces, get_source_paths
 
     from catkin.workspace import CATKIN_WORKSPACE_MARKER_FILE
+    import catkin.workspace
 except ImportError as impe:
     raise ImportError(
         'Please adjust your pythonpath before running this test: %s' % str(impe))
@@ -25,15 +26,19 @@ class WorkspaceTest(unittest.TestCase):
                 fhand.write('loc1;loc2')
             with open(os.path.join(ws2, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
                 fhand.write('loc3;loc4')
-            self.assertEqual([], get_workspaces(_environ={}))
-            self.assertEqual([], get_workspaces(_environ={'CMAKE_PREFIX_PATH': ''}))
-            self.assertEqual([], get_workspaces(_environ={}))
-            self.assertEqual([ws1], get_workspaces(_environ={'CMAKE_PREFIX_PATH': ws1}))
-            self.assertEqual([], get_workspaces(_environ={}))
-            self.assertEqual([], get_workspaces(_environ={'CMAKE_PREFIX_PATH': 'nowhere'}))
-            self.assertEqual([ws2, ws1], get_workspaces(_environ={'CMAKE_PREFIX_PATH': ws2 + os.pathsep + ws1}))
+            catkin.workspace.os.environ = {}
+            self.assertEqual([], get_workspaces())
+            catkin.workspace.os.environ = {'CMAKE_PREFIX_PATH': ''}
+            self.assertEqual([], get_workspaces())
+            catkin.workspace.os.environ = {'CMAKE_PREFIX_PATH': ws1}
+            self.assertEqual([ws1], get_workspaces())
+            catkin.workspace.os.environ = {'CMAKE_PREFIX_PATH': 'nowhere'}
+            self.assertEqual([], get_workspaces())
+            catkin.workspace.os.environ = {'CMAKE_PREFIX_PATH': ws2 + os.pathsep + ws1}
+            self.assertEqual([ws2, ws1], get_workspaces())
         finally:
             shutil.rmtree(root_dir)
+            catkin.workspace.os.environ = os.environ
 
     def test_get_source_paths(self):
         try:


### PR DESCRIPTION
added refactor of workspace as well, as it is related.
- replaced long dict check in workspace.py continuations with equivalent continuation using get with default.
  This may in some cases do an unecessary ''.split(), but I think it is still preferrable code.
  then refactored functions in setup.py:
- moved in get_workspaces() (Note it would be much better to use catkin/workspace.py, but I am not sure about PYTHONPATH issues to consider)
- renamed a lot of vars to make the code readable
- replaced long continuations with shorter ones using dict.get() with default
- removed / prefix in subfolder argument if any, and use os.path.join instead

Note that I would also like to refactor the CLI api of setup.py.
Instead of
setup.py --prefix --name xxx --value yyy
it would be nicer to use
setup.py prepend xxx --values yyy
setup.py reversed-workspace --exclude yyy
setup.py remove xxx --subfolder yyy

Also it would be much nicer if the ..._dir varssetup.sh did not contain a leading '/'

And it would be better that instead of --prefix returning the prefix we would use --prepend returning the whole new env var value (makes both setup.py and setup.sh cleaner)

But since setup.sh is not unit tested yet, I did not do these changes, and will wait for you to comment before trying them.
