### PR TITLE
Fix for Python3.2 compatibility

### DIFF
--- a/python/catkin/tidy_xml.py
+++ b/python/catkin/tidy_xml.py
@@ -30,6 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import unicode_literals
 import codecs
 import os
 import re
@@ -37,12 +38,14 @@ import re
 # unit test suites are not good about screening out illegal unicode characters (#603)
 # recipe from http://boodebr.org/main/python/all-about-python-and-unicode#UNI_XML
 # code copied from rosunit/src/junitxml.py
-RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
-                 u'|' + \
-                 u'([%s-%s][^%s-%s])|([^%s-%s][%s-%s])|([%s-%s]$)|(^[%s-%s])' % \
-                 (unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
-                  unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
-                  unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
+
+
+RE_XML_ILLEGAL = '([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
+    '|' + \
+    '([%s-%s][^%s-%s])|([^%s-%s][%s-%s])|([%s-%s]$)|(^[%s-%s])' % \
+    (unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
+     unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
+     unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
 _SAFE_XML_REGEX = re.compile(RE_XML_ILLEGAL)
 
 


### PR DESCRIPTION
Current implementation breaks compatibility with Python3.2. This simple fix should work for all Python versions between 2.7 and 3.3 making catkin usable in all these versions.

Unittest works for Python2.7, however it does not work for Python3. I did not adapt the unittest towards Python3 since I guess it is meant for Python2.7 and porting unit tests to Python3 is a whole other topic which should probably be addressed somewhen in the future...
