### PR TITLE
escape messages to avoid CMake warning

### DIFF
--- a/cmake/em/order_packages.cmake.em
+++ b/cmake/em/order_packages.cmake.em
@@ -17,7 +17,7 @@ except ImportError as e:
 try:
     ordered_packages = topological_order(os.path.normpath(source_root_dir), whitelisted=whitelisted_packages, blacklisted=blacklisted_packages, underlay_workspaces=underlay_workspaces)
 except InvalidPackage as e:
-    print('message(FATAL_ERROR "%s")' % e)
+    print('message(FATAL_ERROR "%s")' % ('%s' % e).replace('"', '\\"'))
     ordered_packages = []
 fatal_error = False
 }@


### PR DESCRIPTION
Related to #667 but I can't reproduce that one since it fails much earlier in catkin_make when trying to parse the invalid xml.

Anyway the error message should be escaped to avoid a CMake warning (with 2.8.12 and newer).

@tfoote @wjwwood Please review
