### PR TITLE
Find python path properly for installed underlays.

### DIFF
--- a/cmake/templates/generate_cached_setup.py.in
+++ b/cmake/templates/generate_cached_setup.py.in
@@ -5,8 +5,10 @@ import stat
 import sys
 
 # find the import relatively if available to work before installing catkin or overlaying installed version
-if os.path.exists(os.path.join('@catkin_EXTRAS_DIR@', 'catkinConfig.cmake.in')):
+if os.path.exists(os.path.join('@catkin_EXTRAS_DIR@', 'catkinConfig.cmake.in')):  # from an devel space
     sys.path.insert(0, os.path.join('@catkin_EXTRAS_DIR@', '..', 'python'))
+elif os.path.exists(os.path.join('@catkin_EXTRAS_DIR@', 'catkinConfig.cmake')):  # from an install space
+    sys.path.insert(0, os.path.join('@catkin_EXTRAS_DIR@', '..', '..', '..', '${CATKIN_GLOBAL_PYTHON_DESTINATION}'))
 from catkin.environment_cache import generate_environment_script
 
 code = generate_environment_script('@CATKIN_DEVEL_PREFIX@/env.@script_ext@')


### PR DESCRIPTION
This is the only change I need to work with underlays that are completely defined by `CMAKE_PREFIX_PATH` in an initial cache rather than environment variables persistently set by sourcing underlay `setup.xxx` scripts every time you cmake/make.

See parallel email thread in ros-sig-buildsystem. I think it would be very convenient (if for us, then I'm sure others as well) to support this and it doesn't break support of the former manual sourcing style.
