### PR TITLE
catkin_make_isolated should allow building individual packages

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -594,6 +594,10 @@ def build_workspace_isolated(
                 ('KeyboardInterrupt' if isinstance(e, KeyboardInterrupt)
                         else str(e))
             )
+            if isinstance(e, subprocess.CalledProcessError):
+                cmd = ' '.join(e.cmd) if isinstance(e.cmd, list) else e.cmd
+                print(fmt("\n@{rf}Reproduce this error by running:"))
+                print(fmt("@{gf}@!==> @|") + cmd + "\n")
             sys.exit('Command failed, exiting.')
 
 


### PR DESCRIPTION
Currently going into build_isolated/packagename and running make or cmake does not work, nor do I see any other easy way of running that build in isolation, I guess the env.sh file is required, but it should be easier to do this, IMO.

Would be less urgent if catkin_make_isolated had rosbuild parallelity.
