### PR TITLE
Remove spare parenthesis in documentation.

### DIFF
--- a/doc/howto/installing_python.rst
+++ b/doc/howto/installing_python.rst
@@ -74,7 +74,6 @@ layout, it looks like this::
   setup_args = generate_distutils_setup(
       packages=['your_package'],
       package_dir={'': 'src'})
-  )
   
   setup(**setup_args)
 


### PR DESCRIPTION
I tried to copy and paste the example, and it failed. Fixed.
