### PR TITLE
Better nosetest build folder naming

### DIFF
--- a/cmake/test/nosetests.cmake
+++ b/cmake/test/nosetests.cmake
@@ -55,21 +55,18 @@ function(catkin_add_nosetests path)
     set(_covarg " --with-coverage")
   endif()
 
-  # strip PROJECT_BINARY_DIR from output_file_name
+  # strip PROJECT_SOURCE_DIR from output_file_name
   set(output_file_name ${path})
-  string(LENGTH "${PROJECT_BINARY_DIR}/" prefix_length)
-  string(LENGTH "${output_file_name}" var_length)
-  if(${var_length} GREATER ${prefix_length})
-    string(SUBSTRING "${output_file_name}" 0 ${prefix_length} var_prefix)
-    if("${var_prefix}" STREQUAL "${PROJECT_BINARY_DIR}/")
-      # passing length -1 does not work for CMake < 2.8.5
-      # http://public.kitware.com/Bug/view.php?id=10740
-      string(LENGTH "${output_file_name}" _rest)
-      math(EXPR _rest "${_rest} - ${prefix_length}")
-      string(SUBSTRING "${output_file_name}" ${prefix_length} ${_rest} output_file_name)
-    endif()
+  string(REGEX REPLACE "^${PROJECT_SOURCE_DIR}" "" output_file_name ${output_file_name})
+  if("${output_file_name}" STREQUAL "")
+    # if for some reason we end up with nothing (e.g. genmsg's catkin_add_nosetests(${PROJECT_SOURCE_DIR})
+    set(output_file_name "nosetests")
+  else()
+    # Just for niceness, make sure we have no leading /, otherwise the . replacement below hides linux dirs
+    string(REGEX REPLACE "^/" "" output_file_name ${output_file_name})
   endif()
   string(REPLACE "/" "." output_file_name ${output_file_name})
+  string(REPLACE ":" "." output_file_name ${output_file_name})  # avoid the dreaded windows C:
 
   set(output_path ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})
   set(cmd "${CMAKE_COMMAND} -E make_directory ${output_path}")


### PR DESCRIPTION
Windows failing to build genmsg which uses 

```
catkin_add_nosetests(${PROJECT_SOURCE_DIR})
```

and it falls all over the `C:\` prefix to the path. This led to finding this bit of code:
- Was it actually intending to strip the source directory and not the binary directory? I can't see the reason you'd want to strip the binary directory and stripping the source directory makes it more convenient for introspection.
- This regex replace code is quite a bit simpler for removing prefixes
- Provides a name when ends up with the empty string (could maybe choose a better name?)
- Also replaces colons with dots to avoid problem windows path characters.
