### PR TITLE
add RUBYLIB=lib/ruby/vendor_ruby to setup.bash for ruby programs

### DIFF
--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -55,6 +55,7 @@ ENV_VAR_SUBFOLDERS = {
     'PATH': '@CATKIN_GLOBAL_BIN_DESTINATION@',
     'PKG_CONFIG_PATH': 'lib/pkgconfig',
     'PYTHONPATH': '@PYTHON_INSTALL_DIR@',
+    'RUBYLIB': 'lib/ruby/vendor_ruby',
 }
 
 


### PR DESCRIPTION
I want to add ruby library path for setup.sh.

I'm releasing rosruby, and it needs additional environmental variable " RUBYLIB=/opt/ros/hydro/lib/ruvy/vendor_ruby".
If catkin_init_workspace supports this variable generation, it is more easy to use ros ruby libraries.
