### PR TITLE
Support for spaces in path

### DIFF
--- a/cmake/templates/env.sh.in
+++ b/cmake/templates/env.sh.in
@@ -8,6 +8,6 @@ if [ $# -eq 0 ] ; then
 fi
 
 # source @SETUP_FILENAME@.sh from same directory as this file
-_CATKIN_SETUP_DIR=$(cd `dirname $0`;pwd)
+_CATKIN_SETUP_DIR=$(dirname "$0")
 . "$_CATKIN_SETUP_DIR/@SETUP_FILENAME@.sh"
 exec "$@"

--- a/cmake/templates/setup.bash.in
+++ b/cmake/templates/setup.bash.in
@@ -4,5 +4,5 @@
 CATKIN_SHELL=bash
 
 # source setup.sh from same directory as this file
-_CATKIN_SETUP_DIR=$(cd `dirname ${BASH_SOURCE[0]}`;pwd)
+_CATKIN_SETUP_DIR=$(dirname "${BASH_SOURCE[0]}")
 . "$_CATKIN_SETUP_DIR/setup.sh"

--- a/cmake/templates/setup.zsh.in
+++ b/cmake/templates/setup.zsh.in
@@ -2,7 +2,7 @@
 # generated from catkin/cmake/templates/setup.zsh.in
 
 CATKIN_SHELL=zsh
-_CATKIN_SETUP_DIR=$(cd `dirname $0`;pwd)
+_CATKIN_SETUP_DIR=$(dirname "$0")
 emulate sh # emulate POSIX
 . "$_CATKIN_SETUP_DIR/setup.sh"
 emulate zsh # back to zsh mode


### PR DESCRIPTION
There is very commonly spaces in ros workspace path...

EDIT: Fixed setup.bash and setup.zsh too.
