### PR TITLE
Documentation + base.rosinstall update

### DIFF
--- a/doc/adv_user_guide/underlay.rst
+++ b/doc/adv_user_guide/underlay.rst
@@ -22,7 +22,7 @@ Pick a temp directory::
 
 Get the rosinstall file::
 
-   $ wget https://raw.github.com/ros/catkin/master/rosinstalls/base.rosinstall
+   $ wget https://raw.github.com/ros/catkin/groovy-devel/rosinstalls/base.rosinstall
 
 .. todo:: get the file from outside catkin
 

--- a/rosinstalls/base.rosinstall
+++ b/rosinstalls/base.rosinstall
@@ -1,27 +1,27 @@
 - git:
     uri: 'git://github.com/ros/catkin.git'
     local-name: catkin
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/genmsg.git'
     local-name: genmsg
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/gencpp.git'
     local-name: gencpp
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/genlisp.git'
     local-name: genlisp
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/genpy.git'
     local-name: genpy
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/langs.git'
@@ -36,12 +36,12 @@
 - git:
     uri: 'git://github.com/ros/std_msgs.git'
     local-name: std_msgs
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/roscpp_core.git'
     local-name: roscpp_core
-    version: master
+    version: groovy-devel
 
 - git:
     uri: 'git://github.com/ros/ros_comm.git'
@@ -58,11 +58,14 @@
 - git:
     uri: 'git://github.com/ros/common_msgs.git'
     local-name: common_msgs
+    version: groovy-devel
 
-- hg:
+- git:
+    uri: 'git://github.com/ros/rospack.git'
     local-name: rospack
-    uri: https://kforge.ros.org/rosrelease/rospack
+    version: groovy-devel
 
-- hg:
+- git:
+    uri: 'git://github.com/ros/actionlib.git'
     local-name: actionlib
-    uri: https://kforge.ros.org/common/actionlib
+    version: groovy-devel


### PR DESCRIPTION
I encountered two errors following the directions to build a ROS underlay:
http://ros.org/doc/groovy/api/catkin/html/adv_user_guide/underlay.html
1) The URL for the rosinstall file was wrong
2) Some of URI's in the rosinstall file were out of date / broken.

As everything in the rosinstall file is for groovy, perhaps it'd also be a good idea to rename base.rosinstall -> groovy_base.rosinstall or something similar?
