### PR TITLE
Help windows find dll's

### DIFF
--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -48,6 +48,10 @@ for /F "tokens=* delims=;" %%a in ("%_CATKIN_ENVIRONMENT_HOOKS%") do (
   )
 )
 
+REM 3rdparty packages often put dll's into lib (convention is bin) and 
+REM windows finds it's dll's via the PATH variable. Make that happen here!
+set PATH=%LD_LIBRARY_PATH%;%PATH%
+
 REM unset temporary variables
 set _SETUP_UTIL=
 set _PYTHON=


### PR DESCRIPTION
Convention is to put dll's into `bin`, but often packages still 
dump them in `lib`. 

For windows to find them, we need the `lib`
directories to be in the path. Easy solution - just add the 
`LD_LIBRARY_PATH` that catkin defines to the `PATH`.

Finally develspace is running roscore, talker and listener!
