### PR TITLE
Fix to actually build run_depends before the things that depend on them with catkin_make_isolated

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -931,7 +931,7 @@ def get_package_names_with_recursive_dependencies(packages, pkg_names):
         if pkg_name in packages_by_name:
             pkg = packages_by_name[pkg_name]
             dependencies.add(pkg_name)
-            for dep in [dep.name for dep in (pkg.build_depends + pkg.buildtool_depends)]:
+            for dep in [dep.name for dep in (pkg.build_depends + pkg.buildtool_depends + pkg.run_depends)]:
                 if dep in packages_by_name and dep not in check_pkg_names and dep not in dependencies:
                     check_pkg_names.add(dep)
     return dependencies


### PR DESCRIPTION
This is the quick fix I made to be able to run `catkin_make_isolated` with the `--only-pkg-with-deps` argument for a source build of ROS. I'm not sure if changing the behavior of `get_package_names_with_recursive_dependencies` to also recurse to run_depends is kosher. If so, this patch should fix things. If not, `--only-pkg-with-deps` probably needs to call another function that does.

Thoughts?
