### PR TITLE
Do not call chpwd hooks in setup.zsh

### DIFF
--- a/cmake/templates/setup.zsh.in
+++ b/cmake/templates/setup.zsh.in
@@ -2,7 +2,7 @@
 # generated from catkin/cmake/templates/setup.zsh.in
 
 CATKIN_SHELL=zsh
-_CATKIN_SETUP_DIR=$(builtin cd "`dirname "$0"`" && pwd)
+_CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" && pwd)
 emulate sh # emulate POSIX
 . "$_CATKIN_SETUP_DIR/setup.sh"
 emulate zsh # back to zsh mode


### PR DESCRIPTION
By default, cd'ing on zsh calls the shell function `chpwd`. This is commonly used for things like showing the current directory in the title terminal by printing a string with some escape codes, but this breaks `_CATKIN_SETUP_DIR`. `-q` disables the chpwd hooks.

The zshbuiltins(1) man page writes about -q: "If  the -q (quiet) option is specified, the hook function chpwd and the functions in the array chpwd_functions are not called. This is useful for calls to cd that do not change the environment seen by an interactive user."
