### PR TITLE
Remove redundant install-scripts option.

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -18,7 +18,6 @@ if(SETUPTOOLS_DEB_LAYOUT)
 else()
   set(PYTHON_PACKAGES_DIR site-packages)
   file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/bin PYTHON_INSTALL_PREFIX) # setuptools is fussy about windows paths
-  set(SETUPTOOLS_ARG_EXTRA "--install-scripts=${PYTHON_INSTALL_PREFIX}")
 endif()
 
 if(NOT WIN32)


### PR DESCRIPTION
The `--install-scripts` option gets added to `SETUPTOOLS_ARG_EXTRA` and doubled up in `cmake/templates/python_distutils_install.bat.in` and `cmake/templates/python_distutils_install.sh.in`.

We can remove it here, or in the `python_distutils_install.bat.in` files. I did it here in `python.cmake` since I was not sure if it was necessary with `--install-layout=deb`.
