### PR TITLE
Make installed CMake files relocatable

### DIFF
--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -11,7 +11,7 @@
 #    contains the include dirs / library dirs / libraries of the searched component <comp>.
 
 if(CATKIN_TOPLEVEL_FIND_PACKAGE OR NOT CATKIN_TOPLEVEL)
-  set(catkin_EXTRAS_DIR "@PKG_CMAKE_DIR@")
+  set(catkin_EXTRAS_DIR ${CMAKE_CURRENT_LIST_DIR})
 
   # prevent multiple inclusion from repeated find_package() calls in non-workspace context
   # as long as this variable is in the scope the variables from all.cmake are also, so no need to be evaluated again

--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -294,10 +294,7 @@ function(_catkin_package)
   # prepend library path of this workspace
   set(PKG_CONFIG_LIB_PATHS ${lib_paths})
   list(INSERT PKG_CONFIG_LIB_PATHS 0 ${PROJECT_SPACE_DIR}/lib)
-  set(PKG_CMAKE_DIR ${PROJECT_SPACE_DIR}/share/${PROJECT_NAME}/cmake)
-  if("${PROJECT_NAME}" STREQUAL "catkin")
-    set(PKG_CMAKE_DIR "${catkin_EXTRAS_DIR}")
-  endif()
+  set(PKG_CMAKE_DIR "\${${PROJECT_NAME}_EXTRAS_DIR}")
 
   if(NOT PROJECT_SKIP_PKG_CONFIG_GENERATION)
     # ensure that output folder exists
@@ -398,7 +395,7 @@ function(_catkin_package)
   # prepend library path of this workspace
   set(PKG_CONFIG_LIB_PATHS ${lib_paths})
   list(INSERT PKG_CONFIG_LIB_PATHS 0 ${PROJECT_SPACE_DIR}/lib)
-  set(PKG_CMAKE_DIR ${PROJECT_SPACE_DIR}/share/${PROJECT_NAME}/cmake)
+  set(PKG_CMAKE_DIR "\${${PROJECT_NAME}_EXTRAS_DIR}")
 
   if(NOT PROJECT_SKIP_PKG_CONFIG_GENERATION)
     # ensure that output folder exists

--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -328,7 +328,7 @@ function(_catkin_package)
         ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/${extra}.develspace.context.cmake.py
         ${em_template}
         ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra})
-      list(APPEND PKG_CFG_EXTRAS ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra})
+      list(APPEND PKG_CFG_EXTRAS ${extra})
     elseif(EXISTS ${base}.in OR EXISTS ${base}.develspace.in)
       if(EXISTS ${base}.develspace.in)
         set(in_template ${base}.develspace.in)
@@ -339,9 +339,13 @@ function(_catkin_package)
         ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra}
         @ONLY
       )
-      list(APPEND PKG_CFG_EXTRAS ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra})
+      list(APPEND PKG_CFG_EXTRAS ${extra})
     elseif(EXISTS ${base})
-      list(APPEND PKG_CFG_EXTRAS ${base})
+      configure_file(${base}
+        ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra}
+        COPYONLY
+      )
+      list(APPEND PKG_CFG_EXTRAS ${extra})
     elseif(NOT EXISTS ${base}.installspace.em AND NOT EXISTS ${base}.installspace.in)
       message(FATAL_ERROR "catkin_package() could not find CFG_EXTRAS file.  Either 'cmake/${extra}.develspace.em', 'cmake/${extra}.em', 'cmake/${extra}.develspace.in', 'cmake/${extra}.in', 'cmake/${extra}' or a variant specific to the installspace must exist.")
     endif()
@@ -430,7 +434,7 @@ function(_catkin_package)
         ${em_template}
         ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/installspace/${extra})
       list(APPEND installable_cfg_extras ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/installspace/${extra})
-      list(APPEND PKG_CFG_EXTRAS ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra})
+      list(APPEND PKG_CFG_EXTRAS ${extra})
     elseif(EXISTS ${base}.in OR EXISTS ${base}.installspace.in)
       if(EXISTS ${base}.installspace.in)
         set(in_template ${base}.installspace.in)
@@ -442,10 +446,10 @@ function(_catkin_package)
         @ONLY
       )
       list(APPEND installable_cfg_extras ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/installspace/${extra})
-      list(APPEND PKG_CFG_EXTRAS ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra})
+      list(APPEND PKG_CFG_EXTRAS ${extra})
     elseif(EXISTS ${base})
       list(APPEND installable_cfg_extras ${base})
-      list(APPEND PKG_CFG_EXTRAS ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/cmake/${extra})
+      list(APPEND PKG_CFG_EXTRAS ${extra})
     elseif(NOT EXISTS ${base}.develspace.em AND NOT EXISTS ${base}.develspace.in)
       message(FATAL_ERROR "catkin_package() could not find CFG_EXTRAS file.  Either 'cmake/${extra}.installspace.em', 'cmake/${extra}.em', 'cmake/${extra}.installspace.in', 'cmake/${extra}.in', 'cmake/${extra}'or a variant specific to the develspace must exist.")
     endif()

--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -70,6 +70,8 @@ else()
   set(@PROJECT_NAME@_PREFIX ${@PROJECT_NAME@_INSTALL_PREFIX})
 endif()
 
+set(@PROJECT_NAME@_EXTRAS_DIR ${CMAKE_CURRENT_LIST_DIR})
+
 # warn when using a deprecated package
 if(NOT "@PROJECT_DEPRECATED@" STREQUAL "")
   set(_msg "WARNING: package '@PROJECT_NAME@' is deprecated")
@@ -165,5 +167,5 @@ if(@PROJECT_NAME@_LIBRARIES)
 endif()
 
 foreach(extra @PKG_CFG_EXTRAS@)
-  include(${extra})
+  include(${@PROJECT_NAME@_EXTRAS_DIR}/${extra})
 endforeach()


### PR DESCRIPTION
This pull request makes the installed CMake files relocatable. This function is needed to cross compiling ros via yocto project. It adds @PROJECT_NAME@_EXTRAS_DIR to the pkgConfig.cmake.in and set it to the CMAKE_CURRENT_LIST_DIR. This directory is used to include the PKG_CFG_EXTRAS files.
