### PR TITLE
Marker file for catkin_make (#304)

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -19,6 +19,7 @@ from catkin.builder import handle_make_arguments
 from catkin.builder import print_command_banner
 from catkin.builder import run_command
 from catkin.builder import run_command_colorized
+from catkin_pkg.workspaces import ensure_workspace_marker
 from catkin_pkg.packages import find_packages
 
 
@@ -158,6 +159,8 @@ def main():
                 run_command_colorized(cmd, build_path)
         except subprocess.CalledProcessError:
             return fmt('@{rf}Invoking @{boldon}"make cmake_check_build_system"@{boldoff} failed')
+
+    ensure_workspace_marker(base_path)
 
     # invoke make
     cmd = ['make']

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <buildtool_export_depend>cmake</buildtool_export_depend>
 
   <depend>python-argparse</depend>
-  <depend version_gte="0.2.1">python-catkin-pkg</depend>
+  <depend version_gte="0.2.2">python-catkin-pkg</depend>
 
   <build_depend>python-empy</build_depend>
 

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -58,6 +58,7 @@ except ImportError as e:
 
 from catkin.cmake import get_cmake_path
 from catkin.terminal_color import ansi, disable_ANSI_colors, fmt, sanitize
+from catkin_pkg.workspaces import ensure_workspace_marker
 
 
 def split_arguments(args, splitter_name, default=None):
@@ -818,6 +819,8 @@ def build_workspace_isolated(
     if not force_cmake and cmake_input_changed(packages, buildspace, cmake_args=cmake_args, filename='catkin_make_isolated'):
         print('The packages or cmake arguments have changed, forcing cmake invocation')
         force_cmake = True
+
+    ensure_workspace_marker(workspace)
 
     # Build packages
     pkg_develspace = None


### PR DESCRIPTION
First commit only writes a marker file. Possibly that is all you want to merge.

The third commit also makes use of the marker file, in case no explicit target path argument was passed to catkin_make.

I was not sure for which part you wanted a PR, so you can cherry-pick what you want. I am dispassionate about the filename, and about file vs. folder, so you can change to your liking.

I recommend using yaml or a folder because a likely future extention is to store metadata such as preferences or build configurations, and it would be bloat to have to store them in separate files next to the marker file.
