### PR TITLE
catkin_FOUND variable was never set

### DIFF
--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -34,7 +34,9 @@ endif()
 
 # mark as found
 if(NOT catkin_FOUND)
-  set(catkin_FOUND)
+  # cmake will set catkin_FOUND automatically after this config file has been read
+  # but other cmake configuration files of packages mentioned in the COMPONENTS list might need it already
+  set(catkin_FOUND True)
   set(CATKIN_PACKAGE_PREFIX "" CACHE STRING "Prefix to apply to package generated via gendebian")
 endif()
 


### PR DESCRIPTION
Shouldn't this be

```
  set(catkin_FOUND 1)
```

instead of

```
  set(catkin_FOUND)
```

?

From http://www.cmake.org/cmake/help/v2.8.3/cmake.html#command:set:

> If <value> is not specified then the variable is removed instead of set. See also: the unset() command.

Seems that `catkin_FOUND` was never set since the beginning of time...
