### PR TITLE
catkin_make_isolated to accepd -D options

### DIFF
--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -8,10 +8,18 @@ import sys
 # find the import relatively if available to work before installing catkin or overlaying installed version
 if os.path.exists(os.path.join(os.path.dirname(__file__), 'CMakeLists.txt')):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
-from catkin.builder import build_workspace_isolated
+from catkin.builder import build_workspace_isolated, colorize_line
 
 
-def main():
+def extract_cmake_args(args=sys.argv[1:]):
+    # extract -D* and -G* arguments
+    cmake_args = [a for a in args if a.startswith('-D') or a.startswith('-G')]
+    args = [a for a in args if a not in cmake_args]
+
+    return cmake_args, args
+
+
+def parse_args(args=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Builds each catkin (and non-catkin) package from '
                     'a given workspace in isolation, but still in '
@@ -52,20 +60,56 @@ def main():
     add('-v', '--verbose', action='store_true', default=False,
         help='Prints more build output.'
     )
-    args = parser.parse_args()
+    return parser.parse_args(args)
+
+
+def handle_cmake_args(cmake_args, opts):
+    # Process cmake arugments
+    for arg in list(cmake_args):
+        if arg.startswith('-G'):
+            continue
+        if arg.startswith('-DCMAKE_INSTALL_PREFIX='):
+            if opts.install_space is None:
+                opts.install_space = arg.split('=', 1)[-1]
+            else:
+                print(colorize_line(
+                    "Warning: both the cmake argument '" + str(arg) + "' " +
+                    "and the --install-space argument have been used, " +
+                    "using the --install-space argument."
+                ))
+            cmake_args.remove(arg)
+        if arg.startswith('-DCATKIN_DEVEL_PREFIX='):
+            if opts.devel is None:
+                opts.devel = arg.split('=', 1)[-1]
+            else:
+                print(colorize_line(
+                    "Warning: both the cmake argument '" + str(arg) + "' " +
+                    "and the --devel-space argument have been used, " +
+                    "using the --devel-space argument."
+                ))
+            cmake_args.remove(arg)
+    return cmake_args, opts
+
+
+def main():
+    cmake_args, args = extract_cmake_args()
+    opts = parse_args(args)
+
+    cmake_args, opts = handle_cmake_args(cmake_args, opts)
 
     build_workspace_isolated(
-        workspace=args.workspace or '.',
-        sourcespace=args.source,
-        buildspace=args.build,
-        develspace=args.devel,
-        installspace=args.install_space,
-        merge=args.merge,
-        install=args.install,
-        jobs=args.jobs,
-        force_cmake=args.force_cmake,
-        colorize=not args.no_color,
-        quiet=not args.verbose
+        workspace=opts.workspace or '.',
+        sourcespace=opts.source,
+        buildspace=opts.build,
+        develspace=opts.devel,
+        installspace=opts.install_space,
+        merge=opts.merge,
+        install=opts.install,
+        jobs=opts.jobs,
+        force_cmake=opts.force_cmake,
+        colorize=not opts.no_color,
+        quiet=not opts.verbose,
+        cmake_args=cmake_args
     )
 
 if __name__ == '__main__':

--- a/test/unit_tests/test_catkin_make_isolated.py
+++ b/test/unit_tests/test_catkin_make_isolated.py
@@ -1,0 +1,97 @@
+import os
+import unittest
+
+import imp
+imp.load_source('catkin_make_isolated',
+                os.path.join(os.path.dirname(__file__),
+                             '..', '..', 'bin', 'catkin_make_isolated'))
+
+from catkin_make_isolated import extract_cmake_args
+from catkin_make_isolated import parse_args
+from catkin_make_isolated import handle_cmake_args
+
+
+class CatkinMakeIsolatedTests(unittest.TestCase):
+
+    def test_extract_cmake_args(self):
+        args = []
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == []
+        assert args == []
+
+        args = ['-DCMAKE_INSTALL_PREFIX=install']
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCMAKE_INSTALL_PREFIX=install']
+        assert args == []
+
+        args = ['-DCMAKE_INSTALL_PREFIX=install', '--install']
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCMAKE_INSTALL_PREFIX=install']
+        assert args == ['--install']
+
+        args = [
+            '-DCMAKE_INSTALL_PREFIX=install', '--install', '--install-space',
+            'install_isolated'
+        ]
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCMAKE_INSTALL_PREFIX=install']
+        assert args == ['--install', '--install-space', 'install_isolated']
+
+        args = ['-DCATKIN_DEVEL_PREFIX=devel']
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCATKIN_DEVEL_PREFIX=devel']
+        assert args == []
+
+        args = ['-DCATKIN_DEVEL_PREFIX=devel']
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCATKIN_DEVEL_PREFIX=devel']
+        assert args == []
+
+        args = [
+            '-DCATKIN_DEVEL_PREFIX=devel', '--devel-space',
+            'devel_isolated'
+        ]
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCATKIN_DEVEL_PREFIX=devel']
+        assert args == ['--devel-space', 'devel_isolated']
+
+    def test_handle_cmake_args(self):
+        args = ['-DCMAKE_INSTALL_PREFIX=install', '--install']
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCMAKE_INSTALL_PREFIX=install'], cmake_args
+        opts = parse_args(args)
+        cmake_args, opts = handle_cmake_args(cmake_args, opts)
+        assert cmake_args == [], cmake_args
+        assert opts.install == True
+        assert opts.install_space == 'install'
+
+        args = [
+            '-DCMAKE_INSTALL_PREFIX=install', '--install', '--install-space',
+            'install_isolated'
+        ]
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCMAKE_INSTALL_PREFIX=install'], cmake_args
+        opts = parse_args(args)
+        cmake_args, opts = handle_cmake_args(cmake_args, opts)
+        assert cmake_args == [], cmake_args
+        assert opts.install == True
+        assert opts.install_space == 'install_isolated'
+
+        args = ['-DCATKIN_DEVEL_PREFIX=devel']
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCATKIN_DEVEL_PREFIX=devel'], cmake_args
+        opts = parse_args(args)
+        cmake_args, opts = handle_cmake_args(cmake_args, opts)
+        assert cmake_args == [], cmake_args
+        assert opts.devel == 'devel'
+
+        args = [
+            '-DCATKIN_DEVEL_PREFIX=devel', '--devel-space',
+            'devel_isolated'
+        ]
+        cmake_args, args = extract_cmake_args(args)
+        assert cmake_args == ['-DCATKIN_DEVEL_PREFIX=devel'], cmake_args
+        opts = parse_args(args)
+        cmake_args, opts = handle_cmake_args(cmake_args, opts)
+        assert cmake_args == [], cmake_args
+        assert opts.devel == 'devel_isolated'


### PR DESCRIPTION
catkin_make accepts -d options to pass to cmake. It seems catkin_make_isolated does not:

```
$ src/catkin/bin/catkin_make_isolated -DFOO=3
catkin_make_isolated: error: unrecognized arguments: -DFOO=3
```
