### PR TITLE
Minor windows fixes

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -114,6 +114,7 @@ foreach(filename
     parse_arguments
     safe_execute_process
     stamp
+	platform/cross_platform_utilities
     platform/lsb
     platform/ubuntu
     platform/windows

--- a/cmake/em/order_packages.cmake.em
+++ b/cmake/em/order_packages.cmake.em
@@ -22,7 +22,7 @@ fatal_error = True
 }@
 @[elif package.name != 'catkin']@
 list(APPEND CATKIN_ORDERED_PACKAGES "@(package.name)")
-list(APPEND CATKIN_ORDERED_PACKAGE_PATHS "@(path)")
+list(APPEND CATKIN_ORDERED_PACKAGE_PATHS "@(path.replace("\\","/"))")
 list(APPEND CATKIN_ORDERED_PACKAGES_IS_META "@(str('metapackage' in [e.tagname for e in package.exports]))")
 list(APPEND CATKIN_ORDERED_PACKAGES_BUILD_TYPE "@(str([e.content for e in package.exports if e.tagname == 'build_type'][0]) if 'build_type' in [e.tagname for e in package.exports] else 'catkin')")
 @{

--- a/cmake/platform/cross_platform_utilities.cmake
+++ b/cmake/platform/cross_platform_utilities.cmake
@@ -1,0 +1,7 @@
+
+# Path separation is handled differently on win/unix platforms.
+if(CMAKE_HOST_WIN32)
+  set(CATKIN_PATH_SEPARATOR ";")
+else()
+  set(CATKIN_PATH_SEPARATOR ":")
+endif()

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -168,7 +168,7 @@ def assignment(key, value):
     if not IS_WINDOWS:
         return 'export %s="%s"' % (key, value)
     else:
-        return 'set %s="%s"' % (key, value)
+        return 'set %s=%s' % (key, value)
 
 
 def comment(msg):
@@ -184,7 +184,7 @@ def prepend(environ, key, prefix):
     if not IS_WINDOWS:
         return 'export %s="%s$%s"' % (key, prefix, key)
     else:
-        return 'set %s="%s%%%s%%"' % (key, prefix, key)
+        return 'set %s=%s%%%s%%' % (key, prefix, key)
 
 
 def find_env_hooks(environ, cmake_prefix_path):

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -47,7 +47,7 @@ if [%CATKIN_SHELL%]==[] (
 )
 
 REM source all environment hooks
-for /F "tokens=* delims=;" %%a in (%_CATKIN_ENVIRONMENT_HOOKS%) do (
+for /F "tokens=* delims=;" %%a in ("%_CATKIN_ENVIRONMENT_HOOKS%") do (
   for %%b in (%%a) do (
     call "%%b"
   )


### PR DESCRIPTION
Some trivial fixes...bigger fixes are pending and probably need some discussion.

21cfef6c45e6ab2220180e175cd3f92b7cc5d805: it converts windows paths (e.g. ros\core\mk) into *nix paths so that cmake doesn't fall over when it sees backslashes. Further discussion is at #355

c691275f56cb519ecabd1ab04d416c1e99d0dcad: haven't used it here, but will in a coming patch. Useful to have there at any rate.

10fb4ead188114f5156e6819c06e3755bf27aeeb: comments in the commit.
