### PR TITLE
Replace l:$absolute_path in pkgconfig by just the absolute path

### DIFF
--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -261,7 +261,7 @@ function(_catkin_package)
     if(IS_ABSOLUTE ${library})
       get_filename_component(suffix ${library} EXT)
       if(NOT "${suffix}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        # We are passing the absolute library as it, since the l:<absolute_path> syntax was tricky and deprecated
+        # We are passing the absolute library as it, since the -l:<absolute_path> syntax was tricky and deprecated
         # in some version of ld. See https://github.com/ros/catkin/issues/694 for more information.
         set(library "${library}")
       endif()

--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -261,7 +261,9 @@ function(_catkin_package)
     if(IS_ABSOLUTE ${library})
       get_filename_component(suffix ${library} EXT)
       if(NOT "${suffix}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        set(library "-l:${library}")
+        # We are passing the absolute library as it, since the l:<absolute_path> syntax was tricky and deprecated
+        # in some version of ld. See https://github.com/ros/catkin/issues/694 for more information.
+        set(library "${library}")
       endif()
     else()
       set(library "-l${library}")


### PR DESCRIPTION
Fix for issue #694.

The syntax `-l:$library_absolute_path` seems to be unsupported by upstream ld and it is failing in some versions of the linker.

This patch workaround about the problem by generating pkg-config files which does not set the `-l` (only works with relative paths) and just provide the absolute path to the library. The compiler will link the library as a shared lib (if `-static` was not supplied).
