### PR TITLE
catkin_make* should allow for `MAKEFLAGS`

### DIFF
--- a/doc/user_guide/setup_dot_py.rst
+++ b/doc/user_guide/setup_dot_py.rst
@@ -50,10 +50,11 @@ be used by catkin::
   from distutils.core import setup
 
   setup(
-    version='...',
-    scripts=['bin/myscript'],
-    packages=['mypkg'],
-    package_dir={'': 'src'})
+      version='...',
+      scripts=['bin/myscript'],
+      packages=['mypkg'],
+      package_dir={'': 'src'}
+  )
 
 This creates relays for all scripts listed in ``scripts`` to a folder
 in devel space where they can be found and executed, and also relay
@@ -77,9 +78,9 @@ like this::
   from catkin_pkg.python_setup import generate_distutils_setup
 
   d = generate_distutils_setup(
-    packages=['mypkg'],
-    scripts=['bin/myscript'],
-    package_dir={'': 'src'}
+      packages=['mypkg'],
+      scripts=['bin/myscript'],
+      package_dir={'': 'src'}
   )
 
   setup(**d)


### PR DESCRIPTION
Currently `caktin_make*` programs always give job  arguments to `make`, even if none are passed to them directly, e.g. `catkin_make` -> `make -j8 -l8` and `catkin_make -j1` -> `make -j1 -l1`.

This prevents the Make environment variable `MAKEFLAGS` from working with `catkin_make*`. I propose a new logic for handling `-j`, `--jobs`, `-l`, `--load-average` arguments:

![catkin_make_jobs](https://f.cloud.github.com/assets/100427/310965/916710c8-972b-11e2-837f-d2be78d52963.png)

This will allow users to override the make job options with direct arguments to `catkin_make*`, `MAKEFLAGS`, or `ROS_PARALLEL_JOBS`.

_EDIT:_ Removed references to `CATKIN_PARALLEL_JOBS` because it is overshadowed by `MAKEFLAGS` and direct arguments, and I did not want it to have the same weird specification as `ROS_PARALLEL_JOBS` where it has flags for make not just a number.
