### PR TITLE
Fix catkin_make working directory issue

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -35,8 +35,8 @@ def main():
     if args.no_color:
         disable_ANSI_colors()
 
-    # use PWD in order to work when being invoked in a symlinked location
-    cwd = os.getenv('PWD', os.curdir)
+    # remove possible symlinks from the working directory
+    cwd = os.path.realpath(os.curdir)
 
     # verify that the base path is known
     base_path = os.path.abspath(os.path.join(cwd, args.directory))


### PR DESCRIPTION
The proper way of removing symlink from a path seems to be os.path.realpath()
Using the PWD environment variable is uncertain, there is no guaranty that it is free of symlinks and moreover nothing ensure that it is properly set, unless you assume some particular shell and way of calling catkin_make. 
One example of this issue is the call of catkin_make as a python subprocess, hitting issues like: see http://bugs.python.org/issue4057
