### PR TITLE
Using catkin_make_isolated to build Debian packages for a mixed catkin/cmake workspace

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -464,7 +464,7 @@ def build_cmake_package(
     run_command(make_install_cmd, build_dir, quiet)
 
     # If we are installing, and a env.sh exists, don't overwrite it
-    if install and os.path.exists(os.path.join(installspace, 'env.sh')):
+    if install and os.path.exists(prefix_destdir(os.path.join(install_target, 'env.sh'), destdir)):
         return
     cprint(blue_arrow + " Generating an env.sh")
     # Generate env.sh for chaining to catkin packages


### PR DESCRIPTION
I was trying to build a Debian package that contains multiple ROS packages by wrapping `catkin_make_isolated` in a simple Makefile in the root of a workspace that contains catkin and cmake packages. That works quite well, but I had to apply this patch so that catkin generates the environment in the `DESTDIR` prefixed install-space (if the `env.sh` in the real install directory already exists) or does not overwrite catkin-generated setup files (if no `env.sh` file is present in the real install directory). Except of this little problem catkin_make_isolated seems to respect the `DESTDIR` variable set by `dh_auto_install`.

Is there an "official" way to use catkin and/or bloom to generate Debian packages for a whole workspace instead for single packages?
