### PR TITLE
catkin_prepare_release should validate metapackages

### DIFF
--- a/bin/catkin_prepare_release
+++ b/bin/catkin_prepare_release
@@ -6,6 +6,7 @@ import os
 import sys
 
 from catkin_pkg.packages import find_packages, verify_equal_package_versions
+from catkin_pkg import metapackage
 
 # find the import relatively if available to work before installing catkin or overlaying installed version
 if os.path.exists(os.path.join(os.path.dirname(__file__), 'CMakeLists.txt')):
@@ -68,6 +69,14 @@ def main():
     if not packages:
         print('No packages found', file=sys.stderr)
         sys.exit(1)
+    for path, package in packages.iteritems():
+        if metapackage.is_metapackage(package):
+            try:
+                metapackage.validate_metapackage(path, package, warnings=True)
+            except metapackage.InvalidMetapackage as e:
+                print("Invalid metapackage at path '%s':\n  %s\n" % (os.path.abspath(path), str(e)))
+                print("See requirements for metapackages: %s" % metapackage.DEFINITION_URL)
+                sys.exit(1)
     old_version = verify_equal_package_versions(packages.values())
     new_version = bump_version(old_version, args.bump)
 

--- a/bin/catkin_prepare_release
+++ b/bin/catkin_prepare_release
@@ -74,8 +74,8 @@ def main():
             try:
                 metapackage.validate_metapackage(path, package, warnings=True)
             except metapackage.InvalidMetapackage as e:
-                print("Invalid metapackage at path '%s':\n  %s\n" % (os.path.abspath(path), str(e)))
-                print("See requirements for metapackages: %s" % metapackage.DEFINITION_URL)
+                print("Invalid metapackage at path '%s':\n  %s\n" % (os.path.abspath(path), str(e)), file=sys.stderr)
+                print("See requirements for metapackages: %s" % metapackage.DEFINITION_URL, file=sys.stderr)
                 sys.exit(1)
     old_version = verify_equal_package_versions(packages.values())
     new_version = bump_version(old_version, args.bump)

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,7 @@
   <run_depend>cmake</run_depend>
   <run_depend>gtest</run_depend>
   <run_depend>python-argparse</run_depend>
-  <run_depend version_gte="0.1.10">python-catkin-pkg</run_depend>
+  <run_depend version_gte="0.1.11">python-catkin-pkg</run_depend>
   <run_depend>python-empy</run_depend>
   <run_depend>python-nose</run_depend>
 


### PR DESCRIPTION
Specifically that they have valid `CMakeLists.txt`. A lot of people are going to run into this problem while releasing with bloom. It would be nice to have this tool check.

It could output:

```
cat <<EOF
Metapackage <metapackage_name> does not have a valid CMakeLists.txt, therefore it does not conform to REP-0127, see: http://ros.org/reps/rep-0127.html#metapackage

The CMakeLists.txt should look like this:
<CMakeLists.txt that was expected>
EOF
```

Instead of its normal command output, which would be safe for people doing something like this:

```
`catkin_prepare_release`
```
