### PR TITLE
Add the --from-pkg option to catkin_make_isolated

### DIFF
--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -50,8 +50,11 @@ def parse_args(args=None):
         help='Runs cmake explicitly for each catkin package.')
     add('--no-color', action='store_true', default=False,
         help='Disables colored output (only for catkin_make and CMake)')
-    add('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
-        help='Invoke "make" on specific packages (only after initial invocation)')
+    pkg = parser.add_mutually_exclusive_group(required=False)
+    pkg.add_argument('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
+                     help='Invoke "make" on specific packages (only after initial invocation)')
+    pkg.add_argument('--from-pkg', metavar='PKGNAME', dest='from_package',
+                     help='Restart catkin_make_isolated at the given package continuing from there.')
     add('-q', '--quiet', action='store_true', default=False,
         help='Suppresses the cmake and make output until an error occurs.')
     add('--cmake-args', dest='cmake_args', nargs='*', type=str,
@@ -114,11 +117,12 @@ def main():
         install=opts.install,
         force_cmake=opts.force_cmake,
         colorize=not opts.no_color,
-        build_packages=opts.packages,
+        build_packages=opts.packages or ([] if opts.from_package is None else [opts.from_package]),
         quiet=opts.quiet,
         cmake_args=cmake_args,
         make_args=opts.make_args,
-        catkin_make_args=opts.catkin_make_args
+        catkin_make_args=opts.catkin_make_args,
+        continue_from_pkg=opts.from_package is not None
     )
 
 if __name__ == '__main__':

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -552,7 +552,8 @@ def build_workspace_isolated(
     quiet=False,
     cmake_args=None,
     make_args=None,
-    catkin_make_args=None
+    catkin_make_args=None,
+    continue_from_pkg=False
 ):
     '''
     Runs ``cmake``, ``make`` and optionally ``make install`` for all
@@ -581,6 +582,8 @@ def build_workspace_isolated(
     :param make_args: additional arguments for make, ``[str]``
     :param catkin_make_args: additional arguments for make but only for catkin
         packages, ``[str]``
+    :param continue_from_pkg: indicates whether or not cmi should continue
+        when a package is reached, ``bool``
     '''
     if not colorize:
         disable_ANSI_colors()
@@ -706,6 +709,8 @@ def build_workspace_isolated(
         else:
             pkg_develspace = os.path.join(develspace, package.name)
         if not build_packages or package.name in build_packages:
+            if continue_from_pkg and build_packages and package.name in build_packages:
+                build_packages = None
             try:
                 export_tags = [e.tagname for e in package.exports]
                 is_cmake_package = 'cmake' in [e.content for e in package.exports if e.tagname == 'build_type']


### PR DESCRIPTION
This is mutually exclusive with --pkg and takes
a single package which all packages leading up to
it are skipped, it is built and then the process
continues as normal.
