### PR TITLE
ignore cd path echo when using CDPATH, which breaks catkin usage

### DIFF
--- a/cmake/templates/env.sh.in
+++ b/cmake/templates/env.sh.in
@@ -8,6 +8,6 @@ if [ $# -eq 0 ] ; then
 fi
 
 # source @SETUP_FILENAME@.sh from same directory as this file
-_CATKIN_SETUP_DIR=$(cd "`dirname "$0"`" && pwd)
+_CATKIN_SETUP_DIR=$(cd "`dirname "$0"`" > /dev/null && pwd)
 . "$_CATKIN_SETUP_DIR/@SETUP_FILENAME@.sh"
 exec "$@"

--- a/cmake/templates/setup.bash.in
+++ b/cmake/templates/setup.bash.in
@@ -4,5 +4,5 @@
 CATKIN_SHELL=bash
 
 # source setup.sh from same directory as this file
-_CATKIN_SETUP_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" && pwd)
+_CATKIN_SETUP_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)
 . "$_CATKIN_SETUP_DIR/setup.sh"

--- a/cmake/templates/setup.zsh.in
+++ b/cmake/templates/setup.zsh.in
@@ -2,7 +2,7 @@
 # generated from catkin/cmake/templates/setup.zsh.in
 
 CATKIN_SHELL=zsh
-_CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" && pwd)
+_CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
 emulate sh # emulate POSIX
 . "$_CATKIN_SETUP_DIR/setup.sh"
 emulate zsh # back to zsh mode


### PR DESCRIPTION
cd'ing echos the reached directory to the console when the CDPATH environment variable is used
This breaks the extraction of _CATKIN_SETUP_DIR, because now the directory is listed twice!
see http://superuser.com/questions/90535/how-do-i-turn-of-auto-echo-in-bash-when-i-cd
