### PR TITLE
Fix python error when working with non-ascii characters in path

### DIFF
--- a/cmake/templates/__init__.py.in
+++ b/cmake/templates/__init__.py.in
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # generated from catkin/cmake/template/__init__.py.in
 # keep symbol table as clean as possible by deleting all unnecessary symbols
 

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -1,4 +1,5 @@
 #!@PYTHON_EXECUTABLE@
+# -*- coding: utf-8 -*-
 
 # Software License Agreement (BSD License)
 #

--- a/cmake/templates/generate_cached_setup.py.in
+++ b/cmake/templates/generate_cached_setup.py.in
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 import argparse
 import os

--- a/cmake/templates/relay.py.in
+++ b/cmake/templates/relay.py.in
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # creates a relay to a python script source file, acting as that file.
 # The purpose is that of a symlink
 with open("@PYTHON_SCRIPT@", 'r') as fh:

--- a/cmake/templates/script.py.in
+++ b/cmake/templates/script.py.in
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # creates a relay to a python script source file, acting as that file.
 # The purpose is that of a symlink
 with open("@PYTHON_SCRIPT@", 'r') as fh:


### PR DESCRIPTION
This is a recurrent error when working in non-english local system. Non-ascii charaters in the path to the catkin workspace make the cmake execution fail :

```
File "/home/moinel/éàç/src/visual_actimetry_msgs/build/devel/_setup_util.py", line 262
SyntaxError: Non-ASCII character '\xc3' in file /home/moinel/éàç/src/visual_actimetry_msgs/build/devel/_setup_util.py on line 262, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

It is maybe worth specifying utf-8 encoding to every python script.
