### PR TITLE
use underlay workspaces when calculating topological order

### DIFF
--- a/bin/catkin_topological_order
+++ b/bin/catkin_topological_order
@@ -17,6 +17,7 @@ except ImportError as e:
 def main():
     parser = argparse.ArgumentParser(description='Outputs the catkin projects of a workspace in topological order.')
     parser.add_argument('workspace', nargs='?', default='.', help='The path to a workspace (default: .)')
+    parser.add_argument('--underlay-workspaces', nargs='*', default=[], help='The paths to underlay workspaces which are only used to resolve dependencies')
     parser.add_argument('--only-folders', action='store_true', help='Only output the project folders')
     parser.add_argument('--only-names', action='store_true', help='Only output the project names')
     args = parser.parse_args()
@@ -30,7 +31,7 @@ def main():
     if not os.path.isdir(workspace):
         sys.exit('Workspace "%s" does not exist' % workspace)
 
-    ordered_projects = topological_order(workspace)
+    ordered_projects = topological_order(workspace, underlay_workspaces=args.underlay_workspaces)
     if not ordered_projects:
         sys.stderr.write('Workspace "%s" seems to not contain any projects.'
                          ' Have you passed the correct path to a '

--- a/cmake/em/order_packages.cmake.em
+++ b/cmake/em/order_packages.cmake.em
@@ -15,7 +15,7 @@ except ImportError as e:
     raise RuntimeError('ImportError: "from catkin_pkg.package import InvalidPackage" failed: %s\nMake sure that you have installed "catkin_pkg", it is up to date and on the PYTHONPATH.' % e)
 # vars defined in order_packages.context.py.in
 try:
-    ordered_packages = topological_order(os.path.normpath(source_root_dir), whitelisted_packages, blacklisted_packages)
+    ordered_packages = topological_order(os.path.normpath(source_root_dir), whitelisted=whitelisted_packages, blacklisted=blacklisted_packages, underlay_workspaces=underlay_workspaces)
 except InvalidPackage as e:
     print('message(FATAL_ERROR "%s")' % e)
     ordered_packages = []

--- a/cmake/templates/order_packages.context.py.in
+++ b/cmake/templates/order_packages.context.py.in
@@ -2,3 +2,4 @@
 source_root_dir = "@CMAKE_CURRENT_SOURCE_DIR@"
 whitelisted_packages = "@CATKIN_WHITELIST_PACKAGES@".split(';') if "@CATKIN_WHITELIST_PACKAGES@" != "" else []
 blacklisted_packages = "@CATKIN_BLACKLIST_PACKAGES@".split(';') if "@CATKIN_BLACKLIST_PACKAGES@" != "" else []
+underlay_workspaces = "@CATKIN_WORKSPACES@".split(';') if "@CATKIN_WORKSPACES@" != "" else []

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
 
   <build_depend>gtest</build_depend>
   <build_depend>python-argparse</build_depend>
-  <build_depend>python-catkin-pkg</build_depend>
+  <build_depend version_gte="0.1.26">python-catkin-pkg</build_depend>
   <build_depend>python-empy</build_depend>
   <build_depend>python-nose</build_depend>
 
@@ -26,7 +26,7 @@
   <run_depend>cmake</run_depend>
   <run_depend>gtest</run_depend>
   <run_depend>python-argparse</run_depend>
-  <run_depend version_gte="0.1.21">python-catkin-pkg</run_depend>
+  <run_depend version_gte="0.1.26">python-catkin-pkg</run_depend>
   <run_depend>python-empy</run_depend>
   <run_depend>python-nose</run_depend>
 


### PR DESCRIPTION
Depends on ros-infrastructure/catkin_pkg#87 being released as 0.1.26.
Should be backported to _Groovy_ and _Hydro_.

Note: this patch will significantly increase the time to compute the topological order since all available package.xml files from all underlays must be crawled and parsed.

@tfoote @wjwwood Please review.
