### PR TITLE
fix chaining of plain cmake packages: remove exec '' statement

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -480,10 +480,7 @@ fi
 export PATH="{path}$PATH"
 export PKG_CONFIG_PATH="{pkgcfg_path}$PKG_CONFIG_PATH"
 export PYTHONPATH="{pythonpath}$PYTHONPATH"
-
-exec "$@"
-""".format(**subs)
-        )
+""".format(**subs))
 
 
 def build_package(


### PR DESCRIPTION
Signed-off-by: Ruben Smits ruben.smits@mech.kuleuven.be
