### PR TITLE
Only set catkin_* variables when being invoked with find_package COMPONENTS

### DIFF
--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -44,57 +44,61 @@ set(catkin_FOUND_CATKIN_PROJECT TRUE)
 # XXXX don't overwrite catkin_* variables when being called recursively
 if(NOT _CATKIN_FIND_ OR _CATKIN_FIND_ EQUAL 0)
   set(_CATKIN_FIND_ 0)
-  set(catkin_INCLUDE_DIRS "")
-  set(catkin_LIBRARIES "")
-  set(catkin_LIBRARY_DIRS "")
-  set(catkin_EXPORTED_TARGETS "")
+  if(catkin_FIND_COMPONENTS)
+    set(catkin_INCLUDE_DIRS "")
+    set(catkin_LIBRARIES "")
+    set(catkin_LIBRARY_DIRS "")
+    set(catkin_EXPORTED_TARGETS "")
+  endif()
 endif()
 
 # increment recursion counter
 math(EXPR _CATKIN_FIND_ "${_CATKIN_FIND_} + 1")
 
 # find all components
-foreach(component ${catkin_FIND_COMPONENTS})
-  string(TOLOWER "${component}" component_lower)
-  # skip catkin since it does not make sense as a component
-  if(NOT ${component_lower} STREQUAL "catkin")
+if(catkin_FIND_COMPONENTS)
+  foreach(component ${catkin_FIND_COMPONENTS})
+    string(TOLOWER "${component}" component_lower)
+    # skip catkin since it does not make sense as a component
+    if(NOT ${component_lower} STREQUAL "catkin")
 
-    # get search paths from CMAKE_PREFIX_PATH (which includes devel space)
-    set(paths "")
-    foreach(path ${CMAKE_PREFIX_PATH})
-      if(IS_DIRECTORY ${path}/share/${component}/cmake)
-        list(APPEND paths ${path}/share/${component}/cmake)
+      # get search paths from CMAKE_PREFIX_PATH (which includes devel space)
+      set(paths "")
+      foreach(path ${CMAKE_PREFIX_PATH})
+        if(IS_DIRECTORY ${path}/share/${component}/cmake)
+          list(APPEND paths ${path}/share/${component}/cmake)
+        endif()
+      endforeach()
+
+      # find package component
+      if(catkin_FIND_REQUIRED)
+        find_package(${component} REQUIRED NO_MODULE PATHS ${paths}
+          NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+      elseif(catkin_FIND_QUIETLY)
+        find_package(${component} QUIET NO_MODULE PATHS ${paths}
+          NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+      else()
+        find_package(${component} NO_MODULE PATHS ${paths}
+          NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
       endif()
-    endforeach()
 
-    # find package component
-    if(catkin_FIND_REQUIRED)
-      find_package(${component} REQUIRED NO_MODULE PATHS ${paths}
-        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-    elseif(catkin_FIND_QUIETLY)
-      find_package(${component} QUIET NO_MODULE PATHS ${paths}
-        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
-    else()
-      find_package(${component} NO_MODULE PATHS ${paths}
-        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+      # append component-specific variables to catkin_* variables
+      list_append_unique(catkin_INCLUDE_DIRS ${${component}_INCLUDE_DIRS})
+
+      # merge build configuration keywords with library names to correctly deduplicate
+      catkin_pack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
+      catkin_pack_libraries_with_build_configuration(_libraries ${${component}_LIBRARIES})
+      list_append_deduplicate(catkin_LIBRARIES ${_libraries})
+      # undo build configuration keyword merging after deduplication
+      catkin_unpack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
+
+      list_append_unique(catkin_LIBRARY_DIRS ${${component}_LIBRARY_DIRS})
+      list(APPEND catkin_EXPORTED_TARGETS ${${component}_EXPORTED_TARGETS})
     endif()
-
-    # append component-specific variables to catkin_* variables
-    list_append_unique(catkin_INCLUDE_DIRS ${${component}_INCLUDE_DIRS})
-
-    # merge build configuration keywords with library names to correctly deduplicate
-    catkin_pack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
-    catkin_pack_libraries_with_build_configuration(_libraries ${${component}_LIBRARIES})
-    list_append_deduplicate(catkin_LIBRARIES ${_libraries})
-    # undo build configuration keyword merging after deduplication
-    catkin_unpack_libraries_with_build_configuration(catkin_LIBRARIES ${catkin_LIBRARIES})
-
-    list_append_unique(catkin_LIBRARY_DIRS ${${component}_LIBRARY_DIRS})
-    list(APPEND catkin_EXPORTED_TARGETS ${${component}_EXPORTED_TARGETS})
-  endif()
-endforeach()
-list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${catkin_INCLUDE_DIRS})
-list_insert_in_workspace_order(catkin_LIBRARY_DIRS ${catkin_LIBRARY_DIRS})
+  endforeach()
+  list_insert_in_workspace_order(catkin_INCLUDE_DIRS ${catkin_INCLUDE_DIRS})
+  list_insert_in_workspace_order(catkin_LIBRARY_DIRS ${catkin_LIBRARY_DIRS})
+endif()
 
 # add dummy target to catkin_EXPORTED_TARGETS if empty
 if(NOT catkin_EXPORTED_TARGETS)


### PR DESCRIPTION
This is a necessary change to support ros/rosdistro#3010.

@tfoote @wjwwood Please review and consider potential side effects. Is it possible / reasonable to backport this? Otherwise it will force a lot of packages to have a separate indigo branch (which they might not yet have).
