### PR TITLE
Add catkin_download functions for build data

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -102,6 +102,7 @@ foreach(filename
     atomic_configure_file
     catkin_add_env_hooks
     catkin_destinations
+    catkin_download
     catkin_generate_environment
     catkin_install_python
     catkin_libraries

--- a/cmake/catkin_download.cmake
+++ b/cmake/catkin_download.cmake
@@ -1,0 +1,150 @@
+#
+# Download a file containing data from a URL.
+#
+# It is commonly used to download larger data files which should not be
+# stored in the repository.
+#
+# .. note:: The target will be registered as a dependency
+#   of the "download_extra_data" target.
+#
+# :param url: the url to download
+# :type url: string
+#
+# :param TARGET: the target name
+#   (default: ${PROJECT_NAME}_download_${the basename of the url})
+# :type TARGET: string
+# :param DESTINATION: the directory where the file is downloaded to
+#   (default: ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION})
+# :type DESTINATION: string
+# :param FILENAME: the filename of the downloaded file
+#   (default: the basename of the url)
+# :type FILENAME: string
+# :param MD5: the expected md5 hash to compare against
+#   (default: empty, skipping the check)
+# :type MD5: string
+# :param EXCLUDE_FROM_ALL: exclude this download from the 'all' build target
+#   (default: true, excluding it from the all target)
+# :type EXCLUDE_FROM_ALL: bool
+# :param REQUIRED: require the file to be available for the build to succeed
+#   (default: true, requiring the file)
+# :type REQUIRED: bool
+#
+# @public
+function(catkin_download url)
+  cmake_parse_arguments(ARG ""
+    "TARGET;DESTINATION;FILENAME;MD5;EXCLUDE_FROM_ALL;REQUIRED" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "catkin_download() called with unused arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT ARG_DESTINATION)
+    set(ARG_DESTINATION "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}")
+  endif()
+
+  if(NOT ARG_FILENAME)
+    get_filename_component(ARG_FILENAME ${url} NAME)
+  endif()
+
+  if(NOT ARG_TARGET)
+    get_filename_component(FILENAME ${ARG_FILENAME} NAME)
+    set(ARG_TARGET "${PROJECT_NAME}_download_${FILENAME}")
+  endif()
+
+  set(required "")
+  if(DEFINED ARG_REQUIRED)
+    if(NOT ARG_REQUIRED)
+      set(required "--non-essential")
+    endif()
+  endif()
+
+  set(output "${ARG_DESTINATION}/${ARG_FILENAME}")
+
+  set(DOWNLOAD_CHECKMD5_SCRIPT "${catkin_EXTRAS_DIR}/test/download_checkmd5.py")
+
+  # With this, the command is always called, even when the output is up to date.
+  # this is because we want to check the md5 sum if it's given, and redownload
+  # the target if the md5 sum does not match.
+  add_custom_target(${ARG_TARGET}
+    COMMAND ${DOWNLOAD_CHECKMD5_SCRIPT} ${url} ${output} ${ARG_MD5} ${required}
+    VERBATIM)
+
+  if(TARGET download_extra_data)
+    add_dependencies(download_extra_data ${ARG_TARGET})
+  endif()
+
+  if(DEFINED ARG_EXCLUDE_FROM_ALL)
+    set_target_properties(${ARG_TARGET} PROPERTIES
+      EXCLUDE_FROM_ALL ${ARG_EXCLUDE_FROM_ALL})
+  endif()
+
+endfunction()
+
+#
+# Download a file containing data from a URL.
+#
+# It is commonly used to download larger data files which should not be
+# stored in the repository.
+#
+# .. note:: The target will be registered as a dependency
+#   of the "download_extra_data" target and the all target
+#
+# :param url: the url to download
+# :type url: string
+#
+# :param TARGET: the target name
+#   (default: ${PROJECT_NAME}_download_${the basename of the url})
+# :type TARGET: string
+# :param DESTINATION: the directory where the file is downloaded to
+#   (default: ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION})
+# :type DESTINATION: string
+# :param FILENAME: the filename of the downloaded file
+#   (default: the basename of the url)
+# :type FILENAME: string
+# :param MD5: the expected md5 hash to compare against
+#   (default: empty, skipping the check)
+# :type MD5: string
+# :param REQUIRED: require the file to be available for the build to succeed
+#   (default: true, requiring the file)
+# :type REQUIRED: bool
+#
+# @public
+function(catkin_download_build_data)
+  catkin_download(${ARGN} EXCLUDE_FROM_ALL false)
+endfunction()
+
+#
+# Download a file containing data from a URL.
+#
+# It is commonly used to download larger data files which should not be
+# stored in the repository, and which are not required as part of the build
+#
+# .. note:: The target will be registered as a dependency
+#   of the "download_extra_data" target
+#
+# :param url: the url to download
+# :type url: string
+#
+# :param TARGET: the target name
+#   (default: ${PROJECT_NAME}_download_${the basename of the url})
+# :type TARGET: string
+# :param DESTINATION: the directory where the file is downloaded to
+#   (default: ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION})
+# :type DESTINATION: string
+# :param FILENAME: the filename of the downloaded file
+#   (default: the basename of the url)
+# :type FILENAME: string
+# :param MD5: the expected md5 hash to compare against
+#   (default: empty, skipping the check)
+# :type MD5: string
+# :param REQUIRED: require the file to be available for the build to succeed
+#   (default: true, requiring the file)
+# :type REQUIRED: bool
+#
+# @public
+function(catkin_download_extra_data)
+  catkin_download(${ARGN} EXCLUDE_FROM_ALL true)
+endfunction()
+
+if(NOT TARGET download_extra_data)
+  add_custom_target(download_extra_data)
+endif()

--- a/cmake/test/download_checkmd5.py
+++ b/cmake/test/download_checkmd5.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from urllib2 import addinfourl, BaseHandler, build_opener, Request, URLError
 import hashlib
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 NAME = "download_checkmd5.py"
 
@@ -127,17 +127,15 @@ def main(argv=sys.argv[1:]):
     """
     Dowloads URI to file dest and checks md5 if given.
     """
-    parser = OptionParser(usage="usage: %prog URI dest [md5sum]",
-                          prog=NAME,
-                          description="Dowloads URI to file dest. If md5sum is given, checks md5sum. If file existed and mismatch, downloads and checks again")
-    options, args = parser.parse_args(argv)
-    md5sum = None
-    if len(args) == 2:
-        uri, dest = args
-    elif len(args) == 3:
-        uri, dest, md5sum = args
-    else:
-        parser.error("wrong number of arguments")
+    parser = ArgumentParser(description="Dowloads URI to file dest. If md5sum is given, checks md5sum. If file existed and mismatch, downloads and checks again")
+    parser.add_argument("uri")
+    parser.add_argument("dest")
+    parser.add_argument("md5sum", nargs='?')
+    args = parser.parse_args(argv)
+
+    uri = args.uri
+    dest = args.dest
+    md5sum = args.md5sum
 
     if '://' not in uri:
         uri = 'file://' + uri


### PR DESCRIPTION
Add two functions for downloading data at build time; catkin_download_build_data and catkin_download_extra_data. These are useful for download large data blobs such as binaries or configuration that users don't want to include in their repositories.

This is different from catkin_download_test_data because:
- It always builds, and thus always checks the checksum; re-downloading the file if it has changed
- It isn't hidden behind the CATKIN_ENABLE_TESTING flag
- It's optionally added to the all target so that it runs as part of the normal build
- It adds a REQUIRED option in cmake, which allows the download to fail with a warning, without causing the build to fail completely. This is useful for doing builds when there is no network connection.
- It adds the download_extra_data target, which depends on all of the download targets

Comments welcome.
