### PR TITLE
Fix potential race condition in 'download_checkmd5.py'

### DIFF
--- a/cmake/test/download_checkmd5.py
+++ b/cmake/test/download_checkmd5.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+import errno
 import os
 import sys
 try:
@@ -87,8 +88,12 @@ def download_md5(uri, dest):
     """
     # Create intermediate directories as necessary, #2970
     dirname = os.path.dirname(dest)
-    if len(dirname) and not os.path.exists(dirname):
-        os.makedirs(dirname)
+    if len(dirname):
+        try:
+            os.makedirs(dirname)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
     sys.stdout.write('Downloading %s to %s...' % (uri, dest))
     sys.stdout.flush()


### PR DESCRIPTION
When trying to download multiple files in the same directory, using `catkin_download_test_data`, there is a race condition (if `make` has been called with `-jN`, where N>1)  because 2 or more threads are trying to create the same directory.

I have created a simple [package](https://github.com/czalidis/test_download_data) to reproduce that issue. The only thing that package does, is to declare 2 calls to `catkin_download_test_data` in the [CMakeLists.txt](https://github.com/czalidis/test_download_data/blob/master/CMakeLists.txt), where the `DESTINATION` is the same directory.

The error I get is the following:

```
#### Running command: "make tests -j8 -l8" in "/home/chris/catkin_ws/build"
####
Scanning dependencies of target test_download_data_32e.pcap
Scanning dependencies of target test_download_data_test.pgm
[100%] [100%] Generating /home/chris/catkin_ws/devel/share/test_download_data/tests/32e.pcap
Generating /home/chris/catkin_ws/devel/share/test_download_data/tests/test.pgm
Downloading http://download.ros.org/data/maps/test.pgm to /home/chris/catkin_ws/devel/share/test_download_data/tests/test.pgm...Traceback (most recent call last):
  File "/home/chris/catkin_ws/src/catkin/cmake/test/download_checkmd5.py", line 177, in <module>
    sys.exit(main())
  File "/home/chris/catkin_ws/src/catkin/cmake/test/download_checkmd5.py", line 151, in main
    download_md5(uri, args.dest)
  File "/home/chris/catkin_ws/src/catkin/cmake/test/download_checkmd5.py", line 91, in download_md5
    os.makedirs(dirname)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/home/chris/catkin_ws/devel/share/test_download_data/tests'
make[3]: *** [/home/chris/catkin_ws/devel/share/test_download_data/tests/32e.pcap] Error 1
make[2]: *** [test_download_data/CMakeFiles/test_download_data_32e.pcap.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
 done.
Checking md5sum on /home/chris/catkin_ws/devel/share/test_download_data/tests/test.pgm
[100%] Built target test_download_data_test.pgm
make[1]: *** [CMakeFiles/tests.dir/rule] Error 2
make: *** [tests] Error 2
```

You can reproduce the same error, cloning that package and running `catkin_make tests`.

This pull request is supposed to resolve that issue. 
