### PR TITLE
catkin_generate_environment: don't overwrite existing .catkin file

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -21,11 +21,16 @@ set(_catkin_marker_file "${CATKIN_DEVEL_PREFIX}/.catkin")
 
 # check if the develspace marker file exists yet
 if(EXISTS ${_catkin_marker_file})
-  # append to existing list of sourcespaces 
   file(READ ${_catkin_marker_file} _existing_sourcespaces)
-  list(FIND _existing_sourcespaces "${CMAKE_SOURCE_DIR}" _existing_sourcespace_index)
-  if(_existing_sourcespace_index EQUAL -1)
-    file(APPEND ${_catkin_marker_file} ";${CMAKE_SOURCE_DIR}")
+  if(_existing_sourcespaces STREQUAL "")
+    # write this sourcespace to the marker file
+    file(WRITE ${_catkin_marker_file} "${CMAKE_SOURCE_DIR}")
+  else()
+    # append to existing list of sourcespaces if it's not in the list
+    list(FIND _existing_sourcespaces "${CMAKE_SOURCE_DIR}" _existing_sourcespace_index)
+    if(_existing_sourcespace_index EQUAL -1)
+      file(APPEND ${_catkin_marker_file} ";${CMAKE_SOURCE_DIR}")
+    endif()
   endif()
 else()
   # create a new develspace marker file

--- a/cmake/catkin_generate_environment.cmake
+++ b/cmake/catkin_generate_environment.cmake
@@ -75,11 +75,12 @@ function(catkin_generate_environment)
   set(SETUP_DIR ${CMAKE_INSTALL_PREFIX})
 
   if(NOT CATKIN_BUILD_BINARY_PACKAGE)
-    # generate and install workspace marker
-    file(WRITE ${CMAKE_BINARY_DIR}/catkin_generated/installspace/.catkin "")
-    install(FILES
-      ${CMAKE_BINARY_DIR}/catkin_generated/installspace/.catkin
-      DESTINATION ${CMAKE_INSTALL_PREFIX})
+    # install empty workspace marker if it doesn't already exist
+    install(CODE " 
+      if (NOT EXISTS \"\${CMAKE_INSTALL_PREFIX}/.catkin\") 
+        file(WRITE \"\${CMAKE_INSTALL_PREFIX}/.catkin\" \"\") 
+      endif()") 
+
     # generate and install Python setup util
     configure_file(${catkin_EXTRAS_DIR}/templates/_setup_util.py.in
       ${CMAKE_BINARY_DIR}/catkin_generated/installspace/_setup_util.py


### PR DESCRIPTION
The Orocos RTT package, a pure CMake package, currently doesn't _use_ catkin for building, but it does call `find_package(catkin)` in order to determine if catkin is installed on the system, and if so, it calls `catkin_add_env_hooks()` to add an env hook. This works fine if you're installing it to an isolated workspace or somewhere else, but when installing to a develspace (like with `catkin_tools`), it causes the `.catkin` file to be overwritten and you lose the list of all previously-built packages.

This patch replaces the normal CMake `install(FILES ...)` command with an `install(CODE ...)` command which just checks if the file already exists or not.
