### PR TITLE
Fixed bug where IFS shell var would get set to empty string

### DIFF
--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -50,12 +50,25 @@ CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ > $_SETUP_TMP
 _RM=`which rm`
 $_RM $_SETUP_TMP
 
-# source all environment hooks
+# Save value of IFS, including if it was unset.
+# (the "+x" syntax helps differentiate unset from empty string)
+if [ -z ${IFS+x} ]; then
+    _IFS_WAS_UNSET=1
+fi
 _IFS=$IFS
+
+# source all environment hooks
 IFS=":"
 for _envfile in $_CATKIN_ENVIRONMENT_HOOKS; do
   IFS=$_IFS
   . "$_envfile"
 done
+
+# Restore value of IFS, including if it was unset
 IFS=$_IFS
+if [ $_IFS_WAS_UNSET ]; then
+  unset IFS
+fi
+unset _IFS_WAS_UNSET
+unset _IFS
 unset _CATKIN_ENVIRONMENT_HOOKS


### PR DESCRIPTION
I have tested the old version and seen the problem, then tried with this new version, and the problem is gone.

IFS info: http://stackoverflow.com/questions/16719770/what-can-change-command-substitution-behavior-in-bash and http://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html

The bug was that after source-ing the setup.bash my IFS shell var would be set to the empty string, which means it does NO word splitting.  The original behavior is when IFS is UNSET which means split on any white space.
