### PR TITLE
check changes to -D args when considering to reinvoke cmake

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -78,6 +78,7 @@ def main():
         cmake_args = [a for a in cmake_args if a not in devel_prefix]
     devel_path = determine_path_argument(cwd, base_path, devel_arg, 'devel')
     print('Devel space: %s' % devel_path)
+    cmake_args.append('-DCATKIN_DEVEL_PREFIX=%s' % devel_path)
 
     # determine install space
     install_arg = None
@@ -89,6 +90,7 @@ def main():
     install_path = determine_path_argument(
         cwd, base_path, install_arg, 'install')
     print('Install space: %s' % install_path)
+    cmake_args.append('-DCMAKE_INSTALL_PREFIX=%s' % install_path)
 
     # ensure build folder exists
     if not os.path.exists(build_path):
@@ -153,8 +155,6 @@ def main():
         cmd = [
             'cmake',
             source_path,
-            '-DCATKIN_DEVEL_PREFIX=%s' % devel_path,
-            '-DCMAKE_INSTALL_PREFIX=%s' % install_path
         ]
         cmd += cmake_args
         try:

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -885,7 +885,12 @@ def build_workspace_isolated(
         sys.exit('Can not build workspace with packages of unknown build_type')
 
     # Check to see if the workspace has changed
-    if not force_cmake and cmake_input_changed(packages, buildspace, cmake_args=cmake_args, filename='catkin_make_isolated'):
+    cmake_args_with_spaces = list(cmake_args)
+    if develspace:
+        cmake_args_with_spaces.append('-DCATKIN_DEVEL_PREFIX=' + develspace)
+    if installspace:
+        cmake_args_with_spaces.append('-DCMAKE_INSTALL_PREFIX=' + installspace)
+    if not force_cmake and cmake_input_changed(packages, buildspace, cmake_args=cmake_args_with_spaces, filename='catkin_make_isolated'):
         print('The packages or cmake arguments have changed, forcing cmake invocation')
         force_cmake = True
 


### PR DESCRIPTION
- `CATKIN_DEVEL_PREFIX`
- `CMAKE_INSTALL_PREFIX`

Came up here: http://answers.ros.org/question/199740/catkin-dcmake_install_prefix-flag/
