### PR TITLE
Add another major version number pattern in find_program (fix #461)

### DIFF
--- a/cmake/test/nosetests.cmake
+++ b/cmake/test/nosetests.cmake
@@ -88,7 +88,7 @@ endfunction()
 find_program(NOSETESTS nosetests)
 if(NOT nosetests_path)
   # retry with name including major version number
-  find_program(NOSETESTS nosetests2)
+  find_program(NOSETESTS NAMES nosetests2 nosetests-2)
 endif()
 if(NOT NOSETESTS)
   message(WARNING "nosetests not found, Python tests can not be run (try installing package 'python-nose')")


### PR DESCRIPTION
Fix to https://github.com/ros/catkin/issues/461

I'm not sure if this is the best patch for the targeted issue since I'm not an expert with `cmake`. But this seems to find `nosetests-2.7` on my `QNX`. 

`catkin_make` also runs fine on my Ubuntu Quantal.
