### PR TITLE
Delayed expansion for indexed catkin env hooks in windows

### DIFF
--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -42,17 +42,28 @@ call %_SETUP_TMP%
 del %_SETUP_TMP%
 
 REM source all environment hooks
-for /F "tokens=* delims=;" %%a in ("%_CATKIN_ENVIRONMENT_HOOKS%") do (
-  for %%b in (%%a) do (
-    call "%%b"
-  )
+set /A _upper_loop_index = %_CATKIN_ENVIRONMENT_HOOKS_COUNT% - 1
+
+setlocal enabledelayedexpansion
+for /L %%a in (0, 1, %_upper_loop_index%) do (  
+    set _env_var_ref=_CATKIN_ENVIRONMENT_HOOKS_%%a
+    REM The follow lines can be uncommented to illustrate how the delayed expansion is working
+    REM echo %%a
+    REM echo !_env_var_ref!
+    REM call echo %%!_env_var_ref!%%
+    call call %%!_env_var_ref!%%
 )
+REM endlocal will wipe all the environment variables created by the scripts called above
+REM their capture is hardcoded here. This should be revisited
+endlocal &&  set ROS_PACKAGE_PATH=%ROS_PACKAGE_PATH% && set ROS_ETC_DIR=%ROS_ETC_DIR% && set ROS_MASTER_URI=%ROS_MASTER_URI% && set ROS_ROOT=%ROS_ROOT%
+
 
 REM 3rdparty packages often put dll's into lib (convention is bin) and 
 REM windows finds it's dll's via the PATH variable. Make that happen here!
 set PATH=%LD_LIBRARY_PATH%;%PATH%
 
 REM unset temporary variables
+set _upper_loop_index=
 set _SETUP_UTIL=
 set _PYTHON=
 set _SETUP_TMP=


### PR DESCRIPTION
This pull request on win_ros will provide a lot of context: [win_ros pull request #44](https://github.com/ros-windows/win_ros/pull/44)

This is a workable solution to use the new indexed style catkin environment hooks (new to the windows people in the move from 0.5.69 :arrow_right: 0.5.78). It works in my local environment where I'm using Catkin 0.5.78 with the rest of the windows hydro stack. 

Although it works its far from ideal:
1. Delayed expansion is confusing and not intuitive (hence provided comments for those that want to watch the steps in the expansion)
2. `setlocal/endlocal` is a scoping mechanism that destroys all variables created in the scope. This requires explicit capture of the variables at `endlocal`. This requires knowledge of what the end environment should contain.
3. The `_CATKIN_ENVIRONMENT_HOOKS_XXX` variables are not removed from the environment at the end of the script. I tried this using delayed expansion but it never seemed to work. I assume leaving these env variables present will do no harm to the run time.

Related pull requests for files called via the `_CATKIN_ENVIRONMENT_HOOKS_XXX` are here:
- [ROS pull request 60](https://github.com/ros/ros/pull/60)
- [ros-windows/ros_comm pull request 2](https://github.com/ros-windows/ros_comm/pull/2)
