### PR TITLE
print catkin version for easier debugging

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -1,3 +1,10 @@
+find_package(catkin QUIET)
+if(DEFINED catkin_VERSION)
+  message(STATUS "Using catkin ${catkin_VERSION}")
+else()
+  message(STATUS "Using catkin from source")
+endif()
+
 # prevent multiple inclusion
 if(DEFINED _CATKIN_ALL_INCLUDED_)
   message(FATAL_ERROR "catkin/cmake/all.cmake included multiple times")


### PR DESCRIPTION
prints what version of catkin runs, I think all.cmake works for all use-cases.
Useful for helping other people with catkin-related problems, makes it easier for them to report errors with version.
