### PR TITLE
improve generality of generate_cmake_rst.py

### DIFF
--- a/doc/generate_cmake_rst.py
+++ b/doc/generate_cmake_rst.py
@@ -37,11 +37,12 @@ import argparse
 import os
 import re
 import sys
+import json
 
 '''Simple superficial API doc generator for .cmake files'''
 
 
-def crawl_for_cmake(path):
+def crawl_for_cmake(path, excluded_files=[]):
     '''
     Crawls over path, looking for files named *.cmake,
     returns tuple of full and relative path.
@@ -49,7 +50,8 @@ def crawl_for_cmake(path):
     cmake_files = []
     for (parentdir, _, files) in os.walk(path):
         for filename in files:
-            if not filename.endswith('.cmake'):
+            if not filename.endswith('.cmake') or \
+                  filename in excluded_files:
                 continue
             fullpath = os.path.join(parentdir, filename)
             relpath = os.path.relpath(fullpath, path)
@@ -57,7 +59,7 @@ def crawl_for_cmake(path):
     return cmake_files
 
 
-def generate_rst(files):
+def generate_rst(files, skip_private=False, skip_undocumented=False):
     '''
     Each of the CMake files is traversed line by line, looking for
     lines like function(...) or macro(...).  For each of these,
@@ -92,7 +94,7 @@ def generate_rst(files):
                     if dec_type == 'function' or dec_type == 'macro':
                         rst = []
                         # directives defined in catkin-sphinx
-                        dec_line = '.. _`%s_ref`:\n\n`%s`\n%s\n\n.. cmake:macro:: %s(%s)' % (dec_args[0],dec_args[0], '-' * (len(dec_args[0]) + 2), dec_args[0], ', '.join(dec_args[1:]))
+                        dec_line = '.. _`%s_ref`:\n\n`%s`\n%s\n\n.. cmake:macro:: %s(%s)' % (dec_args[0],dec_args[0], '~' * (len(dec_args[0]) + 2), dec_args[0], ', '.join(dec_args[1:]))
                         rst.append(dec_line)
                         rst.append('')
                         rst.append(' *[%s defined in %s]*' % (dec_type, relpath))
@@ -120,6 +122,7 @@ def generate_rst(files):
     rst.append('.. ' + '!' * 70)
     rst.append('')
     rst.append('.. contents::')
+    rst.append('   :local:')
     rst.append('')
     rst.append('')
     rst.append('Public CMake functions / macros')
@@ -130,23 +133,26 @@ def generate_rst(files):
     for name in sorted(public.keys()):
         rst.append('')
         rst.extend(public[name])
+    rst.append('')
 
-    rst.append('')
-    rst.append('Non-public CMake functions / macros')
-    rst.append('-----------------------------------')
-    rst.append('')
-    for name in sorted(documented.keys()):
-        rst.append(' * :cmake:macro:`%s`' % name)
-    for name in sorted(documented.keys()):
+    if not skip_private:
+        rst.append('Non-public CMake functions / macros')
+        rst.append('-----------------------------------')
         rst.append('')
-        rst.extend(documented[name])
-
-    rst.append('')
-    rst.append('Not documented CMake functions / macros')
-    rst.append('---------------------------------------')
-    for name in sorted(undocumented.keys()):
+        for name in sorted(documented.keys()):
+            rst.append(' * :cmake:macro:`%s`' % name)
+        for name in sorted(documented.keys()):
+            rst.append('')
+            rst.extend(documented[name])
         rst.append('')
-        rst.extend(undocumented[name])
+    
+    if not skip_undocumented:
+        rst.append('Not documented CMake functions / macros')
+        rst.append('---------------------------------------')
+        for name in sorted(undocumented.keys()):
+            rst.append('')
+            rst.extend(undocumented[name])
+        rst.append('')
 
     return rst
 
@@ -155,10 +161,26 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Crawls a path for .cmake files and extract documentation of functions and macros into reStructured text.')
     parser.add_argument('path', nargs='?', default='.', help='The path to be crawled')
     parser.add_argument('-o', '--output', help='The name of the generated rst file')
+    parser.add_argument('--skip_private', action="store_true", help='skip documented items not marked with @public')
+    parser.add_argument('--skip_undocumented', action="store_true", help='skip items without documentation')
+
     args = parser.parse_args()
 
-    cmake_files = crawl_for_cmake(args.path)
-    lines = generate_rst(cmake_files)
+    exclusions = '{}/.sphinx_exclusions.json'.format(args.path)
+    excluded_files = []
+    try:
+        if os.path.exists(exclusions):
+            # print('exclusions={}'.format(exclusions))
+            with open(exclusions) as f:
+                excluded_files = json.load(f)
+    except:
+        print('unable to load exclusions from {}; make sure it is valid json or remove it'.format(exclusions), file=sys.stderr)
+        sys.exit(-1)
+
+    print('skip_undocumented={}'.format(args.skip_undocumented))
+    
+    cmake_files = crawl_for_cmake(args.path, excluded_files)
+    lines = generate_rst(cmake_files, args.skip_private, args.skip_undocumented)
     if args.output:
         with open(args.output, 'w') as f:
             f.write('\n'.join(lines))


### PR DESCRIPTION
- use an optional json config file to exclude listed from the auto-generated api file
- extend generate_rst with optional arguments that allow skipping of private and undocumented objects
- use '~' rather than '-' so the individual macro/function objects are one level in the outline below the section headers for Public, Non-public, and Not documented.
- use :local: option to the contents directive to avoid pulling in the title page header

I built and deployed the catkin docs to my fork's gh-pages branch. The page http://pwm1234.github.io/catkin/doc/build/html/dev_guide/generated_cmake_api.html shows the changes/improvements to the extracted api page.
