### PR TITLE
Minor documentation fixes for libraries and python install

### DIFF
--- a/doc/howto/building_libraries.rst
+++ b/doc/howto/building_libraries.rst
@@ -91,7 +91,7 @@ Libraries typically provide headers defining their interfaces.  Please
 follow standard ROS practice and place all external header files under
 ``include/your_package/``::
 
-  install(DIRECTORY include/${PACKAGE_NAME}/
+  install(DIRECTORY include/${PROJECT_NAME}/
           DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 That command installs all the files in your package's include subtree.
@@ -99,7 +99,7 @@ Place only your exported headers there.  If yours is a Subversion_
 repository, don't forget to exclude the ``.svn`` subdirectories like
 this::
 
-  install(DIRECTORY include/${PACKAGE_NAME}/
+  install(DIRECTORY include/${PROJECT_NAME}/
           DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
           PATTERN ".svn" EXCLUDE)
 

--- a/doc/howto/installing_python.rst
+++ b/doc/howto/installing_python.rst
@@ -26,6 +26,7 @@ that directory::
 
   install(DIRECTORY scripts/
           DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+          USE_SOURCE_PERMISSIONS
           PATTERN ".svn" EXCLUDE)
 
 The ``PATTERN ".svn" EXCLUDE`` is only needed if you use a Subversion_


### PR DESCRIPTION
The project name is PROJECT_NAME, not PACKAGE_NAME.
Fix the install permissions for a directory full of scripts.
