### PR TITLE
python: fix python path setting in plain cmake workspaces

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -240,9 +240,9 @@ def get_python_install_dir():
     python_install_dir = 'lib'
     python_use_debian_layout = os.path.exists('/etc/debian_version')
     if os.name != 'nt':
-        python_version_xdoty = str(sys.version_info[0])
-        if not python_use_debian_layout:
-            python_version_xdoty += '.' + str(sys.version_info[1])
+        python_version_xdoty = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
+        if python_use_debian_layout and sys.version_info[0] == 3:
+            python_version_xdoty = str(sys.version_info[0])
         python_install_dir = os.path.join(python_install_dir, 'python' + python_version_xdoty)
 
     python_packages_dir = 'dist-packages' if python_use_debian_layout else 'site-packages'


### PR DESCRIPTION
In plain cmake workspaces the python install dir is set to
lib/python2/dist-packages instead of lib/python2.7/dist-packages

I checked the catkin/cmake/python.cmake file and in that file there is
an extra check for the version, so I assume that we should only use
the major version in case the major version is 3 or higher.
