### PR TITLE
Support inverted color scheme

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -154,7 +154,7 @@ def run_command(cmd, cwd, quiet=False, colorize=False):
         raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
     return out.getvalue() if quiet else ''
 
-blue_arrow = '@!@{bf}==>@{wf}'
+blue_arrow = '@!@{bf}==>@|@!'
 
 
 def _check_build_dir(name, workspace, buildspace):


### PR DESCRIPTION
catkin_make colors the output, and uses bright foreground colors over custom background colors. That means if the user had a white background, he will not see certain text.

Attaching file

![Uploading console.gif . . .]()
