### PR TITLE
Suppress a traceback when a package fails to build

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -728,7 +728,11 @@ def build_workspace_isolated(
                 )
             except subprocess.CalledProcessError as e:
                 _print_build_error(package, e)
-                cmd = ' '.join(e.cmd) if isinstance(e.cmd, list) else e.cmd
+                # Let users know how to reproduce
+                # First add the cd to the buildspace
+                cmd = 'cd ' + buildspace + ' && '
+                # Then reproduce the command called
+                cmd += ' '.join(e.cmd) if isinstance(e.cmd, list) else e.cmd
                 print(fmt("\n@{rf}Reproduce this error by running:"))
                 print(fmt("@{gf}@!==> @|") + cmd + "\n")
                 sys.exit('Command failed, exiting.')

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -722,8 +722,10 @@ def build_workspace_isolated(
                     number=index + 1, of=len(ordered_packages)
                 )
             except Exception as e:
-                import traceback
-                traceback.print_exc()
+                if not isinstance(e, subprocess.CalledProcessError):
+                    print("Unhandled exception of type '{0}':".format(type(e).__name__))
+                    import traceback
+                    traceback.print_exc()
                 cprint(
                     '@{rf}@!<==@| ' +
                     'Failed to process package \'@!@{bf}' +


### PR DESCRIPTION
When a package fails in cmi I get something like this:

```
-- Configuring incomplete, errors occurred!
Traceback (most recent call last):
  File "./src/catkin/bin/../python/catkin/builder.py", line 722, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "./src/catkin/bin/../python/catkin/builder.py", line 497, in build_package
    install, force_cmake, quiet, last_env, cmake_args, make_args + catkin_make_args
  File "./src/catkin/bin/../python/catkin/builder.py", line 330, in build_catkin_package
    run_command_colorized(cmake_cmd, build_dir, quiet)
  File "./src/catkin/bin/../python/catkin/builder.py", line 166, in run_command_colorized
    run_command(cmd, cwd, quiet=quiet, colorize=True)
  File "./src/catkin/bin/../python/catkin/builder.py", line 198, in run_command
    raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
CalledProcessError: Command '/private/tmp/common_tutorials_ws/install_isolated/env.sh cmake /private/tmp/common_tutorials_ws/src/nodelet_core/nodelet_topic_tools -DCATKIN_DEVEL_PREFIX=/private/tmp/common_tutorials_ws/devel_isolated/nodelet_topic_tools -DCMAKE_INSTALL_PREFIX=/private/tmp/common_tutorials_ws/install_isolated' returned non-zero exit status 1
<== Failed to process package 'nodelet_topic_tools':
  Command '/private/tmp/common_tutorials_ws/install_isolated/env.sh cmake /private/tmp/common_tutorials_ws/src/nodelet_core/nodelet_topic_tools -DCATKIN_DEVEL_PREFIX=/private/tmp/common_tutorials_ws/devel_isolated/nodelet_topic_tools -DCMAKE_INSTALL_PREFIX=/private/tmp/common_tutorials_ws/install_isolated' returned non-zero exit status 1
```

Which has a traceback in it, when it is obviously a package failure, we should not print the traceback. The result looks like this:

```
-- Configuring incomplete, errors occurred!
<== Failed to process package 'nodelet_topic_tools':
  Command '/private/tmp/common_tutorials_ws/install_isolated/env.sh cmake /private/tmp/common_tutorials_ws/src/nodelet_core/nodelet_topic_tools -DCATKIN_DEVEL_PREFIX=/private/tmp/common_tutorials_ws/devel_isolated/nodelet_topic_tools -DCMAKE_INSTALL_PREFIX=/private/tmp/common_tutorials_ws/install_isolated' returned non-zero exit status 1

Reproduce this error by running:
==> /private/tmp/common_tutorials_ws/install_isolated/env.sh cmake /private/tmp/common_tutorials_ws/src/nodelet_core/nodelet_topic_tools -DCATKIN_DEVEL_PREFIX=/private/tmp/common_tutorials_ws/devel_isolated/nodelet_topic_tools -DCMAKE_INSTALL_PREFIX=/private/tmp/common_tutorials_ws/install_isolated

Command failed, exiting.
```
