### PR TITLE
"Notify" user of a cyclic package dependency (part 2 of 2)

### DIFF
--- a/bin/catkin_topological_order
+++ b/bin/catkin_topological_order
@@ -38,6 +38,11 @@ def main():
                          'catkin workspace?' % workspace)
         sys.exit(3)
 
+    # Always test for a cycle because topological_order_packages() is stupid
+    if ordered_packages[-1][0] is None:
+        print('Cycle detected: %s' % ordered_packages[-1][1])
+        print('Shitty error in 3, 2, 1...')  # Better not break any APIs by changing behavior
+
     for (path, package) in ordered_projects:
         if args.only_folders:
             print('%s' % path)


### PR DESCRIPTION
See https://github.com/ros/catkin/pull/607

I think I found them all... Hopefully someone remembers to always test for this whenever using topological_order() in the future.
