### PR TITLE
env.sh's new shell when no arguments are given lacks same env changes if .bashrc changes env vars

### DIFF
--- a/cmake/templates/env.bat.in
+++ b/cmake/templates/env.bat.in
@@ -2,20 +2,10 @@
 REM generated from catkin/cmake/templates/env.bat.in
 
 if "%1"=="" (
-  goto EnterBuildEnvironment
+  echo "Usage: env.bat COMMANDS"
+  echo "Calling env.bat without arguments is not supported anymore. Instead spawn a subshell and source a setup file manually."
+  exit 1
 ) else ( 
-  goto EnterExecutionEnvironment
+  call "@SETUP_DIR@/@SETUP_FILENAME@.bat"
+  %*
 )
-
-:EnterBuildEnvironment
-echo "Entering environment at '@SETUP_DIR@', type 'exit' to leave"
-cmd /K "@SETUP_DIR@/@SETUP_FILENAME@.bat"
-echo "Exiting environment at '@SETUP_DIR@'"
-goto End
-
-:EnterExecutionEnvironment
-call "@SETUP_DIR@/@SETUP_FILENAME@.bat"
-%*
-goto End
-
-:End

--- a/cmake/templates/env.sh.in
+++ b/cmake/templates/env.sh.in
@@ -2,10 +2,9 @@
 # generated from catkin/cmake/templates/env.sh.in
 
 if [ $# -eq 0 ] ; then
-  /bin/echo "Entering environment at '@SETUP_DIR@', type 'exit' to leave"
-  . "@SETUP_DIR@/@SETUP_FILENAME@.sh"
-  "$SHELL" -i
-  /bin/echo "Exiting environment at '@SETUP_DIR@'"
+  /bin/echo "Usage: env.sh COMMANDS"
+  /bin/echo "Calling env.sh without arguments is not supported anymore. Instead spawn a subshell and source a setup file manually."
+  exit 1
 else
   . "@SETUP_DIR@/@SETUP_FILENAME@.sh"
   exec "$@"


### PR DESCRIPTION
@wjwwood as discussed env.sh could do a better job of explaining that running or sourcing it without further arguments is not a valid usecase, as the resulting env is not what can be expected.
