### PR TITLE
use emulate -L in setup.zsh to keep options intact

### DIFF
--- a/cmake/templates/setup.zsh.in
+++ b/cmake/templates/setup.zsh.in
@@ -3,6 +3,10 @@
 
 CATKIN_SHELL=zsh
 _CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
-emulate sh # emulate POSIX
-. "$_CATKIN_SETUP_DIR/setup.sh"
-emulate zsh # back to zsh mode
+
+function _catkin_source_setup {
+  emulate -L sh # emulate POSIX
+  source "$_CATKIN_SETUP_DIR/setup.sh"
+}
+
+_catkin_source_setup


### PR DESCRIPTION
Should resolve issue #686. The original overwrites options explicitly set by the user in their zshrc.
