### PR TITLE
Update fuerte catkin to support rosdoc_lite

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import sys, os, subprocess
+import catkin_sphinx
 
 # -- General configuration -----------------------------------------------------
 
@@ -103,7 +104,7 @@ pygments_style = 'sphinx'
 # -- Options for HTML output ---------------------------------------------------
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [os.path.join(os.path.expanduser('~'), 'sphinx'), 'themes']
+html_theme_path = [os.path.join(os.path.dirname(catkin_sphinx.__file__), 'theme')]
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,16 @@
+<package>
+  <description brief="catkin">
+    Willow Garage low-level build system macros and infrastructure.
+  </description>
+  <author>Troy Straszheim/straszheim@willowgarage.com, Morten Kjaergaard, Brian Gerkey</author>
+  <license>BSD</license>
+  <review status="unreviewed" notes=""/>
+  <url>http://ros.org/wiki/catkin</url>
+
+  <export>
+    <rosdoc config="rosdoc.yaml"/>    
+  </export>
+
+</package>
+
+

--- a/rosdoc.yaml
+++ b/rosdoc.yaml
@@ -1,0 +1,2 @@
+ - builder: sphinx
+   sphinx_root_dir: doc


### PR DESCRIPTION
The lack of a manifest.xml and rosdoc.yaml file were keeping catkin from being documented by rosdoc_lite on fuerte. These changes should fix this and allow documentation to be generated automatically.
