### PR TITLE
catkin_make* should allow for `MAKEFLAGS`

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -156,8 +156,8 @@ def _parse_args(args=sys.argv[1:]):
         'If no -j/-l arguments are given, then the MAKEFLAGS environment variable is searched for -j/-l flags. '
         'If found then no -j/-l flags are passed to make explicitly (as not to override the MAKEFLAGS). '
         'If MAKEFLAGS is not set then the environement variable ROS_PARALLEL_JOBS is used. '
-        'If the ROS_PARALLEL_JOBS variable is not defined then the flags "-jn -ln" are used, '
-        'where n is number of CPU cores or 1 if the number of cores cannot be determined. '
+        'If not ROS_PARALLEL_JOBS then the flags "-jn -ln" are used, where n is number of CPU cores. '
+        'If the number of CPU cores cannot be determined then no flags are given to make. '
         'All other arguments (i.e. target names) are passed to the "make" invocation.')
     add = parser.add_argument
     add('-C', '--directory', default='.', help='The base path of the workspace (default ".")')

--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -32,12 +32,15 @@ def main():
         return fmt('@{rf}The specified base path @{boldon}"%s"@{boldoff} does not exist' % base_path)
 
     # verify that the base path does not contain a CMakeLists.txt, except if base path equals source path
-    if (args.source is None or os.path.realpath(base_path) != os.path.realpath(args.source)) and os.path.exists(os.path.join(base_path, 'CMakeLists.txt')):
-        return fmt('@{rf}The specified base path @{boldon}"%s"@{boldoff} contains a CMakeLists.txt but "catkin_make" must be invoked in the root of workspace' % base_path)
+    if (args.source is None or os.path.realpath(base_path) != os.path.realpath(args.source)) \
+       and os.path.exists(os.path.join(base_path, 'CMakeLists.txt')):
+        return fmt(('@{rf}The specified base path @{boldon}"%s"@{boldoff} ' % base_path) +
+                   'contains a CMakeLists.txt but "catkin_make" must be invoked in the root of workspace')
 
     # verify that the base path does not contain a package.xml
     if os.path.exists(os.path.join(base_path, 'package.xml')):
-        return fmt('@{rf}The specified base path @{boldon}"%s"@{boldoff} contains a package but "catkin_make" must be invoked in the root of workspace' % base_path)
+        return fmt(('@{rf}The specified base path @{boldon}"%s"@{boldoff} ' % base_path) +
+                   'contains a package but "catkin_make" must be invoked in the root of workspace')
 
     print('Base path: %s' % base_path)
 
@@ -98,7 +101,12 @@ def main():
     # consider calling cmake
     makefile = os.path.join(build_path, 'Makefile')
     if not os.path.exists(makefile) or args.force_cmake or force_cmake:
-        cmd = ['cmake', source_path, '-DCATKIN_DEVEL_PREFIX=%s' % devel_path, '-DCMAKE_INSTALL_PREFIX=%s' % install_path]
+        cmd = [
+            'cmake',
+            source_path,
+            '-DCATKIN_DEVEL_PREFIX=%s' % devel_path,
+            '-DCMAKE_INSTALL_PREFIX=%s' % install_path
+        ]
         cmd += cmake_args
         try:
             print_command_banner(cmd, build_path, color=not args.no_color)

--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -12,7 +12,12 @@ if os.path.exists(os.path.join(os.path.dirname(__file__), 'CMakeLists.txt')):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
 from catkin.init_workspace import init_workspace
 from catkin.terminal_color import disable_ANSI_colors, fmt
-from catkin.builder import cmake_input_changed, extract_cmake_and_make_arguments, print_command_banner, run_command, run_command_colorized
+from catkin.builder import cmake_input_changed
+from catkin.builder import extract_cmake_and_make_arguments
+from catkin.builder import handle_make_arguments
+from catkin.builder import print_command_banner
+from catkin.builder import run_command
+from catkin.builder import run_command_colorized
 from catkin_pkg.packages import find_packages
 
 
@@ -129,21 +134,7 @@ def main():
 
     # invoke make
     cmd = ['make']
-    jobs = args.jobs
-    if args.jobs == '':
-        cmd.append('-j')
-    else:
-        jobs = args.jobs
-        if not jobs:
-            if 'ROS_PARALLEL_JOBS' in os.environ:
-                ros_parallel_jobs = os.environ['ROS_PARALLEL_JOBS']
-                cmd += [arg for arg in ros_parallel_jobs.split(' ') if arg]
-            else:
-                jobs = multiprocessing.cpu_count()
-        if jobs:
-            cmd.append('-j%d' % jobs)
-            cmd.append('-l%d' % jobs)
-    cmd += args.make_args
+    cmd.extend(handle_make_arguments(args.make_args))
     try:
         make_path = build_path
         if args.pkg:
@@ -157,23 +148,34 @@ def main():
 def _parse_args(args=sys.argv[1:]):
     args, cmake_args, make_args = extract_cmake_and_make_arguments(args)
 
-    parser = argparse.ArgumentParser(description='Creates the catkin workspace layout and invokes cmake and make. Any argument starting with "-D" will be passed to the "cmake" invocation. All other arguments (i.e. target names) are passed to the "make" invocation.')
-    parser.add_argument('-C', '--directory', default='.', help='The base path of the workspace (default ".")')
-    parser.add_argument('--source', help='The path to the source space (default "src")')
-    parser.add_argument('--build', help='The path to the build space (default "build")')
-    parser.add_argument('-j', '--jobs', type=int, metavar='JOBS', nargs='?', help='Specifies the number of jobs (commands) to run simultaneously. Defaults to the environment variable ROS_PARALLEL_JOBS and falls back to the number of CPU cores.')
-    parser.add_argument('--force-cmake', action='store_true', help='Invoke "cmake" even if it has been executed before')
-    parser.add_argument('--no-color', action='store_true', help='Disables colored ouput (only for catkin_make and CMake)')
-    parser.add_argument('--pkg', help='Invoke "make" on a specific package only')
-    parser.add_argument('--cmake-args', dest='cmake_args', nargs='*', type=str,
-        help='Arbitrary arguments which are passes to CMake. It must be passed after other arguments since it collects all following options.')
-    parser.add_argument('--make-args', dest='make_args', nargs='*', type=str,
-        help='Arbitrary arguments which are passes to make. It must be passed after other arguments since it collects all following options. This is only necessary in combination with --cmake-args since else all unknown arguments are passed to make anyway.')
+    parser = argparse.ArgumentParser(
+        description=
+        'Creates the catkin workspace layout and invokes cmake and make. '
+        'Any argument starting with "-D" will be passed to the "cmake" invocation. '
+        'The -j (--jobs) and -l (--load-average) arguments for make are also extracted and passed to make directly. '
+        'If no -j/-l arguments are given, then the MAKEFLAGS environment variable is searched for -j/-l flags. '
+        'If found then no -j/-l flags are passed to make explicitly (as not to override the MAKEFLAGS). '
+        'If MAKEFLAGS is not set then the environement variable ROS_PARALLEL_JOBS is used. '
+        'If the ROS_PARALLEL_JOBS variable is not defined then the flags "-jn -ln" are used, '
+        'where n is number of CPU cores or 1 if the number of cores cannot be determined. '
+        'All other arguments (i.e. target names) are passed to the "make" invocation.')
+    add = parser.add_argument
+    add('-C', '--directory', default='.', help='The base path of the workspace (default ".")')
+    add('--source', help='The path to the source space (default "src")')
+    add('--build', help='The path to the build space (default "build")')
+    add('--force-cmake', action='store_true', help='Invoke "cmake" even if it has been executed before')
+    add('--no-color', action='store_true', help='Disables colored ouput (only for catkin_make and CMake)')
+    add('--pkg', help='Invoke "make" on a specific package only')
+    add('--cmake-args', dest='cmake_args', nargs='*', type=str,
+        help='Arbitrary arguments which are passes to CMake. '
+             'It must be passed after other arguments since it collects all following options.')
+    add('--make-args', dest='make_args', nargs='*', type=str,
+        help='Arbitrary arguments which are passes to make. '
+             'It must be passed after other arguments since it collects all following options. '
+             'This is only necessary in combination with --cmake-args since else all unknown '
+             'arguments are passed to make anyway.')
 
     namespace, unknown_args = parser.parse_known_args(args)
-    # support -j/--jobs without an argument which argparse can not distinguish
-    if not namespace.jobs and [a for a in args if a == '-j' or a == '--jobs']:
-        namespace.jobs = ''
     namespace.cmake_args = cmake_args
     namespace.make_args = unknown_args + make_args
     return namespace

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -29,50 +29,36 @@ def parse_args(args=sys.argv[1:]):
     )
     add = parser.add_argument
     add('-C', '--directory', dest='workspace',
-        help='The base path of the workspace (default ".")'
-    )
+        help='The base path of the workspace (default ".")')
     add('--source', '--source-space', default=None,
-        help='The path to the source space (default "src")'
-    )
+        help='The path to the source space (default "src")')
     add('--build', '--build-space', default=None,
-        help='The path to the build space (default "build_isolated")'
-    )
+        help='The path to the build space (default "build_isolated")')
     add('--devel', '--devel-space', default=None,
-        help='Sets the target devel space (default "devel_isolated")'
-    )
+        help='Sets the target devel space (default "devel_isolated")')
     add('--merge', action='store_true', default=False,
-        help='Build each catkin package into a common devel space.'
-    )
+        help='Build each catkin package into a common devel space.')
     add('--install-space', dest='install_space', default=None,
-        help='Sets the target install space (default "install_isolated")'
-    )
+        help='Sets the target install space (default "install_isolated")')
     add('--install', action='store_true', default=False,
-        help='Causes each catkin package to be installed.'
-    )
+        help='Causes each catkin package to be installed.')
     add('-j', '--jobs', type=int, metavar='JOBS', nargs='?',
         help='Specifies the number of jobs (commands) to run simultaneously. '
-             'Defaults to the number of CPU cores.'
-    )
+             'Defaults to the number of CPU cores.')
     add('--force-cmake', action='store_true', default=False,
-        help='Runs cmake explicitly for each catkin package.'
-    )
+        help='Runs cmake explicitly for each catkin package.')
     add('--no-color', action='store_true', default=False,
-        help='Disables colored output (only for catkin_make and CMake)'
-    )
+        help='Disables colored output (only for catkin_make and CMake)')
     add('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
-        help='Invoke "make" on specific packages (only after initial invocation)'
-    )
+        help='Invoke "make" on specific packages (only after initial invocation)')
     add('-q', '--quiet', action='store_true', default=False,
-        help='Suppresses the cmake and make output until an error occurs.'
-    )
+        help='Suppresses the cmake and make output until an error occurs.')
     add('--cmake-args', dest='cmake_args', nargs='*', type=str,
         help='Arbitrary arguments which are passes to CMake. '
-             'It must be passed after other arguments since it collects all following options.'
-    )
+             'It must be passed after other arguments since it collects all following options.')
     add('--make-args', dest='make_args', nargs='*', type=str,
         help='Arbitrary arguments which are passes to make.'
-             'It must be passed after other arguments since it collects all following options.'
-    )
+             'It must be passed after other arguments since it collects all following options.')
     opts = parser.parse_args(args)
     opts.cmake_args = cmake_args
     opts.make_args = make_args

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -3,29 +3,33 @@
 from __future__ import print_function
 import argparse
 import os
+import re
 import sys
 
 # find the import relatively if available to work before installing catkin or overlaying installed version
 if os.path.exists(os.path.join(os.path.dirname(__file__), 'CMakeLists.txt')):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
-from catkin.builder import build_workspace_isolated, colorize_line, extract_cmake_and_make_arguments
+from catkin.builder import build_workspace_isolated
+from catkin.builder import colorize_line
+from catkin.builder import extract_cmake_and_make_arguments
+from catkin.builder import extract_jobs_flags
 
 
-def extract_cmake_args(args=sys.argv[1:]):
-    # extract -D* and -G* arguments
-    cmake_args = [a for a in args if a.startswith('-D') or a.startswith('-G')]
-    args = [a for a in args if a not in cmake_args]
-
-    return cmake_args, args
-
-
-def parse_args(args=sys.argv[1:]):
+def parse_args(args=None):
+    args = sys.argv[1:] if args is None else args
     args, cmake_args, make_args = extract_cmake_and_make_arguments(args)
 
+    # Extract make jobs flags
+    jobs_flags = extract_jobs_flags(' '.join(args))
+    if jobs_flags:
+        args = re.sub(jobs_flags, '', ' '.join(args)).split()
+        jobs_flags = jobs_flags.split()
+
     parser = argparse.ArgumentParser(
-        description='Builds each catkin (and non-catkin) package from '
-                    'a given workspace in isolation, but still in '
-                    'topological order.'
+        description=
+        'Builds each catkin (and non-catkin) package from a given workspace in isolation, '
+        'but still in topological order. '
+        'Make job flags (-j/-l) are handled just like catkin_make handles them.'
     )
     add = parser.add_argument
     add('-C', '--directory', dest='workspace',
@@ -42,9 +46,6 @@ def parse_args(args=sys.argv[1:]):
         help='Sets the target install space (default "install_isolated")')
     add('--install', action='store_true', default=False,
         help='Causes each catkin package to be installed.')
-    add('-j', '--jobs', type=int, metavar='JOBS', nargs='?',
-        help='Specifies the number of jobs (commands) to run simultaneously. '
-             'Defaults to the number of CPU cores.')
     add('--force-cmake', action='store_true', default=False,
         help='Runs cmake explicitly for each catkin package.')
     add('--no-color', action='store_true', default=False,
@@ -61,7 +62,7 @@ def parse_args(args=sys.argv[1:]):
              'It must be passed after other arguments since it collects all following options.')
     opts = parser.parse_args(args)
     opts.cmake_args = cmake_args
-    opts.make_args = make_args
+    opts.make_args = make_args + (jobs_flags or [])
     return opts
 
 
@@ -103,7 +104,6 @@ def main():
         installspace=opts.install_space,
         merge=opts.merge,
         install=opts.install,
-        jobs=opts.jobs,
         force_cmake=opts.force_cmake,
         colorize=not opts.no_color,
         build_packages=opts.packages,

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -167,8 +167,7 @@ def run_command(cmd, cwd, quiet=False, colorize=False):
     out = io.StringIO() if quiet else sys.stdout
     if capture:
         while True:
-            line = proc.stdout.readline().decode('utf8', 'replace')
-            line = unicode(line)
+            line = unicode(proc.stdout.readline())
             if proc.returncode is not None or not line:
                 break
             try:
@@ -242,10 +241,11 @@ def handle_make_arguments(input_make_args):
                 # Else Use the number of CPU cores
                 try:
                     jobs = multiprocessing.cpu_count()
+                    make_args.append('-j{0}'.format(jobs))
+                    make_args.append('-l{0}'.format(jobs))
                 except NotImplementedError:
-                    jobs = 1
-                make_args.append('-j{0}'.format(jobs))
-                make_args.append('-l{0}'.format(jobs))
+                    # If the number of cores cannot be determined, do not extend args
+                    pass
     return make_args
 
 

--- a/test/unit_tests/test_builder.py
+++ b/test/unit_tests/test_builder.py
@@ -2,13 +2,9 @@
 
 import os
 import unittest
-# import tempfile
-# import shutil
-# import mock
 
 try:
     import catkin.builder
-    # from catkin.builder import build_workspace_in_isolation
 except ImportError as e:
     raise ImportError(
         'Please adjust your pythonpath before running this test: %s' % str(e)
@@ -27,7 +23,7 @@ class BuilderTest(unittest.TestCase):
 
             def readline(self):
                 self.__popen.returncode = 0
-                return u'\u2018'
+                return unichr(2018)
 
         class MockPopen(object):
             def __init__(self, *args, **kwargs):

--- a/test/unit_tests/test_builder.py
+++ b/test/unit_tests/test_builder.py
@@ -38,3 +38,28 @@ class BuilderTest(unittest.TestCase):
             catkin.builder.run_command(['false'], os.getcwd(), True, True)
         finally:
             catkin.builder.subprocess.Popen = backup_Popen
+
+    def test_extract_jobs_flags(self):
+        valid_mflags = [
+            '-j8 -l8', 'j8 ', '-j', 'j', '-l8', 'l8',
+            '-l', 'l', '-j18', ' -j8 l9', '-j1 -l1',
+            '--jobs=8', '--jobs 8', '--jobs', '--load-average',
+            '--load-average=8', '--load-average 8', '--jobs=8 -l9'
+        ]
+        results = [
+            '-j8 -l8', 'j8', '-j', 'j', '-l8', 'l8',
+            '-l', 'l', '-j18', '-j8 l9', '-j1 -l1',
+            '--jobs=8', '--jobs 8', '--jobs', '--load-average',
+            '--load-average=8', '--load-average 8', '--jobs=8 -l9'
+        ]
+        for mflag, result in zip(valid_mflags, results):
+            match = catkin.builder.extract_jobs_flags(mflag)
+            assert match == result, "should match '{0}'".format(mflag)
+            print('--')
+            print("input:    '{0}'".format(mflag))
+            print("matched:  '{0}'".format(match))
+            print("expected: '{0}'".format(result))
+        invalid_mflags = ['', '--jobs= 8', '--jobs8']
+        for mflag in invalid_mflags:
+            match = catkin.builder.extract_jobs_flags(mflag)
+            assert match is None, "should not match '{0}'".format(mflag)


### PR DESCRIPTION
Currently `caktin_make*` programs always give job  arguments to `make`, even if none are passed to them directly, e.g. `catkin_make` -> `make -j8 -l8` and `catkin_make -j1` -> `make -j1 -l1`.

This prevents the Make environment variable `MAKEFLAGS` from working with `catkin_make*`. I propose a new logic for handling `-j`, `--jobs`, `-l`, `--load-average` arguments:

![catkin_make_jobs](https://f.cloud.github.com/assets/100427/311426/13b6a926-9740-11e2-9c62-be97216f48d6.png)

This will allow users to override the make job options with direct arguments to `catkin_make*`, `MAKEFLAGS`, or `ROS_PARALLEL_JOBS`.

_EDIT:_ Removed references to `CATKIN_PARALLEL_JOBS` because it is overshadowed by `MAKEFLAGS` and direct arguments, and I did not want it to have the same weird specification as `ROS_PARALLEL_JOBS` where it has flags for make not just a number.
