### PR TITLE
display elapsed time during running catkin

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -38,6 +38,7 @@ import os
 import platform
 import re
 import stat
+from datetime import datetime, timedelta
 try:
     from StringIO import StringIO
 except ImportError:
@@ -177,6 +178,7 @@ def print_command_banner(cmd, cwd, color):
         print('####')
 
 
+start_time = datetime.utcnow()
 def run_command_colorized(cmd, cwd, quiet=False, add_env=None):
     run_command(cmd, cwd, quiet=quiet, colorize=True, add_env=add_env)
 
@@ -229,7 +231,8 @@ def run_command(cmd, cwd, quiet=False, colorize=False, add_env=None):
                 traceback.print_exc()
                 print('<caktin_make> color formatting problem: ' + str(e),
                       file=sys.stderr)
-            out.write(line)
+            elapsed_time = datetime.utcnow() - start_time
+            out.write(str(timedelta(days=elapsed_time.days, seconds=elapsed_time.seconds)) + " " + line)
     proc.wait()
     if proc.returncode:
         if quiet:


### PR DESCRIPTION
I'm not sure how to pass argument to enable/disable dis feature, should we add new function aruguments and fix catkin_make commands?
