### PR TITLE
fix order of catkin_LIBRARIES

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -112,6 +112,7 @@ foreach(filename
     empy
     find_program_required
     legacy
+    list_append_deduplicate
     list_append_unique
     list_insert_in_workspace_order
     parse_arguments

--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -81,7 +81,7 @@ foreach(component ${catkin_FIND_COMPONENTS})
 
     # append component-specific variables to catkin_* variables
     list_append_unique(catkin_INCLUDE_DIRS ${${component}_INCLUDE_DIRS})
-    list_append_unique(catkin_LIBRARIES ${${component}_LIBRARIES})
+    list_append_deduplicate(catkin_LIBRARIES ${${component}_LIBRARIES})
     list_append_unique(catkin_LIBRARY_DIRS ${${component}_LIBRARY_DIRS})
     list(APPEND catkin_EXPORTED_TARGETS ${${component}_EXPORTED_TARGETS})
   endif()

--- a/cmake/list_append_deduplicate.cmake
+++ b/cmake/list_append_deduplicate.cmake
@@ -1,0 +1,14 @@
+#
+# Append elements to a list and remove existing duplicates from the list.
+#
+# .. note:: Using CMake's ``list(APPEND ..)`` and
+#   ``list(REMOVE_DUPLICATES ..)`` is not sufficient since its
+#   implementation uses a set internally which makes the operation
+#   unstable.
+#
+macro(list_append_deduplicate listname)
+  if(NOT "${ARGN}" STREQUAL "")
+    list(REMOVE_ITEM ${listname} ${ARGN})
+    list(APPEND ${listname} ${ARGN})
+  endif()
+endmacro()

--- a/cmake/list_append_unique.cmake
+++ b/cmake/list_append_unique.cmake
@@ -2,8 +2,9 @@
 # Append elements to a list if they are not already in the list.
 #
 # .. note:: Using CMake's ``list(APPEND ..)`` and
-#   ``list(REMOVE_DUPLICATES ..)`` since its implementation uses a
-#   set internally which make the operation unstable.
+#   ``list(REMOVE_DUPLICATES ..)`` is not sufficient since its
+#   implementation uses a set internally which makes the operation
+#   unstable.
 #
 macro(list_append_unique listname)
   foreach(_item ${ARGN})


### PR DESCRIPTION
Instead of not adding duplicate library names at the end the libraries should always be appended to maintain correct order (especially valid when using static libraries). Before appending them existing duplicates are being removed from the list.

As long as we have no circular dependencies between libraries this should work fine. Since packages already forbid such a dependency cycle that should never be the case.

@tfoote @wjwwood Please review.
