### PR TITLE
Avoid creating nmake inference rule problems

### DIFF
--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -43,17 +43,17 @@ function(catkin_run_tests_target type name xunit_filename)
   if(NOT TARGET run_tests_${PROJECT_NAME})
     add_custom_target(run_tests_${PROJECT_NAME})
     # create hidden meta target which depends on hidden test targets which depend on clean_test_results
-    add_custom_target(.run_tests_${PROJECT_NAME})
+    add_custom_target(_run_tests_${PROJECT_NAME})
     # run_tests depends on this hidden target hierarchy to clear test results before running all tests
-    add_dependencies(run_tests .run_tests_${PROJECT_NAME})
+    add_dependencies(run_tests _run_tests_${PROJECT_NAME})
   endif()
   # create meta target to trigger all tests of a specific type of a project
   if(NOT TARGET run_tests_${PROJECT_NAME}_${type})
     add_custom_target(run_tests_${PROJECT_NAME}_${type})
     add_dependencies(run_tests_${PROJECT_NAME} run_tests_${PROJECT_NAME}_${type})
     # hidden meta target which depends on hidden test targets which depend on clean_test_results
-    add_custom_target(.run_tests_${PROJECT_NAME}_${type})
-    add_dependencies(.run_tests_${PROJECT_NAME} .run_tests_${PROJECT_NAME}_${type})
+    add_custom_target(_run_tests_${PROJECT_NAME}_${type})
+    add_dependencies(_run_tests_${PROJECT_NAME} _run_tests_${PROJECT_NAME}_${type})
   endif()
   # create target for test execution
   set(results ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/${xunit_filename})
@@ -70,8 +70,8 @@ function(catkin_run_tests_target type name xunit_filename)
     add_dependencies(run_tests_${PROJECT_NAME}_${type}_${name} ${_testing_DEPENDENCIES})
   endif()
   # hidden test target which depends on building all tests and cleaning test results
-  add_custom_target(.run_tests_${PROJECT_NAME}_${type}_${name}
+  add_custom_target(_run_tests_${PROJECT_NAME}_${type}_${name}
     COMMAND ${cmd})
-  add_dependencies(.run_tests_${PROJECT_NAME}_${type} .run_tests_${PROJECT_NAME}_${type}_${name})
-  add_dependencies(.run_tests_${PROJECT_NAME}_${type}_${name} clean_test_results tests ${_testing_DEPENDENCIES})
+  add_dependencies(_run_tests_${PROJECT_NAME}_${type} _run_tests_${PROJECT_NAME}_${type}_${name})
+  add_dependencies(_run_tests_${PROJECT_NAME}_${type}_${name} clean_test_results tests ${_testing_DEPENDENCIES})
 endfunction()


### PR DESCRIPTION
**Problem**

rostest's `add_ros_test` calls on windows would run through the cmake ok, but when hitting nmake, it would stop short with the error message:

```
makefile(1035) : fatal error U1086: inference rule cannot have dependents
Stop.
```

In the `Makefile`, you would find a target like:

```
.run_tests_rostest_rostest_test_hztest0.test: cmake_check_build_system
    $(MAKE) -f CMakeFiles\Makefile2 /nologo -$(MAKEFLAGS) .run_tests_rostest_rostest_test_hztest0.test
```

Nmake would read this like an inference rule (aka `.c.obj:`) and abort when it saw the dependency (http://msdn.microsoft.com/en-us/library/d8k6a82k.aspx).

**Solution**

Is there a special reason the _hidden_ targets are using a dot? I've used underscore here.
