### PR TITLE
extract catkin_add_executable_with_gtest() from catkin_add_gtest()

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -25,37 +25,67 @@ _generate_function_if_testing_is_disabled("catkin_add_gtest")
 function(catkin_add_gtest target)
   _warn_if_skip_testing("catkin_add_gtest")
 
+  # XXX look for optional TIMEOUT argument, #2645
+  cmake_parse_arguments(ARG "" "TIMEOUT;WORKING_DIRECTORY" "" ${ARGN})
+  if(ARG_TIMEOUT)
+    message(WARNING "TIMEOUT argument to catkin_add_gtest() is ignored")
+  endif()
+
+  catkin_add_executable_with_gtest(${target} ${ARG_UNPARSED_ARGUMENTS} EXCLUDE_FROM_ALL)
+
+  if(TARGET ${target})
+    # make sure the target is built before running tests
+    add_dependencies(tests ${target})
+
+    # XXX we DONT use rosunit to call the executable to get process control, #1629, #3112
+    get_target_property(_target_path ${target} RUNTIME_OUTPUT_DIRECTORY)
+    set(cmd "${_target_path}/${target} --gtest_output=xml:${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/gtest-${target}.xml")
+    catkin_run_tests_target("gtest" ${target} "gtest-${target}.xml" COMMAND ${cmd} DEPENDENCIES ${target} WORKING_DIRECTORY ${ARG_WORKING_DIRECTORY})
+  endif()
+endfunction()
+
+#
+# Add a GTest executable target.
+#
+# An executable target is created with the source files, it is linked
+# against GTest.
+# If you also want to register the executable as a test use
+# ``catkin_add_gtest()`` instead.
+#
+# :param target: the target name
+# :type target: string
+# :param source_files: a list of source files used to build the test
+#   executable
+# :type source_files: list of strings
+#
+# Additionally, the option EXCLUDE_FROM_ALL can be specified.
+# @public
+#
+function(catkin_add_executable_with_gtest target)
   if(NOT GTEST_FOUND AND NOT GTEST_FROM_SOURCE_FOUND)
     message(WARNING "skipping gtest '${target}' in project '${PROJECT_NAME}'")
     return()
   endif()
 
   if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-    message(FATAL_ERROR "catkin_add_gtest() must be called after catkin_package() so that default output directories for the test binaries are defined")
+    message(FATAL_ERROR "catkin_add_executable_with_gtest() must be called after catkin_package() so that default output directories for the executables are defined")
   endif()
 
-  # XXX look for optional TIMEOUT argument, #2645
-  cmake_parse_arguments(_gtest "" "TIMEOUT;WORKING_DIRECTORY" "" ${ARGN})
-  if(_gtest_TIMEOUT)
-    message(WARNING "TIMEOUT argument to catkin_add_gtest() is ignored")
-  endif()
+  cmake_parse_arguments(ARG "EXCLUDE_FROM_ALL" "" "" ${ARGN})
 
   # create the executable, with basic + gtest build flags
   include_directories(${GTEST_INCLUDE_DIRS})
   link_directories(${GTEST_LIBRARY_DIRS})
-  add_executable(${target} EXCLUDE_FROM_ALL ${_gtest_UNPARSED_ARGUMENTS})
+  add_executable(${target} ${ARG_UNPARSED_ARGUMENTS})
+  if(ARG_EXCLUDE_FROM_ALL)
+    set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  endif()
+
   assert(GTEST_LIBRARIES)
   target_link_libraries(${target} ${GTEST_LIBRARIES} ${THREADS_LIBRARY})
 
-  # make sure gtest is built before the test target
+  # make sure gtest is built before the target
   add_dependencies(${target} gtest gtest_main)
-  # make sure the target is built before running tests
-  add_dependencies(tests ${target})
-
-  # XXX we DONT use rosunit to call the executable to get process control, #1629, #3112
-  get_target_property(_target_path ${target} RUNTIME_OUTPUT_DIRECTORY)
-  set(cmd "${_target_path}/${target} --gtest_output=xml:${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/gtest-${target}.xml")
-  catkin_run_tests_target("gtest" ${target} "gtest-${target}.xml" COMMAND ${cmd} DEPENDENCIES ${target} WORKING_DIRECTORY ${_gtest_WORKING_DIRECTORY})
 endfunction()
 
 find_package(GTest QUIET)

--- a/doc/dev_guide/generated_cmake_api.rst
+++ b/doc/dev_guide/generated_cmake_api.rst
@@ -13,6 +13,7 @@ Public CMake functions / macros
 -------------------------------
 
  * :cmake:macro:`catkin_add_env_hooks`
+ * :cmake:macro:`catkin_add_executable_with_gtest`
  * :cmake:macro:`catkin_add_gtest`
  * :cmake:macro:`catkin_add_nosetests`
  * :cmake:macro:`catkin_download`
@@ -82,6 +83,32 @@ Public CMake functions / macros
    in the devel space but not installed
  :type SKIP_INSTALL: option
 
+
+
+.. _`catkin_add_executable_with_gtest_ref`:
+
+`catkin_add_executable_with_gtest`
+----------------------------------
+
+.. cmake:macro:: catkin_add_executable_with_gtest(target)
+
+ *[function defined in test/gtest.cmake]*
+
+
+ Add a GTest executable target.
+
+ An executable target is created with the source files, it is linked
+ against GTest.
+ If you also want to register the executable as a test use
+ ``catkin_add_gtest()`` instead.
+
+ :param target: the target name
+ :type target: string
+ :param source_files: a list of source files used to build the test
+   executable
+ :type source_files: list of strings
+
+ Additionally, the option EXCLUDE_FROM_ALL can be specified.
 
 
 .. _`catkin_add_gtest_ref`:


### PR DESCRIPTION
Provides separate function for ros/ros_comm#579.
