### PR TITLE
Novice-friendly error message when catkin not found.

### DIFF
--- a/cmake/toplevel.cmake
+++ b/cmake/toplevel.cmake
@@ -14,7 +14,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/catkin/cmake/all.cmake" AND EXISTS "${CMAKE_SOURC
   # include all.cmake without add_subdirectory to let it operate in same scope
   include(catkin/cmake/all.cmake NO_POLICY_SCOPE)
   add_subdirectory(catkin)
-
+  set(catkin_FOUND 1)
 else()
   # use either CMAKE_PREFIX_PATH explicitly passed to CMake as a command line argument
   # or CMAKE_PREFIX_PATH from the environment
@@ -44,4 +44,8 @@ else()
   unset(CATKIN_TOPLEVEL_FIND_PACKAGE)
 endif()
 
-catkin_workspace()
+if(catkin_FOUND)
+  catkin_workspace()
+else()
+  message(FATAL_ERROR " Catkin not found in CMAKE_PREFIX_PATH or workspace. This may happen because you forgot to source a ROS setup.sh.")
+endif()


### PR DESCRIPTION
To help novice users with catkin, it may be good to have a more helpful error message at toplevel.

I also thought about replacing REQUIRED for QUIET to suppress the find_package error message which must be very confusing to novice users (and misleading in the underlay case), but to my taste it is better to leave that.

I am not sure whether 1 is a good value to catkin_FOUND to set.

If you decide against a nice error message, the if() around catkin_workspace() might still be added to just have a single error message.
