### PR TITLE
Batch is clueless about double quotes

### DIFF
--- a/python/catkin/environment_cache.py
+++ b/python/catkin/environment_cache.py
@@ -114,7 +114,6 @@ def _append_comment(code, value):
 
 def _set_variable(code, key, value):
     if _is_not_windows():
-        export_command = 'export'
+        code.append('export %s="%s"' % (key, value))
     else:
-        export_command = 'set'
-    code.append('%s %s="%s"' % (export_command, key, value))
+        code.append('set %s=%s' % (key, value))


### PR DESCRIPTION
This is especially important for setting the paths - you don't want to set a 
path with quotes around them because it just then reads it as a single string 
variable, path -> boom.

However, we may probably need to revisit this issue to handle individual 
variables that are going into the paths at some point in time (they need
quotes).
