### PR TITLE
fix library deduplication (fix #565)

### DIFF
--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -81,16 +81,19 @@ foreach(component ${catkin_FIND_COMPONENTS})
 
     # append component-specific variables to catkin_* variables
     list_append_unique(catkin_INCLUDE_DIRS ${${component}_INCLUDE_DIRS})
+
     # merge build configuration keywords with library names to correctly deduplicate
+    catkin_pack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
     catkin_pack_libraries_with_build_configuration(_libraries ${${component}_LIBRARIES})
     list_append_deduplicate(catkin_LIBRARIES ${_libraries})
+    # undo build configuration keyword merging after deduplication
+    catkin_unpack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
+
     list_append_unique(catkin_LIBRARY_DIRS ${${component}_LIBRARY_DIRS})
     list(APPEND catkin_EXPORTED_TARGETS ${${component}_EXPORTED_TARGETS})
   endif()
 endforeach()
 list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${catkin_INCLUDE_DIRS})
-# undo build configuration keyword merging after deduplication
-catkin_unpack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
 list_insert_in_workspace_order(catkin_LIBRARY_DIRS ${catkin_LIBRARY_DIRS})
 
 # add dummy target to catkin_EXPORTED_TARGETS if empty

--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -24,6 +24,43 @@ macro(_list_append_unique listname)
   endforeach()
 endmacro()
 
+# pack a list of libraries with optional build configuration keywords
+# copied from catkin/cmake/catkin_libraries.cmake to keep pkgConfig
+# self contained
+macro(_pack_libraries_with_build_configuration VAR)
+  set(${VAR} "")
+  set(_argn ${ARGN})
+  list(LENGTH _argn _count)
+  set(_index 0)
+  while(${_index} LESS ${_count})
+    list(GET _argn ${_index} lib)
+    if("${lib}" MATCHES "^debug|optimized|general$")
+      math(EXPR _index "${_index} + 1")
+      if(${_index} EQUAL ${_count})
+        message(FATAL_ERROR "_pack_libraries_with_build_configuration() the list of libraries '${ARGN}' ends with '${lib}' which is a build configuration keyword and must be followed by a library")
+      endif()
+      list(GET _argn ${_index} library)
+      list(APPEND ${VAR} "${lib}${CATKIN_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}${library}")
+    else()
+      list(APPEND ${VAR} "${lib}")
+    endif()
+    math(EXPR _index "${_index} + 1")
+  endwhile()
+  debug_message(10 "_pack_libraries_with_build_configuration(${VAR} ${ARGN}) ${${VAR}}")
+endmacro()
+
+# unpack a list of libraries with optional build configuration keyword prefixes
+# copied from catkin/cmake/catkin_libraries.cmake to keep pkgConfig
+# self contained
+macro(_unpack_libraries_with_build_configuration VAR)
+  set(${VAR} "")
+  foreach(lib ${ARGN})
+    string(REGEX REPLACE "^(debug|optimized|general)${CATKIN_BUILD_CONFIGURATION_KEYWORD_SEPARATOR}(.+)$" "\\1;\\2" lib "${lib}")
+    list(APPEND ${VAR} "${lib}")
+  endforeach()
+  debug_message(10 "_unpack_libraries_with_build_configuration(${VAR} ${ARGN}) ${${VAR}}")
+endmacro()
+
 
 if(@PROJECT_NAME@_CONFIG_INCLUDED)
   return()
@@ -135,7 +172,14 @@ foreach(depend ${depends})
     find_package(${@PROJECT_NAME@_dep} REQUIRED ${depend_list})
   endif()
   _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${${@PROJECT_NAME@_dep}_INCLUDE_DIRS})
-  _list_append_deduplicate(@PROJECT_NAME@_LIBRARIES ${${@PROJECT_NAME@_dep}_LIBRARIES})
+
+  # merge build configuration keywords with library names to correctly deduplicate
+  _pack_libraries_with_build_configuration(@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
+  _pack_libraries_with_build_configuration(_libraries ${${@PROJECT_NAME@_dep}_LIBRARIES})
+  _list_append_deduplicate(@PROJECT_NAME@_LIBRARIES ${_libraries})
+  # undo build configuration keyword merging after deduplication
+  _unpack_libraries_with_build_configuration(@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
+
   _list_append_unique(@PROJECT_NAME@_LIBRARY_DIRS ${${@PROJECT_NAME@_dep}_LIBRARY_DIRS})
   list(APPEND @PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
 endforeach()


### PR DESCRIPTION
`pack()` / `unpack()` must be wrapped around every `list_append_deduplicate()` call since the input data might come from a recursive invocation which is not packed anymore.
