### PR TITLE
Fix setting CATKIN_GLOBAL_LIBEXEC_DESTINATION to libexec.

### DIFF
--- a/doc/user_guide/variables.rst
+++ b/doc/user_guide/variables.rst
@@ -71,6 +71,9 @@ They only contain relative paths and are supposed to be relative to the ``${CMAK
 
    This is set to ``lib``.
    On non-Debian distributions it could be set to ``libexec``.
+   Note that setting this variable to anything but ``lib`` or ``libexec`` will
+   not work as expected since tools like ``catkin_find`` will only consider
+   these two locations.
    This variable should not be used directly, use ``CATKIN_PACKAGE_BIN_DESTINATION`` instead.
 
 .. cmake:data:: CATKIN_GLOBAL_PYTHON_DESTINATION

--- a/python/catkin/find_in_workspaces.py
+++ b/python/catkin/find_in_workspaces.py
@@ -118,9 +118,11 @@ def find_in_workspaces(search_dirs=None, project=None, path=None, _workspaces=ge
     existing_paths = []
     try:
         for workspace in (_workspaces or []):
+            if 'libexec' in search_dirs:
+                search_dirs.insert(search_dirs.index('libexec'), 'lib')
             for sub in search_dirs:
                 # search in workspace
-                p = os.path.join(workspace, sub if sub != 'libexec' else 'lib')
+                p = os.path.join(workspace, sub)
                 if project:
                     p = os.path.join(p, project)
                 if path:

--- a/test/unit_tests/test_find_in_workspace.py
+++ b/test/unit_tests/test_find_in_workspace.py
@@ -57,9 +57,12 @@ class FindInWorkspaceTest(unittest.TestCase):
         self.assertEqual(['bar/include/foo/foopath',
                           'bar/etc/foo/foopath',
                           'bar/lib/foo/foopath',
+                          'bar/libexec/foo/foopath',
                           'baz/include/foo/foopath',
                           'baz/etc/foo/foopath',
-                          'baz/lib/foo/foopath'], checked)
+                          'baz/lib/foo/foopath',
+                          'baz/lib/foo/foopath',
+                          'baz/libexec/foo/foopath'], checked)
         checked = []
         existing = find_in_workspaces(['share', 'etc', 'lib'], None, 'foopath', _workspaces=['bar', 'baz'], considered_paths=checked)
         self.assertEqual([], existing)


### PR DESCRIPTION
I tried to set CATKIN_GLOBAL_LIBEXEC_DESTINATION to libexec, as described as possible in doc/user_guide/variables.rst, since I find this location more natural for nodes & co.
However, catkin_find could not find any node after that. This patch makes it possible to find nodes there, while maintaining the translation libexec -> lib.
