### PR TITLE
set terminal title only when isatty

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -613,7 +613,7 @@ def build_package(
     destdir=None,
     number=None, of=None
 ):
-    if platform.system() in ['Linux', 'Darwin']:
+    if platform.system() in ['Linux', 'Darwin'] and sys.stdout.isatty():
         status_msg = '{package_name} [{number} of {total}]'.format(package_name=package.name, number=number, total=of)
         sys.stdout.write("\x1b]2;" + status_msg + "\x07")
     cprint('@!@{gf}==>@| ', end='')


### PR DESCRIPTION
This prevents the ascii characters to be printed when e.g. running on the farm without a terminal.
