### PR TITLE
use PYTHON_EXECUTABLE for _setup_util.py

### DIFF
--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON_EXECUTABLE@
 
 # Software License Agreement (BSD License)
 #

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -929,6 +929,7 @@ def build_workspace_isolated(
                     'CATKIN_LIB_ENVIRONMENT_PATHS': "'lib'",
                     'CATKIN_PKGCONFIG_ENVIRONMENT_PATHS': "os.path.join('lib', 'pkgconfig')",
                     'CMAKE_PREFIX_PATH_AS_IS': ';'.join(os.environ['CMAKE_PREFIX_PATH'].split(os.pathsep)),
+                    'PYTHON_EXECUTABLE': sys.executable,
                     'PYTHON_INSTALL_DIR': get_python_install_dir(),
                 }
                 with open(generated_setup_util_py, 'w') as f:

--- a/test/unit_tests/test_setup_util.py
+++ b/test/unit_tests/test_setup_util.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -10,6 +11,7 @@ data = configure_file(os.path.join(os.path.dirname(__file__), '..', '..', 'cmake
                           'CATKIN_LIB_ENVIRONMENT_PATHS': "'lib'",
                           'CATKIN_PKGCONFIG_ENVIRONMENT_PATHS': "os.path.join('lib', 'pkgconfig')",
                           'CATKIN_GLOBAL_BIN_DESTINATION': 'bin',
+                          'PYTHON_EXECUTABLE': sys.executable,
                           'PYTHON_INSTALL_DIR': 'pythonX.Y/packages',
                           'CMAKE_PREFIX_PATH_AS_IS': '',
                       })


### PR DESCRIPTION
Similar to #645. Keep using the Python executable throughout all locations.

@wjwwood Please review.
