### PR TITLE
Fix unit tests for find_in_workspaces and minor improvements

### DIFF
--- a/bin/catkin_find
+++ b/bin/catkin_find
@@ -47,7 +47,8 @@ def main():
                 raise RuntimeError('Could not find unique path, the following paths are matching:\n%s' % '\n'.join(results))
             elif len(results) == 0:
                 raise RuntimeError('Could not find any path, checked the following paths:\n%s' % '\n'.join(checked))
-        print('\n'.join(results))
+        if len(results) > 0:
+            print('\n'.join(results))
 
     except Exception as e:
         sys.exit(str(e))

--- a/python/catkin/find_in_workspaces.py
+++ b/python/catkin/find_in_workspaces.py
@@ -20,7 +20,7 @@ def _get_valid_search_dirs(search_dirs, project):
     valid_search_dirs = (valid_global_search_dirs
                          if project is None
                          else valid_project_search_dirs)
-    if search_dirs is None:
+    if not search_dirs:
         search_dirs = valid_search_dirs
     else:
         # make search folders a list

--- a/python/catkin/find_in_workspaces.py
+++ b/python/catkin/find_in_workspaces.py
@@ -61,14 +61,17 @@ def find_in_workspaces(search_dirs=None, project=None, path=None, _workspaces=ge
     All workspaces are searched in order.
     Each workspace, each search_in subfolder, the project name and the path are concatenated to define a candidate path.
     If the candidate path exists it is appended to the result list.
-    Note: the search might return multiple paths for a 'share' from build- and source-space.
+    Note: the search might return multiple paths for 'share' from build- and source-space.
 
     :param search_dir: The list of subfolders to search in (default contains all valid values: 'bin', 'etc', 'lib', 'libexec', 'share'), ``list``
     :param project: The project name to search for (optional, not possible with the global search_in folders 'bin' and 'lib'), ``str``
     :param path: The path, ``str``
     :param _workspaces: (optional, used for unit tests), the list of workspaces to use.
+    :param considered_paths: If not None, function will append all path that were searched
+    :param first_matching_workspace_only: if True returns all results found for first workspace with results
+    :param first_match_only: if True returns first path found (supercedes first_matching_workspace_only)
     :raises ValueError: if search_dirs contains an invalid folder name
-    :returns: List of paths, ``list``
+    :returns: List of paths
     '''
     search_dirs = _get_valid_search_dirs(search_dirs, project)
 

--- a/test/unit_tests/test_find_in_workspace.py
+++ b/test/unit_tests/test_find_in_workspace.py
@@ -3,7 +3,10 @@ import unittest
 import tempfile
 import shutil
 
+from mock import Mock
+
 try:
+    import catkin
     from catkin.find_in_workspaces import find_in_workspaces, _get_valid_search_dirs
     from catkin.workspace import CATKIN_WORKSPACE_MARKER_FILE
 except ImportError as impe:
@@ -29,72 +32,109 @@ class FindInWorkspaceTest(unittest.TestCase):
         self.assertRaises(ValueError, _get_valid_search_dirs, ['libexec'], None)
 
     def test_find_in_workspaces(self):
-        (existing, paths) = find_in_workspaces([], _workspaces=None)
-        self.assertEqual(([], []), (existing, paths))
-        (existing, paths) = find_in_workspaces([], 'foo', _workspaces=None)
-        self.assertEqual(([], []), (existing, paths))
-        (existing, paths) = find_in_workspaces([], 'foo', 'foopath', _workspaces=None)
-        self.assertEqual(([], []), (existing, paths))
+        existing = find_in_workspaces([], _workspaces=None)
+        self.assertEqual([], existing)
+        existing = find_in_workspaces([], 'foo', _workspaces=None)
+        self.assertEqual([], existing)
+        existing = find_in_workspaces([], 'foo', 'foopath', _workspaces=None)
+        self.assertEqual([], existing)
 
-        (existing, paths) = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=None)
-        self.assertEqual(([], []), (existing, paths))
+        existing = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=None)
+        self.assertEqual([], existing)
 
-        (existing, paths) = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=['bar'])
-        self.assertEqual(([], ['bar/include/foo/foopath']), (existing, paths))
-
-        (existing, paths) = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=['bar', 'baz'])
-        self.assertEqual(([], ['bar/include/foo/foopath', 'baz/include/foo/foopath']), (existing, paths))
-
-        (existing, paths) = find_in_workspaces(['include', 'etc', 'libexec'], 'foo', 'foopath', _workspaces=['bar', 'baz'])
-        self.assertEqual(([], ['bar/include/foo/foopath',
-                               'bar/etc/foo/foopath',
-                               'bar/lib/foo/foopath',
-                               'baz/include/foo/foopath',
-                               'baz/etc/foo/foopath',
-                               'baz/lib/foo/foopath']), (existing, paths))
-
-        (existing, paths) = find_in_workspaces(['share', 'etc', 'lib'], None, 'foopath', _workspaces=['bar', 'baz'])
-        self.assertEqual(([], ['bar/share/foopath',
-                               'bar/etc/foopath',
-                               'bar/lib/foopath',
-                               'baz/share/foopath',
-                               'baz/etc/foopath',
-                               'baz/lib/foopath']), (existing, paths))
-        (existing, paths) = find_in_workspaces(None, None, None, _workspaces=['bar'])
-        self.assertEqual(([], ['bar/bin', 'bar/etc', 'bar/include', 'bar/lib', 'bar/share']), (existing, paths))
-
+        checked = []
+        existing = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=['bar'], considered_paths=checked)
+        self.assertEqual([], existing)
+        self.assertEqual(['bar/include/foo/foopath'], checked)
+        checked = []
+        existing = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=['bar', 'baz'], considered_paths=checked)
+        self.assertEqual([], existing)
+        self.assertEqual(['bar/include/foo/foopath', 'baz/include/foo/foopath'], checked)
+        checked = []
+        existing = find_in_workspaces(['include', 'etc', 'libexec'], 'foo', 'foopath', _workspaces=['bar', 'baz'], considered_paths=checked)
+        self.assertEqual([], existing)
+        self.assertEqual(['bar/include/foo/foopath',
+                          'bar/etc/foo/foopath',
+                          'bar/lib/foo/foopath',
+                          'baz/include/foo/foopath',
+                          'baz/etc/foo/foopath',
+                          'baz/lib/foo/foopath'], checked)
+        checked = []
+        existing = find_in_workspaces(['share', 'etc', 'lib'], None, 'foopath', _workspaces=['bar', 'baz'], considered_paths=checked)
+        self.assertEqual([], existing)
+        self.assertEqual(['bar/share/foopath',
+                          'bar/etc/foopath',
+                          'bar/lib/foopath',
+                          'baz/share/foopath',
+                          'baz/etc/foopath',
+                          'baz/lib/foopath'], checked)
+        checked = []
+        existing = find_in_workspaces(None, None, None, _workspaces=['bar'], considered_paths=checked)
+        self.assertEqual([], existing)
+        self.assertEqual(['bar/bin', 'bar/etc', 'bar/include', 'bar/lib', 'bar/share'], checked)
 
     def test_with_sourcepath(self):
         def create_mock_workspace(root_dir, ws):
             ws1 = os.path.join(root_dir, ws)
-            p1 = os.path.join(ws1, "p1")
-            p1inc = os.path.join(p1, "include")
-            p1share = os.path.join(p1, "share")
+            inc = os.path.join(ws1, "include")
+            share = os.path.join(ws1, "share")
+            p1inc = os.path.join(inc, "foo")
+            p1share = os.path.join(share, "foo")
             os.makedirs(ws1)
-            os.makedirs(p1)
+            os.makedirs(inc)
+            os.makedirs(share)
             os.makedirs(p1inc)
             os.makedirs(p1share)
             with open(os.path.join(ws1, CATKIN_WORKSPACE_MARKER_FILE), 'w') as fhand:
                 fhand.write('loc1;loc2')
 
         try:
+            fp_backup = catkin.find_in_workspaces.find_packages
             root_dir = tempfile.mkdtemp()
+            catkin.find_in_workspaces.find_packages = Mock()
+            foomock = Mock()
+            foomock.name = 'foo'
+            barmock = Mock()
+            barmock.name = 'bar'
+            catkin.find_in_workspaces.find_packages.return_value = {'bar': barmock, 'foo': foomock}
             create_mock_workspace(root_dir, 'ws1')
             create_mock_workspace(root_dir, 'ws2')
-
-            (existing, paths) = find_in_workspaces(['share', 'etc'], 'foo', 'foopath', _workspaces=[os.path.join(root_dir, 'ws1')])
+            checked = []
+            existing = find_in_workspaces(['share', 'etc'], 'foo', 'foopath', _workspaces=[os.path.join(root_dir, 'ws1')], considered_paths=checked)
             self.assertEqual([os.path.join(root_dir, 'ws1', 'share', 'foo', 'foopath'),
                               'loc1/foo/foopath',
                               'loc2/foo/foopath',
-                              os.path.join(root_dir, 'ws1', 'etc', 'foo', 'foopath')], paths)
+                              os.path.join(root_dir, 'ws1', 'etc', 'foo', 'foopath')], checked)
             self.assertEqual([], existing)
+            checked = []
+            existing = find_in_workspaces(['share', 'etc'], 'foo', None, _workspaces=[os.path.join(root_dir, 'ws1')], considered_paths=checked)
+            self.assertEqual([os.path.join(root_dir, 'ws1', 'share', 'foo'),
+                              'loc1/foo',
+                              'loc2/foo',
+                              os.path.join(root_dir, 'ws1', 'etc', 'foo')], checked)
+            self.assertEqual([os.path.join(root_dir, 'ws1', 'share', 'foo')], existing)
+            # first-only option
+            checked = []
+            existing = find_in_workspaces(None, None, None, _workspaces=[os.path.join(root_dir, 'ws1'), os.path.join(root_dir, 'ws2')], considered_paths=checked)
+            self.assertEqual([
+                    os.path.join(root_dir, 'ws1', 'include'),
+                    os.path.join(root_dir, 'ws1', 'share'),
+                    os.path.join(root_dir, 'ws2', 'include'),
+                    os.path.join(root_dir, 'ws2', 'share')], existing)
+            existing = find_in_workspaces(None, None, None, _workspaces=[os.path.join(root_dir, 'ws1'), os.path.join(root_dir, 'ws2')], considered_paths=checked, first_matching_workspace_only=True)
+            self.assertEqual([
+                    os.path.join(root_dir, 'ws1', 'include'),
+                    os.path.join(root_dir, 'ws1', 'share')], existing)
+            existing = find_in_workspaces(None, None, None, _workspaces=[os.path.join(root_dir, 'ws1'), os.path.join(root_dir, 'ws2')], considered_paths=checked, first_match_only=True)
+            self.assertEqual([
+                    os.path.join(root_dir, 'ws1', 'include')], existing)
 
-            (existing, paths) = find_in_workspaces(['share', 'etc'], 'p1', None, _workspaces=[os.path.join(root_dir, 'ws1')])
-            self.assertEqual([os.path.join(root_dir, 'ws1', 'share', 'p1'),
-                              'loc1/p1',
-                              'loc2/p1',
-                              os.path.join(root_dir, 'ws1', 'etc', 'p1')], paths)
-            self.assertEqual([], existing)
-
+            # overlay: first_matching_workspace_only=True
+            checked = []
+            existing = find_in_workspaces(None, 'foo', None, _workspaces=[os.path.join(root_dir, 'ws1'), os.path.join(root_dir, 'ws2')], considered_paths=checked, first_matching_workspace_only=True)
+            self.assertEqual([
+                    os.path.join(root_dir, 'ws1', 'include', 'foo'),
+                    os.path.join(root_dir, 'ws1', 'share', 'foo')], existing)
         finally:
+            catkin.find_in_workspaces.find_packages = fp_backup
             shutil.rmtree(root_dir)

--- a/test/unit_tests/test_find_in_workspace.py
+++ b/test/unit_tests/test_find_in_workspace.py
@@ -17,7 +17,8 @@ except ImportError as impe:
 class FindInWorkspaceTest(unittest.TestCase):
 
     def test_get_valid_search_dirs(self):
-        self.assertEqual([], _get_valid_search_dirs([], None))
+        self.assertEqual(['bin', 'etc', 'include', 'lib', 'share'], _get_valid_search_dirs([], None))
+        self.assertEqual(['bin', 'etc', 'include', 'lib', 'share'], _get_valid_search_dirs(None, None))
         self.assertEqual(['etc', 'include', 'libexec', 'share'],
                          _get_valid_search_dirs(None, 'foo'))
         self.assertEqual(['bin', 'etc', 'include', 'lib', 'share'],


### PR DESCRIPTION
Changes the unit tests after find_in_workspaces API has changed

Note that a slight semantic difference exists due to the refactoring in Dirks commits: if a workspace source location does not contain a project, it now is not listed in considered_paths. Not sure whether to consider that a bug.

Also note that when a path but no project is given, the source locations are not searched (still not sure whether this combination is valid, and whether the non-search is a bug).

Else added commits for better default behavior when client code passes search_dirs=[], and to not print an empty line when no results were found.
