### PR TITLE
Added --ignore-alias to 'which' calls in setup.sh

### DIFF
--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -14,7 +14,7 @@ if [ ! -f "$_SETUP_UTIL" ]; then
 fi
 
 # detect if running on Darwin platform
-_UNAME=`which uname`
+_UNAME=`which uname --skip-alias`
 _UNAME=`$_UNAME`
 _IS_DARWIN=0
 if [ "$_UNAME" = "Darwin" ]; then
@@ -39,7 +39,7 @@ if [ -z "$CATKIN_SHELL" ]; then
 fi
 
 # invoke Python script to generate necessary exports of environment variables
-_MKTEMP=`which mktemp`
+_MKTEMP=`which mktemp --skip-alias`
 _SETUP_TMP=`$_MKTEMP /tmp/setup.sh.XXXXXXXXXX`
 if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
   echo "Could not create temporary file: $_SETUP_TMP"
@@ -47,7 +47,7 @@ if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
 fi
 CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ > $_SETUP_TMP
 . $_SETUP_TMP
-_RM=`which rm`
+_RM=`which rm --skip-alias`
 $_RM $_SETUP_TMP
 
 # source all environment hooks

--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -14,7 +14,7 @@ if [ ! -f "$_SETUP_UTIL" ]; then
 fi
 
 # detect if running on Darwin platform
-_UNAME=`which uname --skip-alias`
+_UNAME=`which -a uname | grep -v ^alias | head -1`
 _UNAME=`$_UNAME`
 _IS_DARWIN=0
 if [ "$_UNAME" = "Darwin" ]; then
@@ -39,7 +39,7 @@ if [ -z "$CATKIN_SHELL" ]; then
 fi
 
 # invoke Python script to generate necessary exports of environment variables
-_MKTEMP=`which mktemp --skip-alias`
+_MKTEMP=`which -a mktemp | grep -v ^alias | head -1`
 _SETUP_TMP=`$_MKTEMP /tmp/setup.sh.XXXXXXXXXX`
 if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
   echo "Could not create temporary file: $_SETUP_TMP"
@@ -47,7 +47,7 @@ if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
 fi
 CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ > $_SETUP_TMP
 . $_SETUP_TMP
-_RM=`which rm --skip-alias`
+_RM=`which -a rm | grep -v ^alias | head -1`
 $_RM $_SETUP_TMP
 
 # source all environment hooks


### PR DESCRIPTION
On some systems, rm has a bash alias, often something like:
alias rm='rm -i'
/usr/bin/rm

This causes the setup.sh to not only fail to rm the file it intended, but also corrupt the alias that was present to begin with, causing rm to fail until the alias is fixed or the shell is restarted. Which has a --ignore-alias feature which will fix the issue.
