### PR TITLE
Fixed bug with length calculation

### DIFF
--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -396,7 +396,7 @@ function(_catkin_package)
     string(LENGTH "${CATKIN_DEVEL_PREFIX}/" devel_length)
     string(LENGTH "${idir}/" idir_length)
     if(NOT ${idir_length} LESS ${devel_length})
-      string(SUBSTRING "${idir}" 0 ${devel_length} idir_prefix)
+      string(SUBSTRING "${idir}/" 0 ${devel_length} idir_prefix)
       if("${idir_prefix}" STREQUAL "${CATKIN_DEVEL_PREFIX}/")
         # the value doesn't matter as long as it doesn't match IS_ABSOLUTE
         set(idir "${CATKIN_GLOBAL_INCLUDE_DESTINATION}")


### PR DESCRIPTION
Because the string length is calculated with an additional '/' it is necessary to add this character as well to the substring creation. If not it is possible to get out of range errors like below. Another possibility would be to remove the extra '/' from the length calculation in line 396 and 397, but I do not know if this has any side effects

Fixed build errors like below:
-- Using CATKIN_TEST_RESULTS_DIR:
~/ros_catkin_ws/build_isolated/rqt_image_view/test_results
-- Found gtest sources under '/usr/src/gtest': gtests will be built
-- catkin 0.5.84
CMake Error at
/opt/ros/hydro/share/catkin/cmake/catkin_package.cmake:399
(string):
  string end index: 57 is out of range -1 - 56
