### PR TITLE
use sys.exit and not just exit

### DIFF
--- a/bin/catkin_init_workspace
+++ b/bin/catkin_init_workspace
@@ -25,7 +25,7 @@ def main():
         init_workspace(workspace)
     except Exception as e:
         sys.stderr.write(str(e))
-        exit(2)
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -33,7 +33,7 @@ def main():
             sys.exit(1)
     except Exception as e:
         sys.stderr.write(str(e))
-        exit(2)
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/bin/catkin_topological_order
+++ b/bin/catkin_topological_order
@@ -35,7 +35,7 @@ def main():
         sys.stderr.write('Workspace "%s" seems to not contain any projects.'
                          ' Have you passed the correct path to a '
                          'catkin workspace?' % workspace)
-        exit(3)
+        sys.exit(3)
 
     for (path, package) in ordered_projects:
         if args.only_folders:


### PR DESCRIPTION
I'm pretty sure this wasn't intentional, but as far as I know we should always use `sys.exit`.
