### PR TITLE
Android does not need -lrt

### DIFF
--- a/cmake/tools/rt.cmake
+++ b/cmake/tools/rt.cmake
@@ -31,7 +31,7 @@
 # message("CMAKE_SYSTEM_LIBRARY_PATH: ${CMAKE_SYSTEM_LIBRARY_PATH}")
 # message("CMAKE_VERSION=${CMAKE_VERSION}")
 
-if(NOT (APPLE OR WIN32 OR MINGW))
+if(NOT (APPLE OR WIN32 OR MINGW OR ANDROID))
   if (${CMAKE_VERSION} VERSION_LESS 2.8.4)
     # cmake later than 2.8.0 appears to have a better find_library
     # that knows about the ABI of the compiler.  For lucid we just


### PR DESCRIPTION
This enables the use of catkin with an android cross toolchain that defines _ANDROID_
