### PR TITLE
fix unit test failures (e.g. after fixing of #194)

### DIFF
--- a/test/local_tests/test_with_mock_workspace.py
+++ b/test/local_tests/test_with_mock_workspace.py
@@ -63,7 +63,7 @@ class MockTest(AbstractCatkinWorkspaceTest):
                          expect=fail)
         print("failed as expected, out=", out)
 
-        self.assertTrue('catkin_package() PROJECT_NAME is not set.' in out, out)
+        self.assertTrue("catkin_package() PROJECT_NAME is set to 'Project'" in out, out)
         # assert 'You must call project() with the same name before.' in out
 
     # Test was not finished apparently

--- a/test/mock_resources/src-fail/badly_specified_changelog/package.xml
+++ b/test/mock_resources/src-fail/badly_specified_changelog/package.xml
@@ -8,5 +8,5 @@
   <copyright>Someone</copyright>
   <url/>
 
-  <build_depends>catkin</build_depends>
+  <build_depend>catkin</build_depend>
 </package>

--- a/test/mock_resources/src/catkin_test/a/package.xml
+++ b/test/mock_resources/src/catkin_test/a/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>std_msgs</build_depends>
-  <build_depends>ros_comm</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>ros_comm</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/catkin_test/b/package.xml
+++ b/test/mock_resources/src/catkin_test/b/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>std_msgs</build_depends>
-  <build_depends>ros_comm</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>ros_comm</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/catkin_test/c/package.xml
+++ b/test/mock_resources/src/catkin_test/c/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>std_msgs</build_depends>
-  <build_depends>ros_comm</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>ros_comm</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/catkin_test/catkin_test/package.xml
+++ b/test/mock_resources/src/catkin_test/catkin_test/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <run_depends>catkin</run_depends>
-  <run_depends>gencpp</run_depends>
-  <run_depends>genmsg</run_depends>
-  <run_depends>genpy</run_depends>
-  <run_depends>std_msgs</run_depends>
-  <run_depends>ros_comm</run_depends>
+  <run_depend>catkin</run_depend>
+  <run_depend>gencpp</run_depend>
+  <run_depend>genmsg</run_depend>
+  <run_depend>genpy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>ros_comm</run_depend>
   <export>
     <metapackage/>
   </export>

--- a/test/mock_resources/src/catkin_test/d/package.xml
+++ b/test/mock_resources/src/catkin_test/d/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>std_msgs</build_depends>
-  <build_depends>ros_comm</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>ros_comm</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/catkin_test/quux_msgs/package.xml
+++ b/test/mock_resources/src/catkin_test/quux_msgs/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>std_msgs</build_depends>
-  <build_depends>ros_comm</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>ros_comm</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/catkin_test/quux_user/package.xml
+++ b/test/mock_resources/src/catkin_test/quux_user/package.xml
@@ -7,12 +7,12 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>std_msgs</build_depends>
-  <build_depends>ros_comm</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>ros_comm</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/python_test_a/package.xml
+++ b/test/mock_resources/src/python_test_a/package.xml
@@ -7,10 +7,10 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
   <export>
   </export>
 

--- a/test/mock_resources/src/ros_user/package.xml
+++ b/test/mock_resources/src/ros_user/package.xml
@@ -7,15 +7,15 @@
   <license>Unknown</license>
   <url/>
 
-  <build_depends>catkin</build_depends>
-  <build_depends>gencpp</build_depends>
-  <build_depends>genmsg</build_depends>
-  <build_depends>genpy</build_depends>
-  <build_depends>cpp_common</build_depends>
-  <build_depends>rostime</build_depends>
-  <build_depends>roscpp_traits</build_depends>
-  <build_depends>roscpp_serialization</build_depends>
-  <build_depends>sensor_msgs</build_depends>
+  <build_depend>catkin</build_depend>
+  <build_depend>gencpp</build_depend>
+  <build_depend>genmsg</build_depend>
+  <build_depend>genpy</build_depend>
+  <build_depend>cpp_common</build_depend>
+  <build_depend>rostime</build_depend>
+  <build_depend>roscpp_traits</build_depend>
+  <build_depend>roscpp_serialization</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <export>
   </export>
 

--- a/test/unit_tests/test_run_tests.py
+++ b/test/unit_tests/test_run_tests.py
@@ -22,8 +22,8 @@ class RunTestsTest(unittest.TestCase):
             # with open(src_file, 'w') as fhand:
             #     fhand.write('foo')
             # self.assertTrue(os.path.isfile(check_file))
-            main(['true',
-                  results_file,
+            main([results_file,
+                  'true',
                   '--working-dir', rootdir])
             self.assertFalse(os.path.exists(results_file))
             self.assertTrue(os.path.exists(placeholder))
@@ -31,8 +31,8 @@ class RunTestsTest(unittest.TestCase):
                 contents = fhand.read()
             self.assertTrue(results_file in contents)
             ###
-            main(["echo '<testsuite></testsuite>' > %s" % results_file,
-                  results_file,
+            main([results_file,
+                  "echo '<testsuite></testsuite>' > %s" % results_file,
                   '--working-dir', rootdir])
             self.assertTrue(os.path.exists(results_file))
             self.assertFalse(os.path.exists(placeholder))
@@ -42,8 +42,8 @@ class RunTestsTest(unittest.TestCase):
             self.assertTrue(os.path.exists(results_file))
             self.assertFalse(os.path.exists(placeholder))
             ### make sure resultsfile is deleted
-            main(['true',
-                  results_file,
+            main([results_file,
+                  'true',
                   '--working-dir', rootdir])
             self.assertFalse(os.path.exists(results_file))
             self.assertTrue(os.path.exists(placeholder))


### PR DESCRIPTION
patch just changes argument order in unit test to match script order, and some asserts that are outdated
