### PR TITLE
catkin_make_isolated should provide rosbuild parallelity

### DIFF
--- a/bin/pcmi
+++ b/bin/pcmi
@@ -5,7 +5,8 @@ from __future__ import print_function
 import os
 import sys
 
-if os.path.exists(os.path.join(os.path.dirname(__file__), 'CMakeLists.txt')):
+# find the import relatively if available to work before installing catkin or overlaying installed version
+if os.path.exists(os.path.join(os.path.dirname(__file__), '..', 'python', 'catkin', '__init__.py')):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
 
 from catkin.cmi.cli import main

--- a/bin/pcmi
+++ b/bin/pcmi
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import sys
+
+if os.path.exists(os.path.join(os.path.dirname(__file__), 'CMakeLists.txt')):
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+from catkin.cmi.cli import main
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -193,16 +193,6 @@ def determine_packages_to_be_built(packages, context):
     return packages_to_be_built, packages_to_be_built_deps
 
 
-def write_job_log(job_log, package, context):
-    build_log_dir = os.path.join(context.workspace, 'cmi_log')
-    if not os.path.exists(build_log_dir):
-        os.makedirs(build_log_dir)
-    package_log = os.path.join(build_log_dir, str(package) + '.log')
-    with open(package_log, 'w') as f:
-        f.write('\n'.join(job_log[package]))
-        f.write('\n')
-
-
 def build_isolated_workspace(
     context,
     packages=None,

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -275,7 +275,21 @@ def build_isolated_workspace(
     job_log = {}
 
     # Prime the job_queue
-    ready_packages = get_ready_packages(packages_to_be_built, running_jobs, completed_packages)
+    ready_packages = []
+    if start_with is None:
+        ready_packages = get_ready_packages(packages_to_be_built, running_jobs, completed_packages)
+    while start_with is not None:
+        ready_packages.extend(get_ready_packages(packages_to_be_built, running_jobs, completed_packages))
+        while ready_packages:
+            pth, pkg = ready_packages.pop(0)
+            if pkg.name != start_with:
+                completed_packages.append(pkg.name)
+                package_count += 1
+                wide_log("[cmi] Skipping package '{0}'".format(pkg.name))
+            else:
+                ready_packages.insert(0, (pth, pkg))
+                start_with = None
+                break
     running_jobs = queue_ready_packages(ready_packages, running_jobs, job_queue, context, force_cmake)
     assert running_jobs
 

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -295,6 +295,7 @@ def build_isolated_workspace(
         e.start()
 
     # Variables for tracking running jobs and built/building packages
+    start = time.time()
     total_packages = len(packages_to_be_built)
     package_count = 0
     running_jobs = {}
@@ -416,7 +417,7 @@ def build_isolated_workspace(
                         'name': name,
                         'run_time': format_time_delta_short(time.time() - start_time)
                     })
-                msg = "[cmi] "
+                msg = "[cmi - {run_time}] ".format(run_time=format_time_delta_short(time.time() - start))
                 # If errors post those
                 if errors:
                     for error in errors:

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -35,16 +35,16 @@ import os
 import sys
 import time
 
-from Queue import Empty
-
 from multiprocessing import cpu_count
 from threading import Lock
 try:
     # Python3
     from queue import Queue
+    from queue import Empty
 except ImportError:
     # Python2
     from Queue import Queue
+    from Queue import Empty
 
 try:
     from catkin_pkg.packages import find_packages

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -1,0 +1,317 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import time
+
+from Queue import Empty
+
+from multiprocessing import cpu_count
+from multiprocessing import Lock
+from multiprocessing import Queue
+
+try:
+    from catkin_pkg.packages import find_packages
+    from catkin_pkg.topological_order import topological_order_packages
+except ImportError as e:
+    sys.exit(
+        'ImportError: "from catkin_pkg.topological_order import '
+        'topological_order" failed: %s\nMake sure that you have installed '
+        '"catkin_pkg", and that it is up to date and on the PYTHONPATH.' % e
+    )
+
+from catkin.cmi.common import FakeLock
+from catkin.cmi.common import get_build_type
+from catkin.cmi.common import log
+from catkin.cmi.common import wide_log
+
+from catkin.cmi.executor import Executor
+
+from catkin.cmi.job import CatkinJob
+from catkin.cmi.job import CMakeJob
+
+
+def get_ready_packages(packages, running_jobs, completed):
+    """Returns packages which have no pending depends and are ready to be built
+
+    Iterates through the packages, seeing if any of the packages which
+    are not currently in running_jobs and are not in completed jobs, have all of
+    their build and buildtool depends met, and are there for ready to be queued
+    up and built.
+
+    :param packages: topologically ordered packages in the workspace
+    :type packages: dict
+    :param running_jobs: currently running jobs which are building packages
+    :type running_jobs: dict
+    :param completed: list of packages in the workspace which have been built
+    :type completed: list
+    :returns: list of package_path, package tuples which should be built
+    :rtype: list
+    """
+    ready_packages = []
+    workspace_packages = dict([(pkg.name, pkg) for path, pkg in packages])
+    for path, package in packages:
+        if package.name in (running_jobs.keys() + completed):
+            continue
+        # Collect build and buildtool depends, plus recursive build, buildtool, and run depends,
+        # Excluding depends which are not in the workspace or which are completed
+        uncompleted_depends = set()
+        depends = set([dep.name for dep in (package.build_depends + package.buildtool_depends)])
+        checked_depends = set()
+        while list(depends - checked_depends):
+            # Get a dep
+            dep = list(depends - checked_depends).pop()
+            # Add the dep to the checked list
+            checked_depends.add(dep)
+            # If it is not in the workspace, continue
+            if dep not in workspace_packages:
+                continue
+            # Add the build, buildtool, and run depends of this dep to the list to be checked
+            dep_pkg = workspace_packages[dep]
+            dep_depends = dep_pkg.build_depends + dep_pkg.buildtool_depends + dep_pkg.run_depends
+            depends.update(set([d.name for d in dep_depends]))
+            # If it is not completed, then add it to the blocking list
+            if dep not in completed:
+                uncompleted_depends.add(dep)
+                break  # Once one uncompleted_depends is found, we can stop
+        # If there are no uncompleted dependencies, add this package to the queue
+        if not uncompleted_depends:
+            ready_packages.append((path, package))
+    # Return the new ready_packages
+    return ready_packages
+
+
+def queue_ready_packages(ready_packages, running_jobs, job_queue, context, force_cmake):
+    """Adds packages which are ready to be built to the job queue
+
+    :param ready_packages: packages which are ready to be built
+    :type ready_packages: list
+    :param running_jobs: jobs for building packages which are currently running
+    :type running_jobs: dict
+    :param job_queue: queue to put new jobs in, which will be consumed by executors
+    :type job_queue: :py:class:`multiprocessing.Queue`
+    :param context: context of the build environment
+    :type context: :py:class:`catkin.cmi.context.Context`
+    :param force_cmake: must run cmake if True
+    :type force_cmake: bool
+    :returns: updated running_jobs dict
+    :rtype: dict
+    """
+    for path, package in ready_packages:
+        build_type = get_build_type(package)
+        if build_type == 'catkin':
+            job = CatkinJob(package, path, context, force_cmake)
+        elif build_type == 'cmake':
+            job = CMakeJob(package, path, context, force_cmake)
+        running_jobs[package.name] = {
+            'package_number': None,
+            'job': job,
+            'start_time': None
+        }
+        job_queue.put(job)
+    return running_jobs
+
+
+def build_isolated_workspace(context, jobs=None, force_cmake=False, force_color=False, verbose=False):
+    """Builds a catkin workspace in isolation
+
+    This function will find all of the packages in the source space, start some
+    executors, feed them packages to build based on dependencies and topological
+    ordering, and then monitor the output of the executors, handling loggings of
+    the builds, starting builds, failing builds, and finishing builds of
+    packages, and handling the shutdown of the executors when appropriate.
+
+    :param context: context in which to build the catkin workspace
+    :type context: :py:class:`catkin.cmi.context.Context`
+    :param jobs: number of parallel package build jobs
+    :type jobs: int
+    :param force_cmake: forces invocation of CMake if True, default is False
+    :type force_cmake: bool
+    :param force_color: forces colored output even if terminal does not support it
+    :type force_color: bool
+    :param verbose: outputs commands output to screen, even if it will interleave
+    :type verbose: bool
+
+    :raises: RuntimeError if buildspace is a file
+    """
+    # Make sure there is a build folder and it is not a file
+    if os.path.exists(context.build_space):
+        if os.path.isfile(context.build_space):
+            raise RuntimeError("Build space '{0}' exists but is a file and not a folder.".format(context.build_space))
+    # If it dosen't exist, create it
+    else:
+        log("Creating buildspace directory, '{0}'".format(context.build_space))
+        os.makedirs(context.build_space)
+
+    # Summarize the context
+    log(context.summary())
+
+    # Find list of packages in the workspace
+    start = time.time()
+    packages = find_packages(context.source_space, exclude_subspaces=True)
+    # If there are no packages raise
+    if not packages:
+        raise RuntimeError("No packages were found in the source space '{0}'".format(context.source_space))
+    log("Found '{0}' packages in '{1:.3f}' seconds.".format(len(packages), time.time() - start))
+
+    # Order the packages by topology
+    ordered_packages = topological_order_packages(packages)
+    context.packages = [x[1] for x in ordered_packages]
+
+    # Setup pool of executors
+    executors = {}
+    # The communication queue can have ExecutorEvent's or str's passed into it from the executors
+    comm_queue = Queue()
+    # The job queue has Jobs put into it
+    job_queue = Queue()
+    # This lock can be used to lock the devel space for writing (needed for the merge_devel option)
+    devel_lock = FakeLock()
+    # This lock can be used to lock the installation space for writing
+    install_lock = Lock()
+    # Determine the number of executors
+    jobs = cpu_count() if jobs is None else int(jobs)
+    # Start the executors
+    for x in range(jobs):
+        e = Executor(x, context, comm_queue, job_queue, devel_lock, install_lock)
+        executors[x] = e
+        e.start()
+
+    # Variables for tracking running jobs and built/building packages
+    total_packages = len(ordered_packages)
+    package_count = 0
+    completed_packages = []
+    running_jobs = {}
+
+    # Prime the job_queue
+    ready_packages = get_ready_packages(ordered_packages, running_jobs, completed_packages)
+    running_jobs = queue_ready_packages(ready_packages, running_jobs, job_queue, context, force_cmake)
+    assert running_jobs
+
+    error_state = False
+    errors = []
+
+    # While the executors are all running, process executor events
+    while executors:
+        # Try to get data from the communications queue
+        try:
+            item = comm_queue.get(True, 0.1)
+            # If a log event, print it
+            if item.event_type == 'log':
+                wide_log('[cmi-{executor_id}]: {message}'.format(**item.__dict__))
+            if item.event_type == 'command_log':
+                wide_log('[{package}]: {message}'.format(**item.__dict__), end_with_escape=True)
+                # wide_log('[{package}]: {hex_message}'.format(hex_message=item.message.encode('hex'), **item.__dict__))
+            # If a command started, print message
+            if item.event_type == 'command_started':
+                wide_log("[{package}]: ==> '{message[0]}' in '{message[1]}'".format(**item.__dict__))
+            # If a command finished, print message
+            if item.event_type == 'command_finished':
+                wide_log("[{package}]: <== Command '{message[0]}' finished with exit code '{message[1]}'"
+                         .format(**item.__dict__))
+            # If a command failed, shutdown everything
+            if item.event_type == 'command_failed':
+                wide_log("<<< Failed to build {package}, command '{message[0]}' exited with return code '{message[1]}'"
+                         .format(**item.__dict__))
+                errors.append(item)
+                # Remove the command from the running jobs
+                del running_jobs[item.package]
+                if not error_state:
+                    # Dispatch kill signal to executors
+                    for x in range(jobs):
+                        job_queue.put(None)
+                    # Change loop behavior to prevent new jobs
+                    error_state = True
+            # If an executor exit event, join it and remove it from the executors list
+            if item.event_type == 'exit':
+                executors[item.executor_id].join()
+                del executors[item.executor_id]
+            # If a job started event, assign it a number and a start time
+            if item.event_type == 'job_started':
+                package_count += 1
+                running_jobs[item.package]['package_number'] = package_count
+                running_jobs[item.package]['start_time'] = time.time()
+                wide_log(">>> Starting build of package '{0}'".format(item.package))
+            # If a job finished event, remove from running_jobs, move to completed, call queue_new_jobs
+            if item.event_type == 'job_finished':
+                completed_packages.append(item.package)
+                wide_log("<<< Finished building package '{0}', it took {1:.3f} seconds"
+                         .format(item.package, time.time() - running_jobs[item.package]['start_time']))
+                del running_jobs[item.package]
+                # If shutting down, do not add new packages
+                if error_state:
+                    continue
+                ready_packages = get_ready_packages(ordered_packages, running_jobs, completed_packages)
+                running_jobs = queue_ready_packages(ready_packages, running_jobs, job_queue, context, force_cmake)
+                # Make sure there are jobs to be/being processed, otherwise kill the executors
+                if not running_jobs:
+                    # Kill the executors by sending a None to the job queue for each of them
+                    for x in range(jobs):
+                        job_queue.put(None)
+        except Empty:
+            # timeout occured
+            item = None
+        except KeyboardInterrupt:
+            wide_log("[cmi] User interrupted, stopping.")
+            break
+        finally:
+            # Update the status bar on the screen
+            msg = "[cmi] "
+            executing_jobs = []
+            for name, value in running_jobs.items():
+                number, job, start_time = value['package_number'], value['job'], value['start_time']
+                if number is None or start_time is None:
+                    continue
+                executing_jobs.append((number, total_packages, name, time.time() - start_time))
+            # Print them in order of started number
+            for job_msg_args in sorted(executing_jobs, key=lambda args: args[0]):
+                msg += "[{0}/{1} {2} - {3:.1f}] ".format(*job_msg_args)
+            # Update title bar
+            sys.stdout.write("\x1b]2;" + msg + "\x07")
+            # Update status bar
+            if msg != "[cmi] ":
+                wide_log(msg, end='\r')
+                sys.stdout.flush()
+    # All executors have shutdown
+    if not errors:
+        wide_log("[cmi] Finished.")
+    else:
+        wide_log("[cmi] There were errors:")
+        for error in errors:
+            wide_log(("""
+Failed to build package '{package}' becuase the following command:
+
+    # Command run in '{message[2]}' directory
+    {message[0]}
+
+Exited with return code: {message[1]}""").format(**error.__dict__))

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -348,8 +348,7 @@ def build_isolated_workspace(
                 assert item.package in job_log, "command failed before job started " + item.package
                 package = item.package
                 stripped_lines = [line[len('[{0}]: '.format(package)):] for line in command_log_cache[package]]
-                stripped_lines = remove_ansi_escape(line)
-                job_log[package].append('\n'.join(stripped_lines))
+                job_log[package].append(remove_ansi_escape('\n'.join(stripped_lines)))
                 if not quiet:
                     wide_log(msg)
 
@@ -372,7 +371,9 @@ def build_isolated_workspace(
                 del running_jobs[item.package]
                 # Put the job output to a log file
                 assert item.package in job_log, "command failed before job started " + item.package
-                job_log[item.package].append('\n'.join(command_log_cache[item.package]))
+                package = item.package
+                stripped_lines = [line[len('[{0}]: '.format(package)):] for line in command_log_cache[package]]
+                job_log[item.package].append(remove_ansi_escape('\n'.join(stripped_lines)))
                 write_job_log(job_log, item.package, context)
                 del job_log[item.package]
                 if not error_state:
@@ -463,7 +464,7 @@ def build_isolated_workspace(
         wide_log("[cmi] There were errors:")
         for error in errors:
             wide_log(("""
-Failed to build package '{package}' becuase the following command:
+Failed to build package '{package}' because the following command:
 
     # Command run in '{message[2]}' directory
     {message[0]}

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -38,7 +38,6 @@ import time
 from Queue import Empty
 
 from multiprocessing import cpu_count
-from multiprocessing import Lock
 from multiprocessing import Queue
 
 try:
@@ -51,7 +50,6 @@ except ImportError as e:
         '"catkin_pkg", and that it is up to date and on the PYTHONPATH.' % e
     )
 
-from catkin.cmi.common import FakeLock
 from catkin.cmi.common import get_build_type
 from catkin.cmi.common import get_cached_recursive_build_depends_in_workspace
 from catkin.cmi.common import log
@@ -244,10 +242,6 @@ def build_isolated_workspace(
     comm_queue = Queue()
     # The job queue has Jobs put into it
     job_queue = Queue()
-    # This lock can be used to lock the devel space for writing (needed for the merge_devel option)
-    devel_lock = FakeLock()
-    # This lock can be used to lock the installation space for writing
-    install_lock = Lock()
     # Determine the number of executors
     jobs = cpu_count() if jobs is None else int(jobs)
     # If only one set of jobs, turn on interleaving to get more responsive feedback
@@ -257,7 +251,7 @@ def build_isolated_workspace(
         interleave_output = True
     # Start the executors
     for x in range(jobs):
-        e = Executor(x, context, comm_queue, job_queue, devel_lock, install_lock)
+        e = Executor(x, context, comm_queue, job_queue)
         executors[x] = e
         e.start()
 

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -458,7 +458,7 @@ def build_isolated_workspace(
             # Update title bar
             job_numbers = [x[0] for x in executing_jobs]
             if job_numbers:
-                sys.stdout.write("\x1b]2;[cmi] {0}/{1}\x07".format(max(job_numbers), total_packages))
+                sys.stdout.write("\x1b]2;[cmi] {{{0}-{1}}}/{2}\x07".format(min(job_numbers), max(job_numbers), total_packages))
             else:
                 sys.stdout.write("\x1b]2;[cmi]\x07")
             # Update status bar

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -457,8 +457,12 @@ def build_isolated_workspace(
                 msg += "[{0}/{1} {2} - {3}] ".format(*job_msg_args)
             # Update title bar
             job_numbers = [x[0] for x in executing_jobs]
-            if job_numbers:
-                sys.stdout.write("\x1b]2;[cmi] {{{0}-{1}}}/{2}\x07".format(min(job_numbers), max(job_numbers), total_packages))
+            if len(job_numbers) == 1:
+                sys.stdout.write("\x1b]2;[cmi] {0}/{1}\x07"
+                                 .format(job_numbers[0], total_packages))
+            elif job_numbers:
+                sys.stdout.write("\x1b]2;[cmi] {{{0}-{1}}}/{2}\x07"
+                                 .format(min(job_numbers), max(job_numbers), total_packages))
             else:
                 sys.stdout.write("\x1b]2;[cmi]\x07")
             # Update status bar

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -299,7 +299,7 @@ def build_isolated_workspace(
     color = True
     if not force_color and not sys.stdout.isatty():
         color = True
-    out = OutputController(log_dir, quiet, interleave_output, color, prefix_output=(jobs == 1))
+    out = OutputController(log_dir, quiet, interleave_output, color, prefix_output=(jobs > 1))
 
     # Prime the job_queue
     ready_packages = []

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -430,6 +430,7 @@ def build_isolated_workspace(
             wide_log("[cmi] User interrupted, stopping.")
             set_error_state(error_state)
     # All executors have shutdown
+    sys.stdout.write("\x1b]2;\x07")
     if not errors:
         wide_log("[cmi] Finished.")
     else:

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -391,8 +391,6 @@ def build_isolated_workspace(
                 sys.stdout.flush()
                 ready_packages = get_ready_packages(packages_to_be_built, running_jobs, completed_packages)
                 running_jobs = queue_ready_packages(ready_packages, running_jobs, job_queue, context, force_cmake)
-                wide_log('[cmi] Uh...', end='\r')
-                sys.stdout.flush()
                 # Make sure there are jobs to be/being processed, otherwise kill the executors
                 if not running_jobs:
                     # Kill the executors by sending a None to the job queue for each of them

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -248,6 +248,8 @@ def build_isolated_workspace(
     else:
         # Extend packages to be built to include their deps
         packages_to_be_built.extend(packages_to_be_built_deps)
+    # Also resort
+    packages_to_be_built = topological_order_packages(dict(packages_to_be_built))
 
     # Setup pool of executors
     executors = {}

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -64,6 +64,7 @@ from catkin.cmi.common import get_build_type
 from catkin.cmi.common import get_cached_recursive_build_depends_in_workspace
 from catkin.cmi.common import format_time_delta
 from catkin.cmi.common import format_time_delta_short
+from catkin.cmi.common import is_tty
 from catkin.cmi.common import log
 from catkin.cmi.common import wide_log
 
@@ -303,7 +304,7 @@ def build_isolated_workspace(
     running_jobs = {}
     log_dir = os.path.join(context.build_space, 'cmi_logs')
     color = True
-    if not force_color and not sys.stdout.isatty():
+    if not force_color and not is_tty(sys.stdout):
         color = True
     out = OutputController(log_dir, quiet, interleave_output, color, prefix_output=(jobs > 1))
     if no_status:

--- a/python/catkin/cmi/build.py
+++ b/python/catkin/cmi/build.py
@@ -54,6 +54,7 @@ from catkin.cmi.common import get_build_type
 from catkin.cmi.common import get_cached_recursive_build_depends_in_workspace
 from catkin.cmi.common import format_time_delta
 from catkin.cmi.common import log
+from catkin.cmi.common import remove_ansi_escape
 from catkin.cmi.common import wide_log
 
 from catkin.cmi.executor import Executor
@@ -343,7 +344,10 @@ def build_isolated_workspace(
                 assert item.package in command_log_cache, "command finished before starting"
                 command_log_cache[item.package].append(msg)
                 assert item.package in job_log, "command failed before job started " + item.package
-                job_log[item.package].append('\n'.join(command_log_cache[item.package]))
+                package = item.package
+                stripped_lines = [line[len('[{0}]: '.format(package)):] for line in command_log_cache[package]]
+                stripped_lines = remove_ansi_escape(line)
+                job_log[package].append('\n'.join(stripped_lines))
                 if not quiet:
                     wide_log(msg)
 

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -36,9 +36,11 @@ from __future__ import print_function
 import argparse
 import re
 import sys
+import time
 
 from catkin.cmi.common import extract_cmake_and_make_and_catkin_make_arguments
 from catkin.cmi.common import extract_jobs_flags
+from catkin.cmi.common import format_time_delta
 from catkin.cmi.common import get_build_type
 from catkin.cmi.common import log
 
@@ -167,6 +169,7 @@ def main(sysargs=None):
         list_only(context, opts.packages, opts.no_deps)
         return
 
+    start = time.time()
     try:
         build_isolated_workspace(
             context,
@@ -181,3 +184,5 @@ def main(sysargs=None):
         )
     except Exception:
         raise
+    finally:
+        log("[cmi] Runtime: {0}".format(format_time_delta(time.time() - start)))

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -39,11 +39,13 @@ import sys
 import time
 
 from catkin.cmi.color import clr
+from catkin.cmi.color import set_color
 
 from catkin.cmi.common import extract_cmake_and_make_and_catkin_make_arguments
 from catkin.cmi.common import extract_jobs_flags
 from catkin.cmi.common import format_time_delta
 from catkin.cmi.common import get_build_type
+from catkin.cmi.common import is_tty
 from catkin.cmi.common import log
 
 from catkin.cmi.context import Context
@@ -165,6 +167,9 @@ def list_only(context, packages, no_deps, start_with):
 
 def main(sysargs=None):
     opts = parse_args(sysargs)
+
+    if not opts.force_color and not is_tty(sys.stdout):
+        set_color(False)
 
     context = Context(
         workspace=opts.workspace,

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -34,21 +34,49 @@
 from __future__ import print_function
 
 import argparse
+import re
+import sys
+
+from catkin.cmi.common import extract_cmake_and_make_and_catkin_make_arguments
+from catkin.cmi.common import extract_jobs_flags
+from catkin.cmi.common import get_build_type
+from catkin.cmi.common import log
 
 from catkin.cmi.context import Context
+
 from catkin.cmi.build import build_isolated_workspace
+from catkin.cmi.build import determine_packages_to_be_built
+from catkin.cmi.build import topological_order_packages
 
 
 def parse_args(args):
+    # CMake/make pass-through flags collect dashed options. They require special
+    # handling or argparse will complain about unrecognized options.
+    args = sys.argv[1:] if args is None else args
+    extract_make_args = extract_cmake_and_make_and_catkin_make_arguments
+    args, cmake_args, make_args, catkin_make_args = extract_make_args(args)
+    # Extract make jobs flags.
+    jobs_flags = extract_jobs_flags(' '.join(args))
+    if jobs_flags:
+        args = re.sub(jobs_flags, '', ' '.join(args)).split()
+        jobs_flags = jobs_flags.split()
+
     parser = argparse.ArgumentParser(
         description=
         'Builds each catkin (and non-catkin) package from a given workspace in isolation, '
-        'but still in topological order. Building of packages will be parallelized according to -p <# of jobs>.'
+        'but still in topological order. Building of packages will be parallelized according to -p <# of jobs>. '
         'Make job flags (-j/-l) are extracted and passed to each make invocation.'
     )
     add = parser.add_argument
-    add('--parallel-jobs', '--parallel', '-p', default=None,
-        help='Maximum number of packages which could be built in parallel (default is cpu count)')
+    # What packages to build
+    add('packages', nargs='*',
+        help='Workspace packages to build, package dependencies are built as well unless --no-deps is used. '
+             'If no packages are given, then all the packages are built.')
+    add('--no-deps', action='store_true', default=False,
+        help='Only build specified packages, not their dependencies.')
+    add('--start-with', metavar='PKGNAME',
+        help='Start building with this package, skipping any before it.')
+    # Context options
     add('--workspace', '-w', default=None,
         help='The base path of the workspace (default ".")')
     add('--source', '--source-space', default=None,
@@ -65,18 +93,11 @@ def parse_args(args):
         help='Causes each catkin package to be installed.')
     add('--isolate-install', action='store_true', default=False,
         help='Install each catkin package into a separate install space.')
+    # Build options
+    add('--parallel-jobs', '--parallel', '-p', default=None,
+        help='Maximum number of packages which could be built in parallel (default is cpu count)')
     add('--force-cmake', action='store_true', default=False,
         help='Runs cmake explicitly for each catkin package.')
-    add('--force-color', action='store_true', default=False,
-        help='Forces cmi to ouput in color, even when the terminal does not appear to support it.')
-    # pkg = parser.add_mutually_exclusive_group(required=False)
-    # pkg.add_argument('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
-    #                  help='Invoke "make" on specific packages (only after catkin_make_isolated has been invoked before with the same install flag)')
-    # pkg.add_argument('--from-pkg', metavar='PKGNAME', dest='from_package',
-    #                  help='Restart catkin_make_isolated at the given package continuing from there (do not change CMake arguments, add/move/remove packages or toggle the install flag when using this option since this may result in an inconsistent workspace state).')
-    # add('--only-pkg-with-deps', nargs='+', help='Only consider the specific packages and their recursive dependencies and ignore all other packages in the workspace (only works together with --merge or --install)')
-    add('-v', '--verbose', action='store_true', default=False,
-        help='Outputs output of each command in real-time, even if it interleaves with other output.')
     add('--cmake-args', dest='cmake_args', nargs='*', type=str,
         help='Arbitrary arguments which are passes to CMake. '
              'It must be passed after other arguments since it collects all following options.')
@@ -86,10 +107,52 @@ def parse_args(args):
     add('--catkin-make-args', dest='catkin_make_args', nargs='*', type=str,
         help='Arbitrary arguments which are passes to make but only for catkin packages.'
              'It must be passed after other arguments since it collects all following options.')
+    # Behavior
+    add('--force-color', action='store_true', default=False,
+        help='Forces cmi to ouput in color, even when the terminal does not appear to support it.')
+    add('--verbose', '-v', action='store_true', default=False,
+        help='Print output from build commands, even if it interleaves with other output.')
+    add('--order-output', '-o', action='store_true', default=False,
+        help='Collects all output from a command before printing it in one contiguous block. (implies verbose)')
+    # Commands
+    add('--list-only', '--list', action='store_true', default=False,
+        help='List packages in topological order, then exit.')
+
     opts = parser.parse_args(args)
-    # if opts.only_pkg_with_deps and not opts.merge and not opts.install:
-        # parser.error("The '--only-pkg-with-deps' option can only be used together with '--merge' or '--install'")
+    opts.cmake_args = cmake_args
+    opts.make_args = make_args + (jobs_flags or [])
+    opts.catkin_make_args = catkin_make_args
+
+    if opts.no_deps and not opts.packages:
+        sys.exit("With --no-deps, you must specify packages to build.")
     return opts
+
+
+def get_reverse_depends(package, packages):
+    rdepends = []
+    name = package.name
+    for pth, pkg in packages:
+        if name in [dep.name for dep in (pkg.build_depends + pkg.buildtool_depends + pkg.run_depends)]:
+            rdepends.append((pth, pkg))
+    return rdepends
+
+
+def list_only(context, packages, no_deps):
+    # Print Summary
+    log(context.summary())
+    # Find list of packages in the workspace
+    packages_to_be_built, packages_to_be_built_deps = determine_packages_to_be_built(packages, context)
+    if not no_deps:
+        # Extend packages to be built to include their deps
+        packages_to_be_built.extend(packages_to_be_built_deps)
+        # Also resort
+        packages_to_be_built = topological_order_packages(dict(packages_to_be_built))
+    # Print packages
+    log("Packages to be built:")
+    max_name_len = str(max([len(pkg.name) for pth, pkg in packages_to_be_built]))
+    for pkg_path, pkg in packages_to_be_built:
+        log(("- {name:<" + max_name_len + "} ({build_type})").format(name=pkg.name, build_type=get_build_type(pkg)))
+    log("Total packages: " + str(len(packages_to_be_built)))
 
 
 def main(sysargs=None):
@@ -109,4 +172,20 @@ def main(sysargs=None):
         catkin_make_args=opts.catkin_make_args
     )
 
-    build_isolated_workspace(context, opts.parallel_jobs, opts.force_cmake, opts.force_color, opts.verbose)
+    if opts.list_only:
+        list_only(context, opts.packages, opts.no_deps)
+        return
+
+    try:
+        build_isolated_workspace(
+            context,
+            jobs=opts.parallel_jobs,
+            force_cmake=opts.force_cmake,
+            force_color=opts.force_color,
+            verbose=opts.verbose,
+            packages=opts.packages,
+            start_with=opts.start_with,
+            no_deps=opts.no_deps
+        )
+    except Exception:
+        raise

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -1,0 +1,112 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import argparse
+
+from catkin.cmi.context import Context
+from catkin.cmi.build import build_isolated_workspace
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(
+        description=
+        'Builds each catkin (and non-catkin) package from a given workspace in isolation, '
+        'but still in topological order. Building of packages will be parallelized according to -p <# of jobs>.'
+        'Make job flags (-j/-l) are extracted and passed to each make invocation.'
+    )
+    add = parser.add_argument
+    add('--parallel-jobs', '--parallel', '-p', default=None,
+        help='Maximum number of packages which could be built in parallel (default is cpu count)')
+    add('--workspace', '-w', default=None,
+        help='The base path of the workspace (default ".")')
+    add('--source', '--source-space', default=None,
+        help='The path to the source space (default "src")')
+    add('--build', '--build-space', default=None,
+        help='The path to the build space (default "build")')
+    add('--devel', '--devel-space', default=None,
+        help='Sets the target devel space (default "devel")')
+    add('--merge-devel', action='store_true', default=False,
+        help='Build each catkin package into a common devel space.')
+    add('--install-space', dest='install_space', default=None,
+        help='Sets the target install space (default "install")')
+    add('--install', action='store_true', default=False,
+        help='Causes each catkin package to be installed.')
+    add('--isolate-install', action='store_true', default=False,
+        help='Install each catkin package into a separate install space.')
+    add('--force-cmake', action='store_true', default=False,
+        help='Runs cmake explicitly for each catkin package.')
+    add('--force-color', action='store_true', default=False,
+        help='Forces cmi to ouput in color, even when the terminal does not appear to support it.')
+    # pkg = parser.add_mutually_exclusive_group(required=False)
+    # pkg.add_argument('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
+    #                  help='Invoke "make" on specific packages (only after catkin_make_isolated has been invoked before with the same install flag)')
+    # pkg.add_argument('--from-pkg', metavar='PKGNAME', dest='from_package',
+    #                  help='Restart catkin_make_isolated at the given package continuing from there (do not change CMake arguments, add/move/remove packages or toggle the install flag when using this option since this may result in an inconsistent workspace state).')
+    # add('--only-pkg-with-deps', nargs='+', help='Only consider the specific packages and their recursive dependencies and ignore all other packages in the workspace (only works together with --merge or --install)')
+    add('-v', '--verbose', action='store_true', default=False,
+        help='Outputs output of each command in real-time, even if it interleaves with other output.')
+    add('--cmake-args', dest='cmake_args', nargs='*', type=str,
+        help='Arbitrary arguments which are passes to CMake. '
+             'It must be passed after other arguments since it collects all following options.')
+    add('--make-args', dest='make_args', nargs='*', type=str,
+        help='Arbitrary arguments which are passes to make.'
+             'It must be passed after other arguments since it collects all following options.')
+    add('--catkin-make-args', dest='catkin_make_args', nargs='*', type=str,
+        help='Arbitrary arguments which are passes to make but only for catkin packages.'
+             'It must be passed after other arguments since it collects all following options.')
+    opts = parser.parse_args(args)
+    # if opts.only_pkg_with_deps and not opts.merge and not opts.install:
+        # parser.error("The '--only-pkg-with-deps' option can only be used together with '--merge' or '--install'")
+    return opts
+
+
+def main(sysargs=None):
+    opts = parse_args(sysargs)
+
+    context = Context(
+        workspace=opts.workspace,
+        source_space=opts.source,
+        build_space=opts.build,
+        devel_space=opts.devel,
+        merge_devel=opts.merge_devel,
+        install_space=opts.install_space,
+        install=opts.install,
+        isolate_install=opts.isolate_install,
+        cmake_args=opts.cmake_args,
+        make_args=opts.make_args,
+        catkin_make_args=opts.catkin_make_args
+    )
+
+    build_isolated_workspace(context, opts.parallel_jobs, opts.force_cmake, opts.force_color, opts.verbose)

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -128,15 +128,6 @@ def parse_args(args):
     return opts
 
 
-def get_reverse_depends(package, packages):
-    rdepends = []
-    name = package.name
-    for pth, pkg in packages:
-        if name in [dep.name for dep in (pkg.build_depends + pkg.buildtool_depends + pkg.run_depends)]:
-            rdepends.append((pth, pkg))
-    return rdepends
-
-
 def list_only(context, packages, no_deps):
     # Print Summary
     log(context.summary())

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -183,7 +183,7 @@ def main(sysargs=None):
 
     start = time.time()
     try:
-        build_isolated_workspace(
+        return build_isolated_workspace(
             context,
             packages=opts.packages,
             start_with=opts.start_with,

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -122,6 +122,8 @@ def parse_args(args):
         help='Supresses output from commands unless there is an error.')
     add('--interleave-output', '-i', action='store_true', default=False,
         help='Prevents ordering of command output when multiple commands are running at the same time.')
+    add('--no-status', action='store_true', default=False,
+        help='Suppresses status line, useful in situations where carriage return is not properly supported.')
     # Commands
     add('--list-only', '--list', action='store_true', default=False,
         help='List packages in topological order, then exit.')
@@ -195,6 +197,7 @@ def main(sysargs=None):
             force_color=opts.force_color,
             quiet=opts.quiet,
             interleave_output=opts.interleave_output,
+            no_status=opts.no_status,
             lock_install=opts.lock_install
         )
     except Exception:

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -148,7 +148,10 @@ def list_only(context, packages, no_deps):
     log("Packages to be built:")
     max_name_len = str(max([len(pkg.name) for pth, pkg in packages_to_be_built]))
     for pkg_path, pkg in packages_to_be_built:
-        log(("- {name:<" + max_name_len + "} ({build_type})").format(name=pkg.name, build_type=get_build_type(pkg)))
+        build_type = get_build_type(pkg)
+        if build_type == 'catkin' and 'metapackage' in [e.tagname for e in pkg.exports]:
+            build_type = 'metapackage'
+        log(("- {name:<" + max_name_len + "} ({build_type})").format(name=pkg.name, build_type=build_type))
     log("Total packages: " + str(len(packages_to_be_built)))
 
 

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -134,7 +134,7 @@ def parse_args(args):
     return opts
 
 
-def list_only(context, packages, no_deps):
+def list_only(context, packages, no_deps, start_with):
     # Print Summary
     log(context.summary())
     # Find list of packages in the workspace
@@ -147,11 +147,15 @@ def list_only(context, packages, no_deps):
     # Print packages
     log("Packages to be built:")
     max_name_len = str(max([len(pkg.name) for pth, pkg in packages_to_be_built]))
+    prefix = '------ ' if start_with else '- '
     for pkg_path, pkg in packages_to_be_built:
         build_type = get_build_type(pkg)
         if build_type == 'catkin' and 'metapackage' in [e.tagname for e in pkg.exports]:
             build_type = 'metapackage'
-        log(("- {name:<" + max_name_len + "} ({build_type})").format(name=pkg.name, build_type=build_type))
+        if start_with and pkg.name == start_with:
+            start_with = None
+        log(("{prefix}{name:<" + max_name_len + "} ({build_type})")
+            .format(prefix='(skip) ' if start_with else prefix, name=pkg.name, build_type=build_type))
     log("Total packages: " + str(len(packages_to_be_built)))
 
 
@@ -174,7 +178,7 @@ def main(sysargs=None):
     )
 
     if opts.list_only:
-        list_only(context, opts.packages, opts.no_deps)
+        list_only(context, opts.packages, opts.no_deps, opts.start_with)
         return
 
     start = time.time()

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -95,6 +95,8 @@ def parse_args(args):
         help='Causes each catkin package to be installed.')
     add('--isolate-install', action='store_true', default=False,
         help='Install each catkin package into a separate install space.')
+    add('--space-suffix',
+        help='suffix for build, devel, and install space if they are not otherwise explicitly set')
     # Build options
     add('--parallel-jobs', '--parallel', '-p', default=None,
         help='Maximum number of packages which could be built in parallel (default is cpu count)')
@@ -162,7 +164,8 @@ def main(sysargs=None):
         isolate_install=opts.isolate_install,
         cmake_args=opts.cmake_args,
         make_args=opts.make_args,
-        catkin_make_args=opts.catkin_make_args
+        catkin_make_args=opts.catkin_make_args,
+        space_suffix=opts.space_suffix
     )
 
     if opts.list_only:

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -102,6 +102,8 @@ def parse_args(args):
         help='Maximum number of packages which could be built in parallel (default is cpu count)')
     add('--force-cmake', action='store_true', default=False,
         help='Runs cmake explicitly for each catkin package.')
+    add('--lock-install', action='store_true', default=False,
+        help='Prevents multiple jobs from simultaneously running install targets')
     add('--cmake-args', dest='cmake_args', nargs='*', type=str,
         help='Arbitrary arguments which are passes to CMake. '
              'It must be passed after other arguments since it collects all following options.')
@@ -183,7 +185,8 @@ def main(sysargs=None):
             force_cmake=opts.force_cmake,
             force_color=opts.force_color,
             quiet=opts.quiet,
-            interleave_output=opts.interleave_output
+            interleave_output=opts.interleave_output,
+            lock_install=opts.lock_install
         )
     except Exception:
         raise

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -106,8 +106,8 @@ def parse_args(args):
         help='Maximum number of packages which could be built in parallel (default is cpu count)')
     add('--force-cmake', action='store_true', default=False,
         help='Runs cmake explicitly for each catkin package.')
-    add('--lock-install', action='store_true', default=False,
-        help='Prevents multiple jobs from simultaneously running install targets')
+    add('--no-install-lock', action='store_true', default=False,
+        help='Prevents serialization of the install steps, which is on by default to prevent file install collisions')
     add('--cmake-args', dest='cmake_args', nargs='*', type=str,
         help='Arbitrary arguments which are passes to CMake. '
              'It must be passed after other arguments since it collects all following options.')
@@ -203,7 +203,7 @@ def main(sysargs=None):
             quiet=opts.quiet,
             interleave_output=opts.interleave_output,
             no_status=opts.no_status,
-            lock_install=opts.lock_install
+            lock_install=not opts.no_install_lock
         )
     except Exception:
         raise

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -110,10 +110,10 @@ def parse_args(args):
     # Behavior
     add('--force-color', action='store_true', default=False,
         help='Forces cmi to ouput in color, even when the terminal does not appear to support it.')
-    add('--verbose', '-v', action='store_true', default=False,
-        help='Print output from build commands, even if it interleaves with other output.')
-    add('--order-output', '-o', action='store_true', default=False,
-        help='Collects all output from a command before printing it in one contiguous block. (implies verbose)')
+    add('--quiet', '-q', action='store_true', default=False,
+        help='Supresses output from commands unless there is an error.')
+    add('--interleave-output', '-i', action='store_true', default=False,
+        help='Prevents ordering of command output when multiple commands are running at the same time.')
     # Commands
     add('--list-only', '--list', action='store_true', default=False,
         help='List packages in topological order, then exit.')
@@ -170,13 +170,14 @@ def main(sysargs=None):
     try:
         build_isolated_workspace(
             context,
+            packages=opts.packages,
+            start_with=opts.start_with,
+            no_deps=opts.no_deps,
             jobs=opts.parallel_jobs,
             force_cmake=opts.force_cmake,
             force_color=opts.force_color,
-            verbose=opts.verbose,
-            packages=opts.packages,
-            start_with=opts.start_with,
-            no_deps=opts.no_deps
+            quiet=opts.quiet,
+            interleave_output=opts.interleave_output
         )
     except Exception:
         raise

--- a/python/catkin/cmi/cli.py
+++ b/python/catkin/cmi/cli.py
@@ -38,6 +38,8 @@ import re
 import sys
 import time
 
+from catkin.cmi.color import clr
+
 from catkin.cmi.common import extract_cmake_and_make_and_catkin_make_arguments
 from catkin.cmi.common import extract_jobs_flags
 from catkin.cmi.common import format_time_delta
@@ -147,15 +149,15 @@ def list_only(context, packages, no_deps, start_with):
     # Print packages
     log("Packages to be built:")
     max_name_len = str(max([len(pkg.name) for pth, pkg in packages_to_be_built]))
-    prefix = '------ ' if start_with else '- '
+    prefix = clr('@{pf}' + ('------ ' if start_with else '- ') + '@|')
     for pkg_path, pkg in packages_to_be_built:
         build_type = get_build_type(pkg)
         if build_type == 'catkin' and 'metapackage' in [e.tagname for e in pkg.exports]:
             build_type = 'metapackage'
         if start_with and pkg.name == start_with:
             start_with = None
-        log(("{prefix}{name:<" + max_name_len + "} ({build_type})")
-            .format(prefix='(skip) ' if start_with else prefix, name=pkg.name, build_type=build_type))
+        log(clr("{prefix}@{cf}{name:<" + max_name_len + "}@| (@{yf}{build_type}@|)")
+            .format(prefix=clr('@!@{kf}(skip)@| ') if start_with else prefix, name=pkg.name, build_type=build_type))
     log("Total packages: " + str(len(packages_to_be_built)))
 
 

--- a/python/catkin/cmi/color.py
+++ b/python/catkin/cmi/color.py
@@ -31,11 +31,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""This module implements many of the colorization functions used by cmi"""
+
 from catkin.cmi.terminal_color import enable_ANSI_colors
 from catkin.cmi.terminal_color import disable_ANSI_colors
 from catkin.cmi.terminal_color import fmt
 from catkin.cmi.terminal_color import sanitize
 
+# This map translates more human reable format strings into colorized versions
 _color_translation_map = {
     # 'output': 'colorized_output'
     '': fmt('@!' + sanitize('') + '@|'),
@@ -70,6 +73,11 @@ _color_translation_map = {
 
 
 def colorize_cmake(line):
+    """Colorizes output from CMake
+
+    :param line: one, new line terminated, line from `cmake` which needs coloring.
+    :type line: str
+    """
     cline = sanitize(line)
     if line.startswith('-- '):
         cline = '@{cf}-- @|' + cline[len('-- '):]
@@ -98,6 +106,14 @@ _color_on = True
 
 
 def set_color(state):
+    """Sets the global colorization setting.
+
+    Setting this to False will cause all ansi colorization sequences to get
+    replaced with empty strings.
+
+    :parma state: colorization On or Off, True or False respectively
+    :type state: bool
+    """
     global _color_on
     if state:
         enable_ANSI_colors()
@@ -108,6 +124,14 @@ def set_color(state):
 
 
 def clr(key):
+    """Returns a colorized version of the string given.
+
+    This is occomplished by either returning a hit from the color translation
+    map or by calling :py:func:`fmt` on the string and returning it.
+
+    :param key: string to be colorized
+    :type key: str
+    """
     global _color_translation_map, _color_on
     if not _color_on:
         return fmt(key)

--- a/python/catkin/cmi/color.py
+++ b/python/catkin/cmi/color.py
@@ -76,8 +76,6 @@ def colorize_cmake(line):
         if ':' in cline:
             split_cline = cline.split(':')
             cline = split_cline[0] + ':@{yf}' + ':'.join(split_cline[1:]) + '@|'
-        cline = cline.replace('-- works', '@!-- works@|')
-        cline = cline.replace('- done', '@!- done@|')
     if line.lower().startswith('warning'):
         # WARNING
         cline = fmt('@{yf}') + cline

--- a/python/catkin/cmi/color.py
+++ b/python/catkin/cmi/color.py
@@ -94,16 +94,23 @@ def colorize_cmake(line):
                               '@{cf}@_Call Stack (most recent call first):@|')
     return fmt(cline)
 
+_color_on = True
+
 
 def set_color(state):
+    global _color_on
     if state:
         enable_ANSI_colors()
+        _color_on = True
     else:
         disable_ANSI_colors()
+        _color_on = False
 
 
 def clr(key):
-    global _color_translation_map
+    global _color_translation_map, _color_on
+    if not _color_on:
+        return fmt(key)
     val = _color_translation_map.get(key, None)
     if val is None:
         return fmt(key)

--- a/python/catkin/cmi/color.py
+++ b/python/catkin/cmi/color.py
@@ -1,0 +1,112 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from catkin.cmi.terminal_color import enable_ANSI_colors
+from catkin.cmi.terminal_color import disable_ANSI_colors
+from catkin.cmi.terminal_color import fmt
+from catkin.cmi.terminal_color import sanitize
+
+_color_translation_map = {
+    # 'output': 'colorized_output'
+    '': fmt('@!' + sanitize('') + '@|'),
+
+    "[{package}]: ==> '{cmd.cmd_str}' in '{location}'":
+    fmt("[@{cf}{package}@|]: @!@{bf}==>@| '@!{cmd.cmd_str}@|' @{kf}@!in@| '@!{location}@|'"),
+
+    "Starting ==> {package}":
+    fmt("Starting @!@{gf}==>@| @!@{cf}{package}@|"),
+
+    "[{package}]: {msg}":
+    fmt("[@{cf}{package}@|]: {msg}"),
+
+    "[{package}]: <== '{cmd.cmd_str}' failed with return code '{retcode}'":
+    fmt("[@{cf}{package}@|]: @!@{rf}<==@| '@!{cmd.cmd_str}@|' @{rf}failed with return code@| '@!{retcode}@|'"),
+
+    "[{package}]: <== '{cmd.cmd_str}' finished with return code '{retcode}'":
+    fmt("[@{cf}{package}@|]: @{gf}<==@| '@!{cmd.cmd_str}@|' finished with return code '@!{retcode}@|'"),
+
+    "Finished <== {package} [ {time} ]":
+    fmt("@!@{kf}Finished@| @{gf}<==@| @{cf}{package}@| [ @{yf}{time}@| ]"),
+
+    "[{name} - {run_time}] ":
+    fmt("[@{cf}{name}@| - @{yf}{run_time}@|] "),
+
+    "[{0}/{1} Active | {2}/{3} Completed]":
+    fmt("[@!@{gf}{0}@|/@{gf}{1}@| Active | @!@{gf}{2}@|/@{gf}{3}@| Completed]"),
+
+    "[!{package}] ":
+    fmt("[@!@{rf}!@|@{cf}{package}@|] "),
+}
+
+
+def colorize_cmake(line):
+    cline = sanitize(line)
+    if line.startswith('-- '):
+        cline = '@{cf}-- @|' + cline[len('-- '):]
+        if ':' in cline:
+            split_cline = cline.split(':')
+            cline = split_cline[0] + ':@{yf}' + ':'.join(split_cline[1:]) + '@|'
+        cline = cline.replace('-- works', '@!-- works@|')
+        cline = cline.replace('- done', '@!- done@|')
+    if line.lower().startswith('warning'):
+        # WARNING
+        cline = fmt('@{yf}') + cline
+    if line.startswith('CMake Warning'):
+        # CMake Warning...
+        cline = cline.replace('CMake Warning', '@{yf}@!CMake Warning@|')
+    if line.startswith('ERROR:'):
+        # ERROR:
+        cline = cline.replace('ERROR:', '@!@{rf}ERROR:@|')
+    if line.startswith('CMake Error'):
+        # CMake Error...
+        cline = cline.replace('CMake Error', '@{rf}@!CMake Error@|')
+    if line.startswith('Call Stack (most recent call first):'):
+        # CMake Call Stack
+        cline = cline.replace('Call Stack (most recent call first):',
+                              '@{cf}@_Call Stack (most recent call first):@|')
+    return fmt(cline)
+
+
+def set_color(state):
+    if state:
+        enable_ANSI_colors()
+    else:
+        disable_ANSI_colors()
+
+
+def clr(key):
+    global _color_translation_map
+    val = _color_translation_map.get(key, None)
+    if val is None:
+        return fmt(key)
+    return val

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -34,10 +34,11 @@
 from __future__ import print_function
 
 import datetime
-import multiprocessing
 import os
 import re
 import sys
+
+from multiprocessing import cpu_count
 
 if os.name == 'nt':
     import catkin.cmi.run_windows as run
@@ -159,7 +160,7 @@ def handle_make_arguments(input_make_args, force_single_threaded_when_running_te
             else:
                 # Else Use the number of CPU cores
                 try:
-                    jobs = multiprocessing.cpu_count()
+                    jobs = cpu_count()
                     make_args.append('-j{0}'.format(jobs))
                     make_args.append('-l{0}'.format(jobs))
                 except NotImplementedError:

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -248,6 +248,10 @@ def get_recursive_build_depends_in_workspace(package, ordered_packages):
     return recursive_depends
 
 
+def is_tty(stream):
+    return hasattr(stream, 'isatty') and stream.isatty()
+
+
 def log(*args, **kwargs):
     if 'end_with_escape' not in kwargs or kwargs['end_with_escape'] is True:
         args = list(args)

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -48,6 +48,21 @@ else:
 run_command = run.run_command
 
 
+class FakeLock(object):
+    """Fake lock used to mimic a Lock but without causing synchronization"""
+    def acquire(self, blocking=False):
+        return True
+
+    def release(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
 def create_build_space(buildspace, package_name):
     package_build_dir = os.path.join(buildspace, package_name)
     if not os.path.exists(package_build_dir):

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -337,11 +337,11 @@ def wide_log_(msg, **kwargs):
     else:
         log(msg, **kwargs)
 
-wide_log = wide_log_
+wide_log_fn = wide_log_
 
 
 def disable_wide_log():
-    global wide_log
+    global wide_log_fn
 
     def disabled_wide_log(msg, **kwargs):
         if 'rhs' in kwargs:
@@ -350,7 +350,12 @@ def disable_wide_log():
             del kwargs['truncate']
         log(msg, **kwargs)
 
-    wide_log = disabled_wide_log
+    wide_log_fn = disabled_wide_log
+
+
+def wide_log(msg, **kwargs):
+    global wide_log_fn
+    wide_log_fn(msg, **kwargs)
 
 
 def which(program):

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -1,0 +1,180 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import multiprocessing
+import os
+import re
+import sys
+
+if os.name == 'nt':
+    import catkin.cmi.run_windows as run
+else:
+    import catkin.cmi.run_unix as run
+
+# Get platform specific run command
+run_command = run.run_command
+
+
+def create_build_space(buildspace, package_name):
+    package_build_dir = os.path.join(buildspace, package_name)
+    if not os.path.exists(package_build_dir):
+        os.makedirs(package_build_dir)
+    return package_build_dir
+
+
+def extract_jobs_flags(mflags):
+    regex = r'(?:^|\s)(-?(?:j|l)(?:\s*[0-9]+|\s|$))' + \
+            r'|' + \
+            r'(?:^|\s)((?:--)?(?:jobs|load-average)(?:(?:=|\s+)[0-9]+|(?:\s|$)))'
+    matches = re.findall(regex, mflags) or []
+    matches = [m[0] or m[1] for m in matches]
+    return ' '.join([m.strip() for m in matches]) if matches else None
+
+
+def handle_make_arguments(input_make_args, force_single_threaded_when_running_tests=False):
+    make_args = list(input_make_args)
+    # make_args = ['-j1']
+
+    if force_single_threaded_when_running_tests:
+        # force single threaded execution when running test since rostest does not support multiple parallel runs
+        run_tests = [a for a in make_args if a.startswith('run_tests')]
+        if run_tests:
+            print('Forcing "-j1" for running unit tests.')
+            make_args.append('-j1')
+
+    # If no -j/--jobs/-l/--load-average flags are in make_args
+    if not extract_jobs_flags(' '.join(make_args)):
+        # If -j/--jobs/-l/--load-average are in MAKEFLAGS
+        if 'MAKEFLAGS' in os.environ and extract_jobs_flags(os.environ['MAKEFLAGS']):
+            # Do not extend make arguments, let MAKEFLAGS set things
+            pass
+        else:
+            # Else extend the make_arguments to include some jobs flags
+            # If ROS_PARALLEL_JOBS is set use those flags
+            if 'ROS_PARALLEL_JOBS' in os.environ:
+                # ROS_PARALLEL_JOBS is a set of make variables, not just a number
+                ros_parallel_jobs = os.environ['ROS_PARALLEL_JOBS']
+                make_args.extend(ros_parallel_jobs.split())
+            else:
+                # Else Use the number of CPU cores
+                try:
+                    jobs = multiprocessing.cpu_count()
+                    make_args.append('-j{0}'.format(jobs))
+                    make_args.append('-l{0}'.format(jobs))
+                except NotImplementedError:
+                    # If the number of cores cannot be determined, do not extend args
+                    pass
+    return make_args
+
+
+def get_build_type(package):
+    export_tags = [e.tagname for e in package.exports]
+    if 'build_type' in export_tags:
+        build_type_tag = [e.content for e in package.exports if e.tagname == 'build_type'][0]
+    else:
+        build_type_tag = 'catkin'
+    return build_type_tag
+
+
+def get_python_install_dir():
+    # this function returns the same value as the CMake variable PYTHON_INSTALL_DIR from catkin/cmake/python.cmake
+    python_install_dir = 'lib'
+    if os.name != 'nt':
+        python_version_xdoty = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
+        python_install_dir = os.path.join(python_install_dir, 'python' + python_version_xdoty)
+
+    python_use_debian_layout = os.path.exists('/etc/debian_version')
+    python_packages_dir = 'dist-packages' if python_use_debian_layout else 'site-packages'
+    python_install_dir = os.path.join(python_install_dir, python_packages_dir)
+    return python_install_dir
+
+
+class FakeLock(object):
+    """Fake lock used to mimic a Lock but without causing synchronization"""
+    def acquire(self, blocking=False):
+        return True
+
+    def release(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+def log(*args, **kwargs):
+    if 'end_with_escape' in kwargs and kwargs['end_with_escape']:
+        args = list(args)
+        args.append('\033[0m')
+        del kwargs['end_with_escape']
+    print(*args, **kwargs)
+
+
+def terminal_width():
+    """Estimate the width of the terminal"""
+    width = 0
+    try:
+        import struct
+        import fcntl
+        import termios
+        s = struct.pack('HHHH', 0, 0, 0, 0)
+        x = fcntl.ioctl(1, termios.TIOCGWINSZ, s)
+        width = struct.unpack('HHHH', x)[1]
+    except IOError:
+        pass
+    if width <= 0:
+        try:
+            width = int(os.environ['COLUMNS'])
+        except:
+            pass
+    if width <= 0:
+        width = 80
+
+    return width
+
+
+def remove_ansi_escape(string):
+    ansi_escape = re.compile(r'\x1b[^m]*m')
+    return ansi_escape.sub('', string)
+
+
+def wide_log(msg, **kwargs):
+    width = terminal_width()
+    if len(msg) < width:
+        log(msg + (' ' * (width - len(remove_ansi_escape(msg)) - 1)), **kwargs)
+    else:
+        log(msg, **kwargs)

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -218,10 +218,11 @@ class FakeLock(object):
 
 
 def log(*args, **kwargs):
-    if 'end_with_escape' in kwargs and kwargs['end_with_escape']:
+    if 'end_with_escape' not in kwargs or kwargs['end_with_escape'] is True:
         args = list(args)
         args.append('\033[0m')
-        del kwargs['end_with_escape']
+        if 'end_with_escape' in kwargs:
+            del kwargs['end_with_escape']
     print(*args, **kwargs)
 
 

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -126,8 +126,27 @@ def extract_jobs_flags(mflags):
 
 
 def format_time_delta(delta):
-    hours, minutes, seconds = str(datetime.timedelta(seconds=delta)).split(':')
-    msg = "" if int(hours) == 0 else (hours + ":")
+    days = "0"
+    date_str = str(datetime.timedelta(seconds=delta))
+    if ', ' in date_str:
+        days, date_str = date_str.split(', ')
+    hours, minutes, seconds = date_str.split(':')
+    msg = "" if int(days.split(' ')[0]) == 0 else days + " "
+    msg += "" if int(hours) == 0 else (hours + " hour{0} ".format('' if int(hours) <= 1 else 's'))
+    msg += "" if int(minutes) == 0 else ("{0} minute{1} and ".format(int(minutes), '' if int(minutes) <= 1 else 's'))
+    msg += "{0:.1f}".format(float(seconds))
+    msg += " seconds"
+    return msg
+
+
+def format_time_delta_short(delta):
+    days = "0"
+    date_str = str(datetime.timedelta(seconds=delta))
+    if ', ' in date_str:
+        days, date_str = date_str.split(', ')
+    hours, minutes, seconds = date_str.split(':')
+    msg = "" if int(days.split(' ')[0]) == 0 else days + " "
+    msg += "" if int(hours) == 0 else (hours + ":")
     msg += "" if int(minutes) == 0 else (minutes + ":")
     msg += ("{0:.1f}" if int(minutes) == 0 else "{0:04.1f}").format(float(seconds))
     return msg
@@ -274,12 +293,18 @@ def remove_ansi_escape(string):
 
 def wide_log(msg, **kwargs):
     width = terminal_width()
+    rhs = ''
+    if 'rhs' in kwargs:
+        rhs = ' ' + kwargs['rhs']
+        del kwargs['rhs']
+    if rhs:
+        kwargs['truncate'] = True
     if 'truncate' in kwargs:
         if kwargs['truncate'] and len(msg) >= width - 1:
-            msg = msg[:width - 4] + '...'
+            msg = msg[:width - len(rhs) - 4] + '...'
         del kwargs['truncate']
-    if len(msg) < width:
-        log(msg + (' ' * (width - len(remove_ansi_escape(msg)) - 1)), **kwargs)
+    if len(msg) + len(rhs) < width:
+        log(msg + (' ' * (width - len(remove_ansi_escape(msg)) - len(rhs) - 1)) + rhs, **kwargs)
     else:
         log(msg, **kwargs)
 

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -128,7 +128,7 @@ def format_time_delta(delta):
     hours, minutes, seconds = str(datetime.timedelta(seconds=delta)).split(':')
     msg = "" if int(hours) == 0 else (hours + ":")
     msg += "" if int(minutes) == 0 else (minutes + ":")
-    msg += "{0:2.1f}".format(float(seconds))
+    msg += ("{0:.1f}" if int(minutes) == 0 else "{0:04.1f}").format(float(seconds))
     return msg
 
 

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -255,7 +255,9 @@ def is_tty(stream):
 def log(*args, **kwargs):
     if 'end_with_escape' not in kwargs or kwargs['end_with_escape'] is True:
         args = list(args)
-        args.append('\033[0m')
+        escape_reset = clr('@|')
+        if escape_reset:
+            args.append(escape_reset)
         if 'end_with_escape' in kwargs:
             del kwargs['end_with_escape']
     print(*args, **kwargs)

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -178,3 +178,31 @@ def wide_log(msg, **kwargs):
         log(msg + (' ' * (width - len(remove_ansi_escape(msg)) - 1)), **kwargs)
     else:
         log(msg, **kwargs)
+
+
+def which(program):
+    """Custom version of the ``which`` built-in shell command.
+
+    Searches the pathes in the ``PATH`` environment variable for a given
+    executable name. It returns the full path to the first instance of the
+    executable found or None if it was not found.
+
+    :param program: name of the executable to find
+    :type program: str
+    :returns: Full path to the first instance of the executable, or None
+    :rtype: str or None
+    """
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, _ = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ.get('PATH', os.defpath).split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+    return None

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -202,21 +202,6 @@ def get_recursive_build_depends_in_workspace(package, ordered_packages):
     return recursive_depends
 
 
-class FakeLock(object):
-    """Fake lock used to mimic a Lock but without causing synchronization"""
-    def acquire(self, blocking=False):
-        return True
-
-    def release(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
-
 def log(*args, **kwargs):
     if 'end_with_escape' not in kwargs or kwargs['end_with_escape'] is True:
         args = list(args)

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -33,6 +33,7 @@
 
 from __future__ import print_function
 
+import datetime
 import multiprocessing
 import os
 import re
@@ -106,6 +107,14 @@ def extract_jobs_flags(mflags):
     matches = re.findall(regex, mflags) or []
     matches = [m[0] or m[1] for m in matches]
     return ' '.join([m.strip() for m in matches]) if matches else None
+
+
+def format_time_delta(delta):
+    hours, minutes, seconds = str(datetime.timedelta(seconds=delta)).split(':')
+    msg = "" if int(hours) == 0 else (hours + ":")
+    msg += "" if int(minutes) == 0 else (minutes + ":")
+    msg += "{0:2.1f}".format(float(seconds))
+    return msg
 
 
 def handle_make_arguments(input_make_args, force_single_threaded_when_running_tests=False):
@@ -241,6 +250,10 @@ def remove_ansi_escape(string):
 
 def wide_log(msg, **kwargs):
     width = terminal_width()
+    if 'truncate' in kwargs:
+        if kwargs['truncate'] and len(msg) >= width - 1:
+            msg = msg[:width - 4] + '...'
+        del kwargs['truncate']
     if len(msg) < width:
         log(msg + (' ' * (width - len(remove_ansi_escape(msg)) - 1)), **kwargs)
     else:

--- a/python/catkin/cmi/common.py
+++ b/python/catkin/cmi/common.py
@@ -299,12 +299,15 @@ def wide_log(msg, **kwargs):
         del kwargs['rhs']
     if rhs:
         kwargs['truncate'] = True
+    rhs_len = len(remove_ansi_escape(rhs))
+    msg_len = len(remove_ansi_escape(msg))
     if 'truncate' in kwargs:
-        if kwargs['truncate'] and len(msg) >= width - 1:
-            msg = msg[:width - len(rhs) - 4] + '...'
+        if kwargs['truncate'] and msg_len >= width - 1:
+            msg = msg[:width - rhs_len - 4] + '...'
+            msg_len = len(remove_ansi_escape(msg))
         del kwargs['truncate']
-    if len(msg) + len(rhs) < width:
-        log(msg + (' ' * (width - len(remove_ansi_escape(msg)) - len(rhs) - 1)) + rhs, **kwargs)
+    if msg_len + rhs_len < width:
+        log(msg + (' ' * (width - msg_len - rhs_len - 1)) + rhs, **kwargs)
     else:
         log(msg, **kwargs)
 

--- a/python/catkin/cmi/context.py
+++ b/python/catkin/cmi/context.py
@@ -1,0 +1,273 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""This module implements a class for representing a catkin workspace context"""
+
+from __future__ import print_function
+
+import os
+
+
+# TODO: extend builtin prototype to handle locking
+class Context(object):
+    """Encapsulates a catkin workspace's settings which affect build results.
+
+    This class will validate some of the settings on assignment using the
+    filesystem, but it will never modify the filesystem. For instance, it will
+    raise an exception if the source space does not exist, but it will not
+    create a folder for the build space if it does not already exist.
+
+    This context can be locked, so that changing the members is prevented.
+    """
+    def __init__(
+        self,
+        workspace=None,
+        source_space=None,
+        build_space=None,
+        devel_space=None,
+        install_space=None,
+        merge_devel=False,
+        install=False,
+        isolate_install=False,
+        cmake_args=None,
+        make_args=None,
+        catkin_make_args=None
+    ):
+        """Creates a new Context object, optionally initializing with parameters
+
+        :param workspace: root of the workspace, defaults to '.'
+        :type workspace: str
+        :param source_space: location of source space, defaults to '<workspace>/src'
+        :type source_space: str
+        :param build_space: target location of build space, defaults to '<workspace>/build'
+        :type build_space: str
+        :param devel_space: target location of devel space, defaults to '<workspace>/devel'
+        :type devel_space: str
+        :param install_space: target location of install space, defaults to '<workspace>/install'
+        :type install_space: str
+        :param merge_devel: devel space will be shared for all packages if True, default is False
+        :type merge_devel: bool
+        :param install: packages will be installed by invoking ``make install``, defaults to False
+        :type install: bool
+        :param isolate_install: packages will be installed to separate folders if True, defaults to False
+        :type isolate_install: bool
+        :param cmake_args: extra cmake arguments to be passed to cmake for each package
+        :type cmake_args: list
+        :param make_args: extra make arguments to be passed to make for each package
+        :type make_args: list
+        :param catkin_make_args: extra make arguments to be passed to make for each catkin package
+        :type catkin_make_args: list
+        :raises: ValueError if workspace or source space does not exist
+        """
+        self.__locked = False
+        # Validation is done on assignment
+        # Handle *space assignment and defaults
+        self.workspace = '.' if workspace is None else workspace
+        self.source_space = os.path.join(self.workspace, 'src') if source_space is None else source_space
+        self.build_space = os.path.join(self.workspace, 'build') if build_space is None else build_space
+        self.devel_space = os.path.join(self.workspace, 'devel') if devel_space is None else devel_space
+        self.install_space = os.path.join(self.workspace, 'install') if install_space is None else install_space
+        self.destdir = os.environ['DESTDIR'] if 'DESTDIR' in os.environ else None
+        # Handle build options
+        self.merge_devel = merge_devel
+        self.install = install
+        self.isolate_install = isolate_install
+        # Handle additional cmake and make arguments
+        self.cmake_args = cmake_args or []
+        self.make_args = make_args or []
+        self.catkin_make_args = catkin_make_args or []
+        # List of packages in the workspace is set externally
+        self.packages = []
+
+    def summary(self):
+        summary = """\
+----------------------------
+Workspace:                   {_Context__workspace}
+Buildspace:                  {_Context__build_space}
+Develspace:                  {_Context__devel_space}
+Installspace:                {_Context__install_space}
+DESTDIR:                     {_Context__destdir}
+----------------------------
+Merge Develspaces:           {_Context__merge_devel}
+Install Packages:            {_Context__install}
+Isolate Installs:            {_Context__isolate_install}
+----------------------------
+Additional CMake Args:       {cmake_args}
+Additional Make Args:        {make_args}
+Additional catkin Make Args: {catkin_make_args}
+----------------------------"""
+        return summary.format(
+            cmake_args=', '.join(self.__cmake_args or ['None']),
+            make_args=', '.join(self.__make_args or ['None']),
+            catkin_make_args=', '.join(self.__catkin_make_args or ['None']),
+            **self.__dict__
+        )
+
+    @property
+    def workspace(self):
+        return self.__workspace
+
+    @workspace.setter
+    def workspace(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        # Validate Workspace
+        if not os.path.exists(value):
+            raise ValueError("Workspace path '{0}' does not exist.".format(value))
+        self.__workspace = os.path.abspath(value)
+
+    @property
+    def source_space(self):
+        return self.__source_space
+
+    @source_space.setter
+    def source_space(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        # Check that the source space exists
+        if not os.path.exists(value):
+            raise ValueError("Could not find source space: {0}".format(value))
+        self.__source_space = os.path.abspath(value)
+
+    @property
+    def build_space(self):
+        return self.__build_space
+
+    @build_space.setter
+    def build_space(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        # TODO: check that build space was not run with a different context before
+        self.__build_space = value
+
+    @property
+    def devel_space(self):
+        return self.__devel_space
+
+    @devel_space.setter
+    def devel_space(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        # TODO: check that devel space was not run with a different context before
+        self.__devel_space = value
+
+    @property
+    def install_space(self):
+        return self.__install_space
+
+    @install_space.setter
+    def install_space(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        # TODO: check that install space was not run with a different context before
+        self.__install_space = value
+
+    @property
+    def destdir(self):
+        return self.__destdir
+
+    @destdir.setter
+    def destdir(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__destdir = value
+
+    @property
+    def merge_devel(self):
+        return self.__merge_devel
+
+    @merge_devel.setter
+    def merge_devel(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__merge_devel = value
+
+    @property
+    def install(self):
+        return self.__install
+
+    @install.setter
+    def install(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__install = value
+
+    @property
+    def isolate_install(self):
+        return self.__isolate_install
+
+    @isolate_install.setter
+    def isolate_install(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__isolate_install = value
+
+    @property
+    def cmake_args(self):
+        return self.__cmake_args
+
+    @cmake_args.setter
+    def cmake_args(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__cmake_args = value
+
+    @property
+    def make_args(self):
+        return self.__make_args
+
+    @make_args.setter
+    def make_args(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__make_args = value
+
+    @property
+    def catkin_make_args(self):
+        return self.__catkin_make_args
+
+    @catkin_make_args.setter
+    def catkin_make_args(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__catkin_make_args = value
+
+    @property
+    def packages(self):
+        return self.__packages
+
+    @packages.setter
+    def packages(self, value):
+        if self.__locked:
+            raise RuntimeError("Setting of context members is not allowed while locked.")
+        self.__packages = value

--- a/python/catkin/cmi/context.py
+++ b/python/catkin/cmi/context.py
@@ -37,6 +37,10 @@ from __future__ import print_function
 
 import os
 
+from catkin.cmi.color import clr
+
+from catkin.cmi.common import remove_ansi_escape
+
 
 # TODO: extend builtin prototype to handle locking
 class Context(object):
@@ -116,21 +120,21 @@ class Context(object):
     def summary(self):
         summary = [
             [
-                "Workspace:                   {_Context__workspace}",
-                "Buildspace:                  {_Context__build_space}",
-                "Develspace:                  {_Context__devel_space}",
-                "Installspace:                {_Context__install_space}",
-                "DESTDIR:                     {_Context__destdir}"
+                clr("@{cf}Workspace:@|                   @{yf}{_Context__workspace}@|"),
+                clr("@{cf}Buildspace:@|                  @{yf}{_Context__build_space}@|"),
+                clr("@{cf}Develspace:@|                  @{yf}{_Context__devel_space}@|"),
+                clr("@{cf}Installspace:@|                @{yf}{_Context__install_space}@|"),
+                clr("@{cf}DESTDIR:@|                     @{yf}{_Context__destdir}@|"),
             ],
             [
-                "Merge Develspaces:           {_Context__merge_devel}",
-                "Install Packages:            {_Context__install}",
-                "Isolate Installs:            {_Context__isolate_install}"
+                clr("@{cf}Merge Develspaces:@|           @{yf}{_Context__merge_devel}@|"),
+                clr("@{cf}Install Packages:@|            @{yf}{_Context__install}@|"),
+                clr("@{cf}Isolate Installs:@|            @{yf}{_Context__isolate_install}@|"),
             ],
             [
-                "Additional CMake Args:       {cmake_args}",
-                "Additional Make Args:        {make_args}",
-                "Additional catkin Make Args: {catkin_make_args}"
+                clr("@{cf}Additional CMake Args:@|       @{yf}{cmake_args}@|"),
+                clr("@{cf}Additional Make Args:@|        @{yf}{make_args}@|"),
+                clr("@{cf}Additional catkin Make Args:@| @{yf}{catkin_make_args}@|"),
             ]
         ]
         subs = {
@@ -144,9 +148,10 @@ class Context(object):
         for group in summary:
             for index, line in enumerate(group):
                 group[index] = line.format(**subs)
-                max_length = max(max_length, len(line))
+                max_length = max(max_length, len(remove_ansi_escape(group[index])))
             groups.append("\n".join(group))
-        return ('-' * max_length) + "\n" + ("\n" + ('-' * max_length) + "\n").join(groups) + "\n" + ('-' * max_length)
+        divider = clr('@{pf}' + ('-' * max_length) + '@|')
+        return divider + "\n" + ("\n" + divider + "\n").join(groups) + "\n" + divider
 
     @property
     def workspace(self):

--- a/python/catkin/cmi/context.py
+++ b/python/catkin/cmi/context.py
@@ -61,7 +61,8 @@ class Context(object):
         isolate_install=False,
         cmake_args=None,
         make_args=None,
-        catkin_make_args=None
+        catkin_make_args=None,
+        space_suffix=None
     ):
         """Creates a new Context object, optionally initializing with parameters
 
@@ -87,16 +88,19 @@ class Context(object):
         :type make_args: list
         :param catkin_make_args: extra make arguments to be passed to make for each catkin package
         :type catkin_make_args: list
+        :param space_suffix: suffix for build, devel, and install spaces which are not explicitly set.
+        :type space_suffix: str
         :raises: ValueError if workspace or source space does not exist
         """
         self.__locked = False
+        ss = '' if space_suffix is None else space_suffix
         # Validation is done on assignment
         # Handle *space assignment and defaults
         self.workspace = '.' if workspace is None else workspace
         self.source_space = os.path.join(self.workspace, 'src') if source_space is None else source_space
-        self.build_space = os.path.join(self.workspace, 'build') if build_space is None else build_space
-        self.devel_space = os.path.join(self.workspace, 'devel') if devel_space is None else devel_space
-        self.install_space = os.path.join(self.workspace, 'install') if install_space is None else install_space
+        self.build_space = os.path.join(self.workspace, 'build' + ss) if build_space is None else build_space
+        self.devel_space = os.path.join(self.workspace, 'devel' + ss) if devel_space is None else devel_space
+        self.install_space = os.path.join(self.workspace, 'install' + ss) if install_space is None else install_space
         self.destdir = os.environ['DESTDIR'] if 'DESTDIR' in os.environ else None
         # Handle build options
         self.merge_devel = merge_devel

--- a/python/catkin/cmi/context.py
+++ b/python/catkin/cmi/context.py
@@ -110,28 +110,39 @@ class Context(object):
         self.packages = []
 
     def summary(self):
-        summary = """\
-----------------------------
-Workspace:                   {_Context__workspace}
-Buildspace:                  {_Context__build_space}
-Develspace:                  {_Context__devel_space}
-Installspace:                {_Context__install_space}
-DESTDIR:                     {_Context__destdir}
-----------------------------
-Merge Develspaces:           {_Context__merge_devel}
-Install Packages:            {_Context__install}
-Isolate Installs:            {_Context__isolate_install}
-----------------------------
-Additional CMake Args:       {cmake_args}
-Additional Make Args:        {make_args}
-Additional catkin Make Args: {catkin_make_args}
-----------------------------"""
-        return summary.format(
-            cmake_args=', '.join(self.__cmake_args or ['None']),
-            make_args=', '.join(self.__make_args or ['None']),
-            catkin_make_args=', '.join(self.__catkin_make_args or ['None']),
-            **self.__dict__
-        )
+        summary = [
+            [
+                "Workspace:                   {_Context__workspace}",
+                "Buildspace:                  {_Context__build_space}",
+                "Develspace:                  {_Context__devel_space}",
+                "Installspace:                {_Context__install_space}",
+                "DESTDIR:                     {_Context__destdir}"
+            ],
+            [
+                "Merge Develspaces:           {_Context__merge_devel}",
+                "Install Packages:            {_Context__install}",
+                "Isolate Installs:            {_Context__isolate_install}"
+            ],
+            [
+                "Additional CMake Args:       {cmake_args}",
+                "Additional Make Args:        {make_args}",
+                "Additional catkin Make Args: {catkin_make_args}"
+            ]
+        ]
+        subs = {
+            'cmake_args': ', '.join(self.__cmake_args or ['None']),
+            'make_args': ', '.join(self.__make_args or ['None']),
+            'catkin_make_args': ', '.join(self.__catkin_make_args or ['None'])
+        }
+        subs.update(**self.__dict__)
+        max_length = 0
+        groups = []
+        for group in summary:
+            for index, line in enumerate(group):
+                group[index] = line.format(**subs)
+                max_length = max(max_length, len(line))
+            groups.append("\n".join(group))
+        return ('-' * max_length) + "\n" + ("\n" + ('-' * max_length) + "\n").join(groups) + "\n" + ('-' * max_length)
 
     @property
     def workspace(self):

--- a/python/catkin/cmi/executor.py
+++ b/python/catkin/cmi/executor.py
@@ -31,6 +31,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Executor implementation, these objects create threads and process jobs in them"""
+
 from __future__ import print_function
 
 from threading import Thread
@@ -42,7 +44,12 @@ from catkin.cmi.common import run_command
 
 
 class ExecutorEvent(object):
-    """This is returned by the Executor when terminating, possibly other times"""
+    """This is returned by the Executor when an event occurs
+
+    Events can be jobs starting/finishing, commands starting/failing/finishing,
+    commands producing output (each line is an event), or when the executor
+    quits or failes.
+    """
     def __init__(self, executor_id, event_type, data, package):
         self.executor_id = executor_id
         self.event_type = event_type
@@ -51,7 +58,7 @@ class ExecutorEvent(object):
 
 
 class Executor(Thread):
-    """Multiprocessing executor for the parallel cmi jobs"""
+    """Threaded executor for the parallel cmi jobs"""
     name_prefix = 'cmi'
 
     def __init__(self, executor_id, context, comm_queue, job_queue, install_lock):

--- a/python/catkin/cmi/executor.py
+++ b/python/catkin/cmi/executor.py
@@ -33,7 +33,7 @@
 
 from __future__ import print_function
 
-from multiprocessing import Process
+from threading import Thread
 
 from catkin.cmi.common import remove_ansi_escape
 from catkin.cmi.common import run_command
@@ -48,7 +48,7 @@ class ExecutorEvent(object):
         self.package = package
 
 
-class Executor(Process):
+class Executor(Thread):
     """Multiprocessing executor for the parallel cmi jobs"""
     name_prefix = 'cmi'
 

--- a/python/catkin/cmi/executor.py
+++ b/python/catkin/cmi/executor.py
@@ -1,0 +1,154 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+from multiprocessing import Process
+
+from catkin.cmi.common import remove_ansi_escape
+from catkin.cmi.common import run_command
+
+
+class ExecutorEvent(object):
+    """This is returned by the Executor when terminating, possibly other times"""
+    def __init__(self, executor_id, event_type, message, package):
+        self.executor_id = executor_id
+        self.event_type = event_type
+        self.message = message
+        self.package = package
+
+
+class Executor(Process):
+    """Multiprocessing executor for the parallel cmi jobs"""
+    name_prefix = 'cmi'
+
+    def __init__(self, executor_id, context, comm_queue, job_queue, devel_lock, install_lock):
+        super(Executor, self).__init__()
+        self.name = self.name_prefix + '-' + str(executor_id + 1)
+        self.executor_id = executor_id
+        self.c = context
+        self.queue = comm_queue
+        self.jobs = job_queue
+        self.devel_lock = devel_lock
+        self.install_lock = install_lock
+        self.current_job = None
+
+    def log(self, msg):
+        package_name = '' if self.current_job is None else self.current_job.package.name
+        self.queue.put(ExecutorEvent(self.executor_id, 'log', msg, package_name))
+
+    def command_log(self, msg):
+        package_name = '' if self.current_job is None else self.current_job.package.name
+        self.queue.put(ExecutorEvent(self.executor_id, 'command_log', msg, package_name))
+
+    def command_started(self, cmd, location):
+        package_name = '' if self.current_job is None else self.current_job.package.name
+        self.queue.put(ExecutorEvent(self.executor_id, 'command_started', (cmd, location), package_name))
+
+    def command_finished(self, cmd, retcode):
+        package_name = '' if self.current_job is None else self.current_job.package.name
+        self.queue.put(ExecutorEvent(self.executor_id, 'command_finished', (cmd, retcode), package_name))
+
+    def command_failed(self, cmd, retcode, location):
+        package_name = '' if self.current_job is None else self.current_job.package.name
+        self.queue.put(ExecutorEvent(self.executor_id, 'command_failed', (cmd, retcode, location), package_name))
+
+    def started_new_job(self, job):
+        self.queue.put(ExecutorEvent(self.executor_id, 'job_started', '', job.package.name))
+
+    def finished_job(self, job):
+        self.queue.put(ExecutorEvent(self.executor_id, 'job_finished', '', job.package.name))
+
+    def quit(self):
+        package_name = '' if self.current_job is None else self.current_job.package.name
+        self.queue.put(ExecutorEvent(self.executor_id, 'exit', 'Finished processing.', package_name))
+
+    def run(self):
+        try:
+            # Until exit
+            while True:
+                # Get a job off the queue
+                self.current_job = self.jobs.get()
+                # If the job is None, then we should shutdown
+                if self.current_job is None:
+                    # Notify shutfown
+                    self.quit()
+                    break
+                # Notify that a new job was started
+                self.started_new_job(self.current_job)
+                # Execute each command in the job
+                for command in self.current_job:
+                    try:
+                        devel_lock_acquired = False
+                        install_lock_acquired = False
+                        # If it uses the devel space, acquire the devel_lock
+                        if 'devel' in command.spaces:
+                            devel_lock_acquired = self.devel_lock.acquire()
+                        # If it uses the install space, acquire the install_lock
+                        if 'install' in command.spaces:
+                            install_lock_acquired = self.install_lock.acquire()
+                        # Log that the command being run
+                        self.command_started(' '.join(command.cmd), command.location)
+                        # Receive lines from the running command
+                        for line in run_command(command.cmd, cwd=command.location):
+                            # If it is a string, log it
+                            if isinstance(line, str):
+                                # Ensure it is not just ansi escape characters
+                                if remove_ansi_escape(line).strip():
+                                    for sub_line in line.split('\n'):
+                                        sub_line = sub_line.rstrip()
+                                        if sub_line:
+                                            self.command_log(sub_line)
+                            else:
+                                # Otherwise it is a return code
+                                retcode = line
+                                # If the return code is not zero
+                                if retcode != 0:
+                                    # Log the failure (the build loop will dispatch None's)
+                                    self.command_failed(' '.join(command.cmd), retcode, command.location)
+                                    # Try to consume and throw away any and all remaining jobs in the queue
+                                    while self.jobs.get() is not None:
+                                        pass
+                                    # Once we get our None, quit
+                                    self.quit()
+                                    return
+                                else:
+                                    self.command_finished(' '.join(command.cmd), retcode)
+                    finally:
+                        if devel_lock_acquired:
+                            self.devel_lock.release()
+                        if install_lock_acquired:
+                            self.install_lock.release()
+                self.finished_job(self.current_job)
+        except KeyboardInterrupt:
+            pass

--- a/python/catkin/cmi/executor.py
+++ b/python/catkin/cmi/executor.py
@@ -144,8 +144,7 @@ class Executor(Thread):
                             if isinstance(line, str):
                                 # Ensure it is not just ansi escape characters
                                 if remove_ansi_escape(line).strip():
-                                    for sub_line in line.split('\n'):
-                                        sub_line = sub_line.rstrip()
+                                    for sub_line in line.splitlines(True):  # keepends=True
                                         if sub_line:
                                             if command.stage_name == 'cmake':
                                                 sub_line = colorize_cmake(sub_line)

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -306,5 +306,5 @@ class CatkinJob(Job):
         ))
         # Make install command, if installing
         if self.context.install:
-            commands.append(InstallCommand([env_cmd, MAKE_EXEC, 'install'], build_space))
+            commands.append(InstallCommand(env_cmd, [MAKE_EXEC, 'install'], build_space))
         return commands

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -306,5 +306,5 @@ class CatkinJob(Job):
         ))
         # Make install command, if installing
         if self.context.install:
-            commands.append(InstallCommand(env_cmd, [MAKE_EXEC, 'install'], build_space))
+            commands.append(InstallCommand([env_cmd, MAKE_EXEC, 'install'], build_space))
         return commands

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -147,9 +147,17 @@ if [ $# -eq 0 ] ; then
   exit 1
 fi
 
+# save original args for later
+_ARGS=$@
+# remove all passed in args, resetting $@, $*, $#, $n
+shift $#
+# set the args for the sourced scripts
+set $@=--extend
 # source setup.sh with --extend argument for each direct build depend in the workspace
 {sources}
-exec "$@"
+
+# execute given args
+exec $_ARGS
 """.format(sources=''.join(sources))
     with open(env_file_path, 'w') as f:
         f.write(env_file)

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -100,7 +100,7 @@ def create_env_file(package, context):
         # Source each package's install or devel space
         space = context.install_space if context.install else context.devel_space
         # Get the recursive dependcies
-        depends = get_cached_recursive_build_depends_in_workspace(package, context.workspace_packages)
+        depends = get_cached_recursive_build_depends_in_workspace(package, context.packages)
         # For each dep add a line to source its setup file
         source_snippet = ". {source_path} --extend\n"
         for dep_pth, dep in depends:

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -84,7 +84,6 @@ class Job(object):
 
 
 def create_env_file(package, context):
-    source_snippet = ". {source_path} --extend\n"
     sources = []
     # If installing to isolated folders or not installing, but devel spaces are not merged
     if (context.install and context.isolate_install) or (not context.install and not context.merge_devel):
@@ -93,11 +92,13 @@ def create_env_file(package, context):
         # Get the recursive dependcies
         depends = get_cached_recursive_build_depends_in_workspace(package, context.workspace_packages)
         # For each dep add a line to source its setup file
+        source_snippet = ". {source_path} --extend\n"
         for dep_pth, dep in depends:
             source_path = os.path.join(space, dep.name, 'setup.sh')
             sources.append(source_snippet.format(source_path=source_path))
     else:
         # Just source common install or devel space
+        source_snippet = ". {source_path}\n"
         source_path = os.path.join(context.install_space if context.install else context.devel_space, 'setup.sh')
         sources = [source_snippet.format(source_path=source_path)] if os.path.exists(source_path) else []
     # Build the env_file

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -52,9 +52,19 @@ if MAKE_EXEC is None:
 
 class Command(object):
     """Single command which is part of a job"""
+    lock_install_space = False
+
     def __init__(self, cmd, location):
         self.cmd = cmd
         self.location = location
+
+
+class InstallCommand(Command):
+    """Command which touches the install space"""
+    lock_install_space = True
+
+    def __init__(self, cmd, location):
+        super(InstallCommand, self).__init__(cmd, location)
 
 
 class Job(object):
@@ -170,7 +180,7 @@ class CMakeJob(Job):
             build_space
         ))
         # Make install command (always run on plain cmake)
-        commands.append(Command([env_cmd, MAKE_EXEC, 'install'], build_space))
+        commands.append(InstallCommand([env_cmd, MAKE_EXEC, 'install'], build_space))
         # Determine the location of where the setup.sh file should be created
         if self.context.install:
             setup_file_path = os.path.join(install_space, 'setup.sh')
@@ -267,5 +277,5 @@ class CatkinJob(Job):
         ))
         # Make install command, if installing
         if self.context.install:
-            commands.append(Command([env_cmd, MAKE_EXEC, 'install'], build_space))
+            commands.append(InstallCommand([env_cmd, MAKE_EXEC, 'install'], build_space))
         return commands

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -1,0 +1,277 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import os
+import stat
+
+from catkin.cmi.common import create_build_space
+from catkin.cmi.common import get_python_install_dir
+from catkin.cmi.common import handle_make_arguments
+
+
+class Command(object):
+    """Single command which is part of a job"""
+    def __init__(self, cmd, location, spaces=None):
+        self.cmd = cmd
+        self.location = location
+        self.spaces = [] if spaces is None else spaces
+
+
+class Job(object):
+    """Encapsulates a job which builds a package"""
+    def __init__(self, package, package_path, context, force_cmake):
+        self.package = package
+        self.package_path = package_path
+        self.context = context
+        self.force_cmake = force_cmake
+        self.commands = []
+        self.__command_index = 0
+
+    def get_commands(self):
+        raise NotImplementedError('get_commands')
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        if self.__command_index >= len(self.commands):
+            raise StopIteration()
+        self.__command_index += 1
+        return self.commands[self.__command_index - 1]
+
+
+def create_env_file(package, build_space, devel_space, merge_devel, workspace_packages):
+    source_snippet = ". {source_path} --extend\n"
+    # If merge_devel then you only ever need to use the env file for the merged devel space
+    sources = [source_snippet.format(source_path=os.path.join(devel_space, 'setup.sh'))]
+    if not merge_devel:
+        # Otherwise you need to source each of the devel spaces which you depend on, recursively
+        sources = []  # Clear the list
+        packages = dict([(x.name, x) for x in workspace_packages])
+        # Seed deps with package's build and buildtool dependnecies
+        deps = set([d.name for d in (package.build_depends + package.buildtool_depends)])
+        processed_deps = set()
+        # print('>', package.name)
+        # Add snippets to try and source dependencies which are in the workspace, recursively
+        while list(deps - processed_deps):
+            # Get a dep
+            dep = list(deps - processed_deps).pop()
+            processed_deps.add(dep)
+            # print('> ', dep)
+            # If the dep is not in the workspace, ignore it
+            if dep not in packages:
+                continue
+            # Add this dep's build, buildtool, and run dependencies to the deps list
+            dep_pkg = packages[dep]
+            pkg_depends = dep_pkg.build_depends + dep_pkg.buildtool_depends + dep_pkg.run_depends
+            # print('> ', dep, 'dependencies:', [d.name for d in pkg_depends])
+            deps.update(set([d.name for d in pkg_depends]))
+            # Add a snippet to try and source this dep
+            source_path = os.path.join(devel_space, dep, 'setup.sh')
+            sources.append(source_snippet.format(source_path=source_path))
+    env_file = """\
+#!/usr/bin/env sh
+# generated from within catkin/python/catkin/cmi/job.py
+
+if [ $# -eq 0 ] ; then
+  /bin/echo "Usage: env.sh COMMANDS"
+  /bin/echo "Calling env.sh without arguments is not supported anymore."
+  /bin/echo "Instead spawn a subshell and source a setup file manually."
+  exit 1
+fi
+
+# source setup.sh with --extend argument for each direct build depend in the workspace
+{sources}
+exec "$@"
+""".format(sources=''.join(sources))
+    env_file_path = os.path.join(build_space, package.name, 'cmi_env.sh')
+    with open(env_file_path, 'w') as f:
+        f.write(env_file)
+    os.chmod(env_file_path, stat.S_IXUSR | stat.S_IWUSR | stat.S_IRUSR)
+    return env_file_path
+
+
+# TODO: Move various Job types out to another file
+
+class CMakeJob(Job):
+    """Job class for building plain cmake packages"""
+    def __init__(self, package, package_path, context, force_cmake):
+        Job.__init__(self, package, package_path, context, force_cmake)
+        self.commands = self.get_commands()
+
+    def get_commands(self):
+        commands = []
+        # Setup build variables
+        pkg_dir = os.path.join(self.context.source_space, self.package.name)
+        build_space = create_build_space(self.context.build_space, self.package.name)
+        if self.context.merge_devel:
+            devel_space = self.context.devel_space
+        else:
+            devel_space = os.path.join(self.context.devel_space, self.package.name)
+        if self.context.isolate_install:
+            install_space = os.path.join(self.context.install_space, self.package.name)
+        else:
+            install_space = self.context.install_space
+        install_target = install_space if self.context.install else devel_space
+        # Create an environment file
+        env_cmd = create_env_file(self.package, self.context.build_space,
+                                  self.context.devel_space, self.context.merge_devel, self.context.packages)
+        # CMake command
+        makefile_path = os.path.join(build_space, 'Makefile')
+        if not os.path.isfile(makefile_path) or self.force_cmake:
+            commands.append(Command(
+                [
+                    env_cmd,
+                    'cmake',
+                    pkg_dir,
+                    '-DCMAKE_INSTALL_PREFIX=' + install_target
+                ] + self.context.cmake_args,
+                build_space,
+                ['devel']
+            ))
+            commands[-1].cmd.extend(self.context.cmake_args)
+        else:
+            commands.append(Command([env_cmd, 'make', 'cmake_check_build_system'], build_space, ['devel']))
+        # Make command
+        commands.append(Command(
+            [env_cmd, 'make'] + handle_make_arguments(self.context.make_args),
+            build_space,
+            ['devel']
+        ))
+        # Make install command (always run on plain cmake)
+        commands.append(Command([env_cmd, 'make', 'install'], build_space, ['devel', 'install']))
+        # Determine the location of where the setup.sh file should be created
+        if self.context.install:
+            setup_file_path = os.path.join(install_space, 'setup.sh')
+        else:  # Create it in the devel space
+            setup_file_path = os.path.join(devel_space, 'setup.sh')
+            if self.context.merge_devel and os.path.exists(setup_file_path):
+                # Do not replace existing setup.sh if devel space is merged
+                return commands
+        # Create the setup file other packages will source when depending on this package
+        subs = {}
+        subs['cmake_prefix_path'] = install_target + ":"
+        subs['ld_path'] = os.path.join(install_target, 'lib') + ":"
+        pythonpath = os.path.join(install_target, get_python_install_dir())
+        subs['pythonpath'] = pythonpath + ':'
+        subs['pkgcfg_path'] = os.path.join(install_target, 'lib', 'pkgconfig')
+        subs['pkgcfg_path'] += ":"
+        subs['path'] = os.path.join(install_target, 'bin') + ":"
+        setup_file_directory = os.path.dirname(setup_file_path)
+        if not os.path.exists(setup_file_directory):
+            os.mkdir(setup_file_directory)
+        with open(setup_file_path, 'w') as file_handle:
+            file_handle.write("""\
+#!/usr/bin/env sh
+# generated from catkin.builder module
+
+# remember type of shell if not already set
+if [ -z "$CATKIN_SHELL" ]; then
+  CATKIN_SHELL=sh
+fi
+""")
+            file_handle.write("""\
+# detect if running on Darwin platform
+_UNAME=`uname -s`
+IS_DARWIN=0
+if [ "$_UNAME" = "Darwin" ]; then
+  IS_DARWIN=1
+fi
+
+# Prepend to the environment
+export CMAKE_PREFIX_PATH="{cmake_prefix_path}$CMAKE_PREFIX_PATH"
+if [ $IS_DARWIN -eq 0 ]; then
+  export LD_LIBRARY_PATH="{ld_path}$LD_LIBRARY_PATH"
+else
+  export DYLD_LIBRARY_PATH="{ld_path}$DYLD_LIBRARY_PATH"
+fi
+export PATH="{path}$PATH"
+export PKG_CONFIG_PATH="{pkgcfg_path}$PKG_CONFIG_PATH"
+export PYTHONPATH="{pythonpath}$PYTHONPATH"
+""".format(**subs))
+        return commands
+
+
+class CatkinJob(Job):
+    """Job class for building catkin packages"""
+    def __init__(self, package, package_path, context, force_cmake):
+        Job.__init__(self, package, package_path, context, force_cmake)
+        self.commands = self.get_commands()
+
+    def get_commands(self):
+        commands = []
+        # Setup build variables
+        pkg_dir = os.path.join(self.context.source_space, self.package.name)
+        build_space = create_build_space(self.context.build_space, self.package.name)
+        if self.context.merge_devel:
+            devel_space = self.context.devel_space
+        else:
+            devel_space = os.path.join(self.context.devel_space, self.package.name)
+        if self.context.isolate_install:
+            install_space = os.path.join(self.context.install_space, self.package.name)
+        else:
+            install_space = self.context.install_space
+        # Create an environment file
+        env_cmd = create_env_file(self.package, self.context.build_space,
+                                  self.context.devel_space, self.context.merge_devel, self.context.packages)
+        # CMake command
+        makefile_path = os.path.join(build_space, 'Makefile')
+        if not os.path.isfile(makefile_path) or self.force_cmake:
+            commands.append(Command(
+                [
+                    env_cmd,
+                    'cmake',
+                    pkg_dir,
+                    '-DCATKIN_DEVEL_PREFIX=' + devel_space,
+                    '-DCMAKE_INSTALL_PREFIX=' + install_space
+                ] + self.context.cmake_args,
+                build_space,
+                ['devel']
+            ))
+        else:
+            commands.append(Command([env_cmd, 'make', 'cmake_check_build_system'], build_space, ['devel']))
+        # Make command
+        commands.append(Command(
+            [env_cmd, 'make'] + handle_make_arguments(self.context.make_args),
+            build_space,
+            ['devel']
+        ))
+        # Make install command, if installing
+        if self.context.install:
+            commands.append(Command([env_cmd, 'make', 'install'], build_space, ['devel', 'install']))
+        return commands

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -272,8 +272,9 @@ export PYTHONPATH="{pythonpath}$PYTHONPATH"
             # if the source and destination are on different partitions
             # it might be impossible to atomically move
             # then fall back to copy to destination (with random suffix) and then move from there
-            import shutil
-            tmp_dst_handle, tmp_dst_path = tempfile.mkstemp(dir=os.path.dirname(setup_file_path), prefix=os.path.basename(setup_file_path) + '.')
+            tmp_dst_handle, tmp_dst_path = tempfile.mkstemp(
+                dir=os.path.dirname(setup_file_path),
+                prefix=os.path.basename(setup_file_path) + '.')
             with open(temp_setup_file_path, 'rb') as f:
                 os.write(tmp_dst_handle, f.read())
                 os.close(tmp_dst_handle)
@@ -322,7 +323,7 @@ class CatkinJob(Job):
         # Make command
         commands.append(MakeCommand(
             env_cmd,
-            [MAKE_EXEC] + handle_make_arguments(self.context.make_args),
+            [MAKE_EXEC] + handle_make_arguments(self.context.make_args + self.context.catkin_make_args),
             build_space
         ))
         # Make install command, if installing

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -266,12 +266,9 @@ export PATH="{path}$PATH"
 export PKG_CONFIG_PATH="{pkgcfg_path}$PKG_CONFIG_PATH"
 export PYTHONPATH="{pythonpath}$PYTHONPATH"
 """.format(**subs))
-        # Close the file
         os.close(tmp_dst_handle)
-        # Do an atomic rename
+        # Do an atomic rename with os.rename
         os.rename(tmp_dst_path, setup_file_path)
-        # Remove the temporary file
-        os.remove(tmp_dst_path)
         return commands
 
 

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 import os
 import stat
+import tempfile
 
 from catkin.cmi.common import create_build_space
 from catkin.cmi.common import get_cached_recursive_build_depends_in_workspace
@@ -203,10 +204,12 @@ class CMakeJob(Job):
         setup_file_directory = os.path.dirname(setup_file_path)
         if not os.path.exists(setup_file_directory):
             os.makedirs(setup_file_directory)
-        with open(setup_file_path, 'w') as file_handle:
+        temp_setup_file_dir = tempfile.mkdtemp()
+        temp_setup_file_path = os.path.join(temp_setup_file_dir, 'setup.sh')
+        with open(temp_setup_file_path, 'w') as file_handle:
             file_handle.write("""\
 #!/usr/bin/env sh
-# generated from catkin.builder module
+# generated from catkin.cmi.job module
 
 # remember type of shell if not already set
 if [ -z "$CATKIN_SHELL" ]; then
@@ -231,6 +234,8 @@ export PATH="{path}$PATH"
 export PKG_CONFIG_PATH="{pkgcfg_path}$PKG_CONFIG_PATH"
 export PYTHONPATH="{pythonpath}$PYTHONPATH"
 """.format(**subs))
+        os.rename(temp_setup_file_path, setup_file_path)
+        os.rmdir(temp_setup_file_dir)
         return commands
 
 

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -52,10 +52,9 @@ if MAKE_EXEC is None:
 
 class Command(object):
     """Single command which is part of a job"""
-    def __init__(self, cmd, location, spaces=None):
+    def __init__(self, cmd, location):
         self.cmd = cmd
         self.location = location
-        self.spaces = [] if spaces is None else spaces
 
 
 class Job(object):
@@ -158,20 +157,18 @@ class CMakeJob(Job):
                     pkg_dir,
                     '-DCMAKE_INSTALL_PREFIX=' + install_target
                 ] + self.context.cmake_args,
-                build_space,
-                ['devel']
+                build_space
             ))
             commands[-1].cmd.extend(self.context.cmake_args)
         else:
-            commands.append(Command([env_cmd, MAKE_EXEC, 'cmake_check_build_system'], build_space, ['devel']))
+            commands.append(Command([env_cmd, MAKE_EXEC, 'cmake_check_build_system'], build_space))
         # Make command
         commands.append(Command(
             [env_cmd, MAKE_EXEC] + handle_make_arguments(self.context.make_args),
-            build_space,
-            ['devel']
+            build_space
         ))
         # Make install command (always run on plain cmake)
-        commands.append(Command([env_cmd, MAKE_EXEC, 'install'], build_space, ['devel', 'install']))
+        commands.append(Command([env_cmd, MAKE_EXEC, 'install'], build_space))
         # Determine the location of where the setup.sh file should be created
         if self.context.install:
             setup_file_path = os.path.join(install_space, 'setup.sh')
@@ -257,18 +254,16 @@ class CatkinJob(Job):
                     '-DCATKIN_DEVEL_PREFIX=' + devel_space,
                     '-DCMAKE_INSTALL_PREFIX=' + install_space
                 ] + self.context.cmake_args,
-                build_space,
-                ['devel']
+                build_space
             ))
         else:
-            commands.append(Command([env_cmd, MAKE_EXEC, 'cmake_check_build_system'], build_space, ['devel']))
+            commands.append(Command([env_cmd, MAKE_EXEC, 'cmake_check_build_system'], build_space))
         # Make command
         commands.append(Command(
             [env_cmd, MAKE_EXEC] + handle_make_arguments(self.context.make_args),
-            build_space,
-            ['devel']
+            build_space
         ))
         # Make install command, if installing
         if self.context.install:
-            commands.append(Command([env_cmd, MAKE_EXEC, 'install'], build_space, ['devel', 'install']))
+            commands.append(Command([env_cmd, MAKE_EXEC, 'install'], build_space))
         return commands

--- a/python/catkin/cmi/job.py
+++ b/python/catkin/cmi/job.py
@@ -118,6 +118,7 @@ class Job(object):
 
 def create_env_file(package, context):
     sources = []
+    source_snippet = ". {source_path}\n"
     # If installing to isolated folders or not installing, but devel spaces are not merged
     if (context.install and context.isolate_install) or (not context.install and not context.merge_devel):
         # Source each package's install or devel space
@@ -125,13 +126,11 @@ def create_env_file(package, context):
         # Get the recursive dependcies
         depends = get_cached_recursive_build_depends_in_workspace(package, context.packages)
         # For each dep add a line to source its setup file
-        source_snippet = ". {source_path} --extend\n"
         for dep_pth, dep in depends:
             source_path = os.path.join(space, dep.name, 'setup.sh')
             sources.append(source_snippet.format(source_path=source_path))
     else:
         # Just source common install or devel space
-        source_snippet = ". {source_path}\n"
         source_path = os.path.join(context.install_space if context.install else context.devel_space, 'setup.sh')
         sources = [source_snippet.format(source_path=source_path)] if os.path.exists(source_path) else []
     # Build the env_file
@@ -152,8 +151,8 @@ _ARGS=$@
 # remove all passed in args, resetting $@, $*, $#, $n
 shift $#
 # set the args for the sourced scripts
-set $@=--extend
-# source setup.sh with --extend argument for each direct build depend in the workspace
+set -- $@ "--extend"
+# source setup.sh with implicit --extend argument for each direct build depend in the workspace
 {sources}
 
 # execute given args

--- a/python/catkin/cmi/output.py
+++ b/python/catkin/cmi/output.py
@@ -74,6 +74,7 @@ class FileBackedLogCache(object):
 
     def print_last_command_log(self):
         wide_log("")
+        command_output = ""
         with open(self.log_path, 'r') as f:
             line_number = 0
             for line in f:
@@ -81,10 +82,11 @@ class FileBackedLogCache(object):
                     line_number += 1
                     continue
                 line_number = None
-                if not self.color:
-                    wide_log(remove_ansi_escape(line.rstrip('\n')))
-                else:
-                    wide_log(line.rstrip('\n'))
+                command_output += line.rstrip('\n') + '\n'
+        if not self.color:
+            wide_log(remove_ansi_escape(command_output.rstrip('\n')))
+        else:
+            wide_log(command_output.rstrip('\n'))
         wide_log("")
 
 

--- a/python/catkin/cmi/output.py
+++ b/python/catkin/cmi/output.py
@@ -1,0 +1,151 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import os
+
+from catkin.cmi.common import remove_ansi_escape
+from catkin.cmi.common import wide_log
+
+
+class FileBackedLogCache(object):
+    def __init__(self, package_name, log_dir, color):
+        self.package = package_name
+        self.log_dir = log_dir
+        self.color = color
+        self.log_path = os.path.join(log_dir, self.package + '.log')
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+        self.file_handle = open(self.log_path, 'w')
+        self.current_cmd = None
+
+    def start_command(self, cmd, msg):
+        self.current_cmd = cmd
+        self.append(msg)
+
+    def append(self, msg):
+        self.file_handle.write(msg + '\n')
+        self.file_handle.flush()
+
+    def finish_command(self, msg):
+        self.current_cmd = None
+        self.append(msg)
+
+    def close(self):
+        self.file_handle.close()
+        self.file_handle = None
+
+    def print_log(self):
+        wide_log("")
+        with open(self.log_path, 'r') as f:
+            for line in f:
+                if not self.color:
+                    wide_log(remove_ansi_escape(line.rstrip('\n')))
+                else:
+                    wide_log(line.rstrip('\n'))
+        wide_log("")
+
+
+class OutputController(object):
+    def __init__(self, log_dir, quiet, interleave_output, color, prefix_output=False):
+        self.log_dir = log_dir
+        self.quiet = quiet
+        self.interleave = interleave_output
+        self.color = color
+        self.prefix_output = prefix_output
+        self.__command_log = {}
+
+    def job_started(self, package):
+        self.__command_log[package] = FileBackedLogCache(package, self.log_dir, self.color)
+        wide_log("Starting ==> {package}".format(**locals()))
+
+    def command_started(self, package, cmd, location):
+        if package not in self.__command_log:
+            raise RuntimeError("Command started received for package '{0}' before package job started: '{1}' in '{2}'"
+                               .format(package, cmd, location))
+        msg = "[{package}]: ==> '{cmd}' in '{location}'".format(**locals())
+        self.__command_log[package].start_command(cmd, msg)
+        if not self.quiet and self.interleave:
+            wide_log(msg)
+
+    def command_log(self, package, msg):
+        if package not in self.__command_log:
+            raise RuntimeError("Command log received for package '{0}' before package job started: '{1}'"
+                               .format(package, msg))
+        if self.__command_log[package].current_cmd is None:
+            raise RuntimeError("Command log received for package '{0}' before command started: '{1}'"
+                               .format(package, msg))
+        self.__command_log[package].append(msg)
+        if not self.quiet and self.interleave:
+            if self.prefix_output:
+                wide_log('[{package}]: {msg}'.format(**locals()))
+            else:
+                wide_log(msg)
+
+    def command_failed(self, package, cmd, location, retcode):
+        if package not in self.__command_log:
+            raise RuntimeError(
+                "Command failed received for package '{0}' before package job started: '{1}' in '{2}' returned '{3}'"
+                .format(package, cmd, location, retcode))
+        if self.__command_log[package].current_cmd is None:
+            raise RuntimeError(
+                "Command failed received for package '{0}' before command started: '{1}' in '{2}' returned '{3}'"
+                .format(package, cmd, location, retcode))
+        msg = "[{package}]: <== '{cmd}' in '{location}' failed with return code '{retcode}'".format(**locals())
+        self.__command_log[package].finish_command(msg)
+        self.__command_log[package].close()
+        if not self.interleave:
+            self.__command_log[package].print_log()
+        del self.__command_log[package]
+
+    def command_finished(self, package, cmd, location, retcode):
+        if package not in self.__command_log:
+            raise RuntimeError(
+                "Command finished received for package '{0}' before package job started: '{1}' in '{2}' returned '{3}'"
+                .format(package, cmd, location, retcode))
+        if self.__command_log[package].current_cmd is None:
+            raise RuntimeError(
+                "Command finished received for package '{0}' before command started: '{1}' in '{2}' returned '{3}'"
+                .format(package, cmd, location, retcode))
+        msg = "[{package}]: <== '{cmd}' in '{location}' finished with return code '{retcode}'".format(**locals())
+        self.__command_log[package].finish_command(msg)
+        if not self.quiet and self.interleave:
+            self.__command_log[package].print_log()
+
+    def job_finished(self, package, time):
+        self.__command_log[package].close()
+        if not self.quiet and not self.interleave:
+            self.__command_log[package].print_log()
+        del self.__command_log[package]
+        wide_log("Finished <== {package} [ {time} ]".format(**locals()))

--- a/python/catkin/cmi/output.py
+++ b/python/catkin/cmi/output.py
@@ -108,7 +108,7 @@ class OutputController(object):
                                .format(package, msg))
         self.__command_log[package].append(msg)
         if not self.quiet and self.interleave:
-            if self.prefix_output:
+            if self.interleave and self.prefix_output:
                 wide_log('[{package}]: {msg}'.format(**locals()))
             else:
                 wide_log(msg)
@@ -140,7 +140,7 @@ class OutputController(object):
                 .format(package, cmd, location, retcode))
         msg = "[{package}]: <== '{cmd}' in '{location}' finished with return code '{retcode}'".format(**locals())
         self.__command_log[package].finish_command(msg)
-        if not self.quiet and self.interleave:
+        if not self.quiet and not self.interleave:
             self.__command_log[package].print_log()
 
     def job_finished(self, package, time):

--- a/python/catkin/cmi/output.py
+++ b/python/catkin/cmi/output.py
@@ -57,16 +57,16 @@ class FileBackedLogCache(object):
     def start_command(self, cmd, msg):
         self.last_command_line = self.current_line
         self.current_cmd = cmd
-        self.append(msg)
+        self.append(msg.rstrip('\n') + '\n')
 
     def append(self, msg):
-        self.file_handle.write(msg + '\n')
+        self.file_handle.write(msg)
         self.file_handle.flush()
         self.current_line += 1
 
     def finish_command(self, msg):
         self.current_cmd = None
-        self.append(msg)
+        self.append(msg.rstrip('\n') + '\n')
 
     def close(self):
         self.file_handle.close()
@@ -82,11 +82,11 @@ class FileBackedLogCache(object):
                     line_number += 1
                     continue
                 line_number = None
-                command_output += line.rstrip('\n') + '\n'
+                command_output += line
         if not self.color:
-            wide_log(remove_ansi_escape(command_output.rstrip('\n')))
+            wide_log(remove_ansi_escape(command_output), end='')
         else:
-            wide_log(command_output.rstrip('\n'))
+            wide_log(command_output, end='')
         wide_log("")
 
 
@@ -123,6 +123,7 @@ class OutputController(object):
         if not self.color:
             msg = remove_ansi_escape(msg)
         if not self.quiet and self.interleave:
+            msg = msg.rstrip()
             if self.interleave and self.prefix_output:
                 wide_log(clr("[{package}]: {msg}").format(**locals()))
             else:

--- a/python/catkin/cmi/run_unix.py
+++ b/python/catkin/cmi/run_unix.py
@@ -1,0 +1,69 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import os
+import pty
+import select
+
+from subprocess import Popen
+from subprocess import STDOUT
+
+
+def run_command(cmd, cwd=None):
+    master, slave = pty.openpty()
+
+    p = Popen(cmd, stdin=slave, stdout=slave, stderr=STDOUT, cwd=cwd)
+    os.close(slave)  # This causes the below select to exit when the subprocess closes
+
+    left_over = b''
+
+    while p.poll() is None:
+        incomming = left_over
+        rlist, wlist, xlist = select.select([master], [], [], 0.1)
+        if rlist:
+            incomming += os.read(master, 1024)
+            lines = incomming.splitlines(True)  # keepends=True
+            if not lines:
+                continue
+            if lines[-1].endswith('\n'):
+                data = b''.join(lines)
+                left_over = b''
+            else:
+                data = b''.join(lines[-1])
+                left_over = lines[-1]
+            yield data
+    # Done
+    os.close(master)
+    yield p.returncode

--- a/python/catkin/cmi/run_unix.py
+++ b/python/catkin/cmi/run_unix.py
@@ -50,7 +50,7 @@ def process_incomming_lines(lines, left_over):
         data = b''.join(lines)
         left_over = b''
     else:
-        data = b''.join(lines[-1])
+        data = b''.join(lines[:-1])
         left_over = lines[-1]
     return data, left_over
 

--- a/python/catkin/cmi/run_windows.py
+++ b/python/catkin/cmi/run_windows.py
@@ -1,0 +1,65 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import os
+import select
+
+from subprocess import PIPE
+from subprocess import Popen
+from subprocess import STDOUT
+
+
+def run_command(cmd, cwd=None):
+    p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=STDOUT, cwd=cwd)
+
+    left_over = b''
+
+    while p.poll() is None:
+        incomming = left_over
+        rlist, wlist, xlist = select.select([p.stdout], [], [])
+        if rlist:
+            incomming += os.read(p.stdout, 1024)
+            lines = incomming.splitlines(True)  # keepends=True
+            if not lines:
+                continue
+            if lines[-1].endswith('\n'):
+                data = b''.join(lines)
+                left_over = b''
+            else:
+                data = b''.join(lines[-1])
+                left_over = lines[-1]
+            yield data
+    # Done
+    yield p.returncode

--- a/python/catkin/cmi/terminal_color.py
+++ b/python/catkin/cmi/terminal_color.py
@@ -1,0 +1,133 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation, Inc. nor
+#    the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior
+#    written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Module to enable color terminal output
+"""
+
+from __future__ import print_function
+
+import string
+import os
+
+_ansi = {}
+
+
+def ansi(key):
+    """Returns the escape sequence for a given ansi color key"""
+    global _ansi
+    return _ansi[key]
+
+
+def enable_ANSI_colors():
+    """
+    Populates the global module dictionary `ansi` with ANSI escape sequences.
+    """
+    global _ansi
+    color_order = [
+        'black', 'red', 'green', 'yellow', 'blue', 'purple', 'cyan', 'white'
+    ]
+    short_colors = {
+        'black': 'k', 'red': 'r', 'green': 'g', 'yellow': 'y', 'blue': 'b',
+        'purple': 'p', 'cyan': 'c', 'white': 'w'
+    }
+    _ansi = {
+        'escape': '\033', 'reset': 0, '|': 0,
+        'boldon': 1, '!': 1, 'italicson': 3, '/': 3, 'ulon': 4, '_': 4,
+        'invon': 7, 'boldoff': 22, 'italicsoff': 23,
+        'uloff': 24, 'invoff': 27
+    }
+
+    # Convert plain numbers to escapes
+    for key in _ansi:
+        if key != 'escape':
+            _ansi[key] = '{0}[{1}m'.format(_ansi['escape'], _ansi[key])
+
+    # Foreground
+    for index, color in enumerate(color_order):
+        _ansi[color] = '{0}[{1}m'.format(_ansi['escape'], 30 + index)
+        _ansi[color + 'f'] = _ansi[color]
+        _ansi[short_colors[color] + 'f'] = _ansi[color + 'f']
+
+    # Background
+    for index, color in enumerate(color_order):
+        _ansi[color + 'b'] = '{0}[{1}m'.format(_ansi['escape'], 40 + index)
+        _ansi[short_colors[color] + 'b'] = _ansi[color + 'b']
+
+    # Fmt sanitizers
+    _ansi['atexclimation'] = '@!'
+    _ansi['atfwdslash'] = '@/'
+    _ansi['atunderscore'] = '@_'
+    _ansi['atbar'] = '@|'
+
+
+def disable_ANSI_colors():
+    """
+    Sets all the ANSI escape sequences to empty strings, effectively disabling
+    console colors.
+    """
+    global _ansi
+    for key in _ansi:
+        _ansi[key] = ''
+
+# Default to ansi colors on
+enable_ANSI_colors()
+if os.name in ['nt']:
+    disable_ANSI_colors()
+
+
+class ColorTemplate(string.Template):
+    delimiter = '@'
+
+
+def sanitize(msg):
+    """Sanitizes the existing msg, use before adding color annotations"""
+    msg = msg.replace('@', '@@')
+    msg = msg.replace('{', '{{')
+    msg = msg.replace('}', '}}')
+    msg = msg.replace('@@!', '@{atexclimation}')
+    msg = msg.replace('@@/', '@{atfwdslash}')
+    msg = msg.replace('@@_', '@{atunderscore}')
+    msg = msg.replace('@@|', '@{atbar}')
+    return msg
+
+
+def fmt(msg):
+    """Replaces color annotations with ansi escape sequences"""
+    global _ansi
+    msg = msg.replace('@!', '@{boldon}')
+    msg = msg.replace('@/', '@{italicson}')
+    msg = msg.replace('@_', '@{ulon}')
+    msg = msg.replace('@|', '@{reset}')
+    t = ColorTemplate(msg)
+    return t.substitute(_ansi) + ansi('reset')

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ d = generate_distutils_setup(
         'bin/catkin_prepare_release',
         'bin/catkin_test_results',
         'bin/catkin_topological_order',
+        'bin/pcmi',
     ],
 )
 


### PR DESCRIPTION
I see no reason to not parallelize project builds of projects without dependencies between them. Code can be reused from rosmake or from rosinstall.

This might require changing the catkin_pkg API not just to return a topologically ordered list of packages, but a dependency graph (maybe without transitive dependencies)
