### PR TITLE
catkin_make_isolated: fix setup generation when plain cmake package is last in workspace (fix #530)

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -509,9 +509,13 @@ exec "$@"
 #!/usr/bin/env sh
 # generated from catkin.builder module
 
+# remember type of shell if not already set
+if [ -z "$CATKIN_SHELL" ]; then
+  CATKIN_SHELL=sh
+fi
 """)
             if last_env is not None:
-                file_handle.write('. %s\n\n' % last_setup_env)
+                file_handle.write('. %s.$CATKIN_SHELL\n\n' % last_setup_env[:-3])
             file_handle.write("""\
 # detect if running on Darwin platform
 _UNAME=`uname -s`
@@ -531,6 +535,20 @@ export PATH="{path}$PATH"
 export PKG_CONFIG_PATH="{pkgcfg_path}$PKG_CONFIG_PATH"
 export PYTHONPATH="{pythonpath}$PYTHONPATH"
 """.format(**subs))
+
+        # generate setup.bash|zsh scripts
+        for shell in ['bash', 'zsh']:
+            setup_path = os.path.join(install_target, 'setup.%s' % shell)
+            if install:
+                setup_path = prefix_destdir(setup_path, destdir)
+            with open(setup_path, 'w') as f:
+                f.write("""\
+#!/usr/bin/env {1}
+# generated from catkin.builder module
+
+CATKIN_SHELL={1}
+. "{0}/setup.sh"
+""".format(os.path.dirname(setup_path), shell))
 
 
 def build_package(


### PR DESCRIPTION
First, it generates setup.bash|zsh script for plain cmake package (to make the next step easier).
Second, the setup.sh for plain packages now relays to the parent setup with the currently selected CATKIN_SHELL.

@wjwwood @scpeters Please review
