### PR TITLE
Better place for workspace configuration

### DIFF
--- a/cmake/toplevel.cmake
+++ b/cmake/toplevel.cmake
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 # optionally provide a cmake file in the workspace to override arbitrary stuff
-include(workspace.cmake OPTIONAL)
+include(${CMAKE_BINARY_DIR}/workspace.cmake OPTIONAL)
 
 set(CATKIN_TOPLEVEL TRUE)
 


### PR DESCRIPTION
The parallel build directories are a better place for workspace configuration. e.g. you might have three parallel builds:
- debug
- release
- arm cross compile

and you'd probably use three different workspace.cmake files to modify variables like CMAKE_BUILD_TYPE and CMAKE_CXX_FLAGS et. al. You don't want to have to keep copying in and out of the source's root folder.
