### PR TITLE
Add flag to download_checkmd5 to ignore network errors

### DIFF
--- a/cmake/test/download_checkmd5.py
+++ b/cmake/test/download_checkmd5.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from urllib2 import addinfourl, BaseHandler, build_opener, Request, URLError
 import hashlib
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 NAME = "download_checkmd5.py"
 
@@ -127,17 +127,15 @@ def main(argv=sys.argv[1:]):
     """
     Dowloads URI to file dest and checks md5 if given.
     """
-    parser = OptionParser(usage="usage: %prog URI dest [md5sum]",
-                          prog=NAME,
-                          description="Dowloads URI to file dest. If md5sum is given, checks md5sum. If file existed and mismatch, downloads and checks again")
-    options, args = parser.parse_args(argv)
-    md5sum = None
-    if len(args) == 2:
-        uri, dest = args
-    elif len(args) == 3:
-        uri, dest, md5sum = args
-    else:
-        parser.error("wrong number of arguments")
+    parser = ArgumentParser(description="Dowloads URI to file dest. If md5sum is given, checks md5sum. If file existed and mismatch, downloads and checks again")
+    parser.add_argument("uri")
+    parser.add_argument("dest")
+    parser.add_argument("md5sum", nargs='?')
+    args = parser.parse_args(argv)
+
+    uri = args.uri
+    dest = args.dest
+    md5sum = args.md5sum
 
     if '://' not in uri:
         uri = 'file://' + uri

--- a/cmake/test/download_checkmd5.py
+++ b/cmake/test/download_checkmd5.py
@@ -164,6 +164,8 @@ def main(argv=sys.argv[1:]):
         if result is False:
             return 'ERROR: md5sum mismatch (%s != %s) on %s; aborting' % (hexdigest, args.md5sum, args.dest)
 
+    return 0
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/unit_tests/test_download_md5.py
+++ b/test/unit_tests/test_download_md5.py
@@ -53,7 +53,7 @@ class DowloadCheckMd5Test(unittest.TestCase):
             self.assertTrue(os.path.isfile(check_file))
             os.remove(check_file)
             self.assertFalse(os.path.isfile(check_file))
-            self.assertRaises(SystemExit, main, [os.path.join('file://localhost', src_file), check_file, "hello"])
+            self.assertTrue(main([os.path.join('file://localhost', src_file), check_file, "hello"]))
             main([os.path.join('file://localhost', src_file), check_file, realmd5])
 
         finally:

--- a/test/unit_tests/test_download_md5.py
+++ b/test/unit_tests/test_download_md5.py
@@ -53,7 +53,7 @@ class DowloadCheckMd5Test(unittest.TestCase):
             self.assertTrue(os.path.isfile(check_file))
             os.remove(check_file)
             self.assertFalse(os.path.isfile(check_file))
-            self.assertTrue(main([os.path.join('file://localhost', src_file), check_file, "hello"]))
+            self.assertNotEqual(main([os.path.join('file://localhost', src_file), check_file, "hello"]), 0)
             main([os.path.join('file://localhost', src_file), check_file, realmd5])
 
         finally:


### PR DESCRIPTION
Convert catkin_checkmd5 to argparse and add a flag to make it exit normally if the network connection isn't available.
