### PR TITLE
use local scope for zsh emulating sh

### DIFF
--- a/cmake/templates/setup.zsh.in
+++ b/cmake/templates/setup.zsh.in
@@ -3,6 +3,9 @@
 
 CATKIN_SHELL=zsh
 _CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
-emulate sh # emulate POSIX
-. "$_CATKIN_SETUP_DIR/setup.sh"
-emulate zsh # back to zsh mode
+
+_catkin_source_setup() {
+  emulate -L sh
+  . "$_CATKIN_SETUP_DIR/setup.sh"
+}
+_catkin_source_setup


### PR DESCRIPTION
Addressing #686

@wjwwood Can you please verify that this works well on Mac OS. E.g. with a small workspace like `ros_core` and making sure that the environment hooks are sourced correctly.
