### PR TITLE
use atomic APPEND write mode for writing source spaces to .catkin marker file

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -16,19 +16,23 @@ else()
 endif()
 message(STATUS "Using CATKIN_DEVEL_PREFIX: ${CATKIN_DEVEL_PREFIX}")
 
-# create workspace marker
-set(_sourcespaces "${CMAKE_SOURCE_DIR}")
-if(EXISTS "${CATKIN_DEVEL_PREFIX}/.catkin")
-  # prepend to existing list of sourcespaces
-  file(READ "${CATKIN_DEVEL_PREFIX}/.catkin" _existing_sourcespaces)
-  list(FIND _existing_sourcespaces "${CMAKE_SOURCE_DIR}" _index)
-  if(_index EQUAL -1)
-    list(INSERT _existing_sourcespaces 0 ${CMAKE_SOURCE_DIR})
-  endif()
-  set(_sourcespaces ${_existing_sourcespaces})
-endif()
-file(WRITE "${CATKIN_DEVEL_PREFIX}/.catkin" "${_sourcespaces}")
+# update develspace marker file with a reference to this sourcespace
+set(_catkin_marker_file "${CATKIN_DEVEL_PREFIX}/.catkin")
 
+# check if the develspace marker file exists yet
+if(EXISTS ${_catkin_marker_file})
+  # append to existing list of sourcespaces 
+  file(READ ${_catkin_marker_file} _existing_sourcespaces)
+  list(FIND _existing_sourcespaces "${CMAKE_SOURCE_DIR}" _existing_sourcespace_index)
+  if(_existing_sourcespace_index EQUAL -1)
+    file(APPEND ${_catkin_marker_file} ";${CMAKE_SOURCE_DIR}")
+  endif()
+else()
+  # create a new develspace marker file
+  # NOTE: extra care must be taken when running multiple catkin jobs in parallel 
+  #       so that this does not overwrite the result of a similar call in another package
+  file(WRITE ${_catkin_marker_file} "${CMAKE_SOURCE_DIR}")
+endif()
 
 # use either CMAKE_PREFIX_PATH explicitly passed to CMake as a command line argument
 # or CMAKE_PREFIX_PATH from the environment


### PR DESCRIPTION
There is no significance to the order of the packages written to the `.catkin` file, so instead of reading/inserting/writing, this patch uses a single `file(APPEND ...)` command to modify the file. While not bullet-proof, this significantly decreases the probability that the problem described in #670 / catkin/catkin_tools#77 occurs.
