### PR TITLE
catkin_make doesn't handle colorizing of unicode text properly

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -56,7 +56,7 @@ def cprint(msg, end=None):
 
 
 def colorize_line(line):
-    cline = str(sanitize(line))
+    cline = sanitize(line)
     cline = cline.replace(
         '-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
         '-- @{pf}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~@|'
@@ -133,11 +133,12 @@ def run_command(cmd, cwd, quiet=False, colorize=False):
     out = io.StringIO() if quiet else sys.stdout
     if capture:
         while True:
-            line = proc.stdout.readline().decode('utf-8')
+            line = proc.stdout.readline().decode('utf8', 'replace')
+            line = unicode(line)
             if proc.returncode is not None or not line:
                 break
             try:
-                line = unicode(colorize_line(line)) if colorize else line
+                line = colorize_line(line) if colorize else line
             except Exception as e:
                 import traceback
                 traceback.print_exc()
@@ -485,11 +486,12 @@ def build_workspace_isolated(
                 install, jobs, force_cmake, quiet, last_env,
                 number=index + 1, of=len(packages)
             )
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, KeyboardInterrupt) as e:
             cprint(
                 '@{rf}@!<==@| ' +
                 'Failed to process package \'@!@{bf}' +
                 package.name + '@|\': \n  ' +
-                str(e)
+                (str(e) if isinstance(e, KeyboardInterrupt)
+                        else 'KeyboardInterrupt')
             )
             sys.exit('Command failed, exiting.')

--- a/python/catkin/terminal_color.py
+++ b/python/catkin/terminal_color.py
@@ -127,12 +127,3 @@ def fmt(msg):
     msg = msg.replace('@|', '@{reset}')
     t = ColorTemplate(msg)
     return t.substitute(_ansi) + ansi('reset')
-
-
-if __name__ == '__main__':
-    test = '@_This is underlined@|'
-    print(fmt(test))
-    test = 'This has bad stuff @! @/ @_ @| OK!'
-    test = sanitize(test)
-    print(test)
-    print(fmt(test))

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))

--- a/test/unit_tests/test_builder.py
+++ b/test/unit_tests/test_builder.py
@@ -1,61 +1,44 @@
+# -*- coding: utf-8 -*-
+
 import os
 import unittest
-import tempfile
-import shutil
-import mock
+# import tempfile
+# import shutil
+# import mock
 
 try:
     import catkin.builder
-    from catkin.builder import build_workspace_in_isolation
-except ImportError as impe:
+    # from catkin.builder import build_workspace_in_isolation
+except ImportError as e:
     raise ImportError(
-        'Please adjust your pythonpath before running this test: %s' % str(impe))
+        'Please adjust your pythonpath before running this test: %s' % str(e)
+    )
 
 
 class BuilderTest(unittest.TestCase):
+    # TODO: Add tests for catkin_make and catkin_make_isolated
 
-    def test_build_workspace_in_isolation(self):
-        backup_top = catkin.builder.topological_order
-        backup_run = catkin.builder._run_command_with_env
-        old_cwd = os.getcwd()
+    def test_run_command_unicode(self):
+        backup_Popen = catkin.builder.subprocess.Popen
+
+        class StdOut(object):
+            def __init__(self, popen):
+                self.__popen = popen
+
+            def readline(self):
+                self.__popen.returncode = 0
+                return u'\u2018'
+
+        class MockPopen(object):
+            def __init__(self, *args, **kwargs):
+                self.returncode = None
+                self.stdout = StdOut(self)
+
+            def wait(self):
+                return True
+
         try:
-            root_dir = tempfile.mkdtemp()
-            os.chdir(root_dir)
-            mockp1 = mock.Mock()
-            mockp1.exports = []
-            mockp1.name = 'p1'
-            mockp1.filename = '/foo/package.xml'
-            mockp2 = mock.Mock()
-            mockp2.exports = []
-            mockp2.name = 'p2'
-            mockp2.filename = '/bar/package.xml'
-            mock_top = mock.Mock()
-            mock_top.return_value = [('foopack', mockp1), ('barpack', mockp2)]
-            mock_run = mock.Mock()
-            catkin.builder.topological_order = mock_top
-            catkin.builder._run_command_with_env = mock_run
-            build_workspace_in_isolation('/path1')
-            self.assertEqual(1, mock_top.call_count)
-            top_args = mock_top.call_args[0]
-            self.assertEqual(('/path1',), top_args)
-            self.assertEqual(4, mock_run.call_count, mock_run.call_args_list)
-            run_args = mock_run.call_args_list
-            self.assertEqual(['cmake', '/foo', '-DCATKIN_DEVEL_PREFIX=%s' % os.path.join(root_dir, 'p1__devel')], run_args[0][0][0])
-            self.assertEqual(['make', '-j8'], run_args[1][0][0])
-            # install case
-            mock_top.reset_mock()
-            mock_run.reset_mock()
-            build_workspace_in_isolation('/path1', install=True)
-            self.assertEqual(1, mock_top.call_count)
-            top_args = mock_top.call_args[0]
-            self.assertEqual(('/path1',), top_args)
-            self.assertEqual(6, mock_run.call_count)
-            run_args = mock_run.call_args_list
-            self.assertEqual(['cmake', '/foo', '-DCATKIN_DEVEL_PREFIX=%s' % os.path.join(root_dir, 'p1__devel'), '-DCMAKE_INSTALL_PREFIX=%s' % os.path.join(root_dir, 'p1__install')], run_args[0][0][0])
-            self.assertEqual(['make', '-j8'], run_args[1][0][0])
-            self.assertEqual(['make', 'install'], run_args[2][0][0])
+            catkin.builder.subprocess.Popen = MockPopen
+            catkin.builder.run_command(['false'], os.getcwd(), True, True)
         finally:
-            os.chdir(old_cwd)
-            catkin.builder.topological_order = backup_top
-            catkin.builder._run_command_with_env = backup_run
-            shutil.rmtree(root_dir)
+            catkin.builder.subprocess.Popen = backup_Popen

--- a/test/unit_tests/test_terminal_color.py
+++ b/test/unit_tests/test_terminal_color.py
@@ -1,0 +1,24 @@
+import unittest
+
+try:
+    from catkin.terminal_color import fmt, sanitize
+except ImportError as e:
+    raise ImportError(
+        'Please adjust your pythonpath before running this test: %s' % str(e)
+    )
+
+
+class TerminalColorTest(unittest.TestCase):
+
+    def test_terminal_colors(self):
+        test = '@_This is underlined@|'
+        rslt = '\033[4mThis is underlined\033[0m\033[0m'
+        assert fmt(test) == rslt
+        test = 'This has bad stuff @! @/ @_ @| OK!'
+        test = sanitize(test)
+        rslt = 'This has bad stuff @! @/ @_ @| OK!\033[0m'
+        assert fmt(test) == rslt
+        test = u'\u2018@'
+        test = sanitize(test)
+        rslt = u'\u2018@@'
+        assert test == rslt


### PR DESCRIPTION
We're building a couple third party packages using catkin, and wrapping their build systems. Some of them output non-ascii characters, which breaks the colorizing in catkin:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 38: ordinal not in range(128)
<caktin_make> color formatting problem: 'ascii' codec can't encode character u'\u2018' in position 38: ordinal not in range(128)
Traceback (most recent call last):
  File "/opt/ros/groovy/lib/python2.7/dist-packages/catkin/builder.py", line 132, in run_command_colorized
    out.write(unicode(colorize_line(line)))
  File "/opt/ros/groovy/lib/python2.7/dist-packages/catkin/builder.py", line 58, in colorize_line
    cline = str(sanitize(line))
```
