### PR TITLE
Fix 2 minor bugs in catkin_python_setup

### DIFF
--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -19,6 +19,12 @@ function(catkin_python_setup)
     message(FATAL_ERROR "catkin_python_setup() called with unused arguments: ${ARGN}")
   endif()
 
+  # make sure catkin_package() has been called (implies ${PROJECT_NAME} has been set)
+  if(NOT _CATKIN_CURRENT_PACKAGE)
+    message(FATAL_ERROR "catkin_python_setup() must be called after catkin_package()")
+  endif()
+
+
   # mark that catkin_python_setup() was called in order to disable installation of generated __init__.py files in generate_messages()
   set(${PROJECT_NAME}_CATKIN_PYTHON_SETUP TRUE PARENT_SCOPE)
   if(${PROJECT_NAME}_GENERATE_MESSAGES)
@@ -67,10 +73,6 @@ function(catkin_python_setup)
   safe_execute_process(COMMAND ${cmd})
   include(${${PROJECT_NAME}_BINARY_DIR}/catkin_generated/setup_py_interrogation.cmake)
 
-  # call catkin_package_xml() if it has not been called before
-  if(NOT _CATKIN_CURRENT_PACKAGE)
-    catkin_package_xml()
-  endif()
   assert(${PROJECT_NAME}_VERSION)
   # verify that version from setup.py is equal to version from package.xml
   if(NOT "${${PROJECT_NAME}_SETUP_PY_VERSION}" STREQUAL "${${PROJECT_NAME}_VERSION}")

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -112,9 +112,7 @@ class Dummy:
             sys.stderr.write("\n*** Unable to find 'version' in setup.py of %s" % self.package_name)
             raise RuntimeError("version not found in setup.py")
         version = kwargs['version']
-        if 'package_dir' not in kwargs:
-            raise RuntimeError(r'package_dir not in setup.py')
-        package_dir = kwargs['package_dir']
+        package_dir = kwargs['package_dir'] if 'package_dir' in kwargs else {}
 
         pkgs = kwargs.get('packages', [])
         scripts = kwargs.get('scripts', [])


### PR DESCRIPTION
1st bug is that package_dir is required, but not required for distutils.

2nd bug is that catkin_python_setup.cmake calls catkin_package_xml itself. This can cause plenty of unsuitable error messages. E.g. if call to project() is missing, ${PROJECT_NAME} will still be default value "Project". And consecutive errors.

Also note that there are several other such flaws around genmsg. E.g. in genmsg-extras.cmake.em, PROJECT_NAME is used without checking it has been set.

Also in catkin_python_setup.cmake, the variable ${PROJECT_NAME}_GENERATE_MESSAGES is used, but this is an implicit dependency on genmsg and should be avoided. BUt I do not understand enough about the problems involved to fix that myself. I can raise an issue though.
