### PR TITLE
add new CMake function catkin_download_test_data

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -120,6 +120,7 @@ foreach(filename
     platform/lsb
     platform/ubuntu
     platform/windows
+    test/catkin_download_test_data
     test/download_test_data
     test/gtest
     test/nosetests

--- a/cmake/test/catkin_download_test_data.cmake
+++ b/cmake/test/catkin_download_test_data.cmake
@@ -1,0 +1,48 @@
+#
+# Download a file containing test data from a URL.
+#
+# It is commonly used to download larger data files for unit tests
+# which should not be stored in the repository.
+#
+# .. note:: The target will be registered as a dependency
+#   of the "tests" target.
+#
+# .. note:: If the tests should be run on the ROS buildfarm the URL
+#   must be publically and reliably accessible.
+#
+# :param target: the target name
+# :type target: string
+# :param url: the url to download
+# :type url: string
+
+# :param DESTINATION: the directory where the file is downloaded to
+#   (default: ${PROJECT_BINARY_DIR})
+# :type DESTINATION: string
+# :param FILENAME: the filename of the downloaded file
+#   (default: the basename of the url)
+# :type FILENAME: string
+# :param MD5: the expected md5 hash to compare against
+#   (default: empty, skipping the check)
+# :type MD5: string
+#
+# @public
+function(catkin_download_test_data target url)
+  cmake_parse_arguments(ARG "" "DESTINATION;FILENAME;MD5" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "catkin_download_test_data() called with unused arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+  if(NOT ARG_DESTINATION)
+    set(ARG_DESTINATION ${PROJECT_BINARY_DIR})
+  endif()
+  if(NOT ARG_FILENAME)
+    get_filename_component(ARG_FILENAME ${url} NAME)
+  endif()
+  set(output "${ARG_DESTINATION}/${ARG_FILENAME}")
+  add_custom_command(OUTPUT ${output}
+    COMMAND ${catkin_EXTRAS_DIR}/test/download_checkmd5.py ${url} ${output} ${ARG_MD5}
+    VERBATIM)
+  add_custom_target(${target} DEPENDS ${output})
+  if(TARGET tests)
+    add_dependencies(tests ${target})
+  endif()
+endfunction()

--- a/cmake/test/download_test_data.cmake
+++ b/cmake/test/download_test_data.cmake
@@ -2,9 +2,6 @@
 function(download_test_data _url _filename _md5)
   # create a legal target name, in case the target name has slashes in it
   string(REPLACE "/" "_" _testname download_data_${_filename})
-  add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/${_filename}
-    COMMAND ${catkin_EXTRAS_DIR}/test/download_checkmd5.py ${_url} ${PROJECT_BINARY_DIR}/${_filename} ${_md5}
-    VERBATIM)
-  add_custom_target(${_testname} DEPENDS ${PROJECT_BINARY_DIR}/${_filename})
-  add_dependencies(tests ${_testname})
+  message(WARNING "download_test_data() is deprecated, please use catkin_download_test_data() instead.\nUse the following signature:\ncatkin_download_test_data(${_testname} ${_url} FILENAME ${_filename} MD5 ${_md5})")
+  catkin_download_test_data(${_testname} ${_url} FILENAME ${_filename} MD5 ${_md5})
 endfunction()


### PR DESCRIPTION
mark download_test_data as deprecated.

Based on the discussion in #426 I have added a new download function with the necessary API to use it in any way suggested in there. It also exposes the target name explicitly (as any other CMake function) to enable the user land code to add custom dependencies.
