### PR TITLE
Robust paths

### DIFF
--- a/cmake/order_paths.py
+++ b/cmake/order_paths.py
@@ -27,14 +27,19 @@ def main():
         fh.write('set(ORDERED_PATHS "%s")' % ';'.join(ordered_paths))
 
 
-def order_paths(paths_to_order, prefixes):
-    # the ordered paths contains a list for each prefix plus one more which contains paths which do not match one of the prefixes
-    ordered_paths = [[] for _ in range(len(prefixes) + 1)]
+def order_paths(paths_to_order, prefix_paths):
+    """
+    returns a list containing all items of path_to_order ordered by list of prefix_paths, compared as strings
+    :param paths_to_order: list of paths
+    :param prefix_paths: list of paths, must not end with '/'
+    """
+    # the ordered paths contains a list for each prefix plus one more which contains paths which do not match one of the prefix_paths
+    ordered_paths = [[] for _ in range(len(prefix_paths) + 1)]
 
     for path in paths_to_order:
         # put each include directory into the slot where it matches the prefix, or last otherwise
         index = 0
-        for prefix in prefixes:
+        for prefix in prefix_paths:
             if path == prefix or path.startswith(prefix + os.sep) or (os.altsep and path.startswith(prefix + os.altsep)):
                 break
             index += 1

--- a/cmake/parse_package_xml.py
+++ b/cmake/parse_package_xml.py
@@ -4,8 +4,10 @@ from __future__ import print_function
 import sys
 import argparse
 
-from catkin_pkg.package import parse_package
-
+try:
+    from catkin_pkg.package import parse_package
+except ImportError as impe:
+    sys.exit("ERROR Cannot find a module of catkin_pkg, make sure it is up to date and on the PYTHONPATH, see catkin install instructions: %s" % impe)
 
 def _get_output(package):
     """

--- a/cmake/templates/_setup_util.py
+++ b/cmake/templates/_setup_util.py
@@ -58,15 +58,18 @@ def remove_from_env(name, subfolder):
     if subfolder:
         if subfolder.startswith(os.path.sep) or (os.path.altsep and subfolder.startswith(os.path.altsep)):
             subfolder = subfolder[1:]
+        if subfolder.endswith(os.path.sep) or (os.path.altsep and subfolder.endswith(os.path.altsep)):
+            subfolder = subfolder[:-1]
     for ws_path in get_workspaces():
-        try:
-            if subfolder:
-                path_to_remove = os.path.join(ws_path, subfolder)
-            else:
-                path_to_remove = ws_path
+        path_to_find = os.path.join(ws_path, subfolder) if subfolder else ws_path
+        path_to_remove = None
+        for env_path in env_paths:
+            env_path_clean = env_path[:-1] if env_path and env_path[-1] in [os.path.sep, os.path.altsep] else env_path
+            if env_path_clean == path_to_find:
+                path_to_remove = env_path
+                break
+        if path_to_remove:
             env_paths.remove(path_to_remove)
-        except ValueError:
-            pass
     return os.pathsep.join(env_paths)
 
 

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1,9 +1,12 @@
 from __future__ import print_function
 import os
+import sys
 import subprocess
 
-from catkin_pkg.topological_order import topological_order
-
+try:
+    from catkin_pkg.topological_order import topological_order
+except ImportError as impe:
+    sys.exit("ERROR Cannot find a module of catkin_pkg, make sure it is up to date and on the PYTHONPATH, see catkin install instructions: %s" % impe)
 
 def build_workspace_in_isolation(sourcespace_dir, buildspace_parent_dir, install=False):
     '''

--- a/test/unit_tests/test_order_paths.py
+++ b/test/unit_tests/test_order_paths.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+import tempfile
+import shutil
+from mock import Mock
+
+import imp
+imp.load_source('order_paths',
+                os.path.join(os.path.dirname(__file__),
+                             '..', '..', 'cmake', 'order_paths.py'))
+
+from order_paths import order_paths, main
+
+class OrderPathsTest(unittest.TestCase):
+
+    def test_order_paths(self):
+        self.assertEqual([], order_paths([], []))
+        self.assertEqual(['foo/1', 'foo/2', 'bar/1', 'bar/2', 'foo3'],
+                         order_paths(['foo3', 'bar/1', 'foo/1', 'foo/2', 'bar/2'], ['foo', 'bar']))
+        self.assertEqual(['foo/1', 'foo/2'],
+                         order_paths(['foo/1', 'foo/2'], []))
+        self.assertEqual(['foo/1', 'foo/2'],
+                         order_paths(['foo/1', 'foo/2'], ['']))

--- a/test/unit_tests/test_setup_util.py
+++ b/test/unit_tests/test_setup_util.py
@@ -67,7 +67,7 @@ class SetupUtilTest(unittest.TestCase):
             setup_util.os.environ = mock_env
             # foows
             foows = os.path.join(rootdir, 'foo')
-            foolib = os.path.join(foows, 'lib')
+            foolib = os.path.join(foows, 'lib') + '/'
             os.makedirs(foows)
             with open(os.path.join(foows, '.CATKIN_WORKSPACE'), 'w') as fhand:
                 fhand.write('')
@@ -95,7 +95,7 @@ class SetupUtilTest(unittest.TestCase):
             self.assertEqual(os.pathsep.join([foolib, barlib]), remove_from_env(varname, ''))
             self.assertEqual(os.pathsep.join([foolib, barlib]), remove_from_env(varname, 'nolib'))
             self.assertEqual(os.pathsep.join([foolib, barlib]), remove_from_env(varname, '/nolib'))
-            # self.assertEqual('', remove_from_env(varname, 'lib'))
+            self.assertEqual('', remove_from_env(varname, 'lib'))
             self.assertEqual('', remove_from_env(varname, '/lib'))
             self.assertEqual(os.pathsep.join([foolib, barlib]), remove_from_env(varname, ''))
             self.assertEqual('', remove_from_env(wsvarname, ''))
@@ -119,3 +119,4 @@ class SetupUtilTest(unittest.TestCase):
         finally:
             setup_util.os.environ = os.environ
             os.path.altsep = altsep
+            shutil.rmtree(rootdir)


### PR DESCRIPTION
one commit just adds unit test, the other fixes a vulnerability when env var has trailing slashes (maybe an unlikely case)
The code comparing path + subfolder has become quite ugly, and I would prefer an implementation based on os.path functions rather than string comparison, can implement that if you want me to.
