### PR TITLE
remove CATKIN_TEST_RESULTS_DIR environment variable

### DIFF
--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -12,11 +12,8 @@ from catkin.test_results import aggregate_results, print_summary, test_results
 
 
 def main():
-    env_name = 'CATKIN_TEST_RESULTS_DIR'
-    test_results_dir = os.environ[env_name] if env_name in os.environ else False
-
     parser = argparse.ArgumentParser(description='Outputs a summary of the test results. If there are any test errors or failures the scripts return code is 1.')
-    parser.add_argument('test_results_dir', nargs='?' if test_results_dir else None, default=test_results_dir, help='The path to the test results (necessary when the environment variable "%s" is not defined)' % env_name)
+    parser.add_argument('test_results_dir', nargs='?', default=os.curdir, help='The path to the test results')
     parser.add_argument('--all', action='store_true', default=False, help='Show all test results even the ones without errors/failures')
     parser.add_argument('--verbose', action='store_true', default=False, help='Show all tests which have errors or failed')
     args = parser.parse_args()

--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -198,9 +198,6 @@ endif()
 if(CMAKE_HOST_UNIX)
   catkin_add_env_hooks(05.catkin_make SHELLS bash DIRECTORY ${catkin_EXTRAS_DIR}/env-hooks ${catkin_skip_install_env_hooks})
   catkin_add_env_hooks(05.catkin_make_isolated SHELLS bash DIRECTORY ${catkin_EXTRAS_DIR}/env-hooks ${catkin_skip_install_env_hooks})
-  catkin_add_env_hooks(05.catkin-test-results SHELLS sh DIRECTORY ${catkin_EXTRAS_DIR}/env-hooks ${catkin_skip_install_env_hooks})
-else()
-  catkin_add_env_hooks(05.catkin-test-results SHELLS bat DIRECTORY ${catkin_EXTRAS_DIR}/env-hooks ${catkin_skip_install_env_hooks})
 endif()
 
 # requires stamp and environment files

--- a/cmake/env-hooks/05.catkin-test-results.bat.develspace.in
+++ b/cmake/env-hooks/05.catkin-test-results.bat.develspace.in
@@ -1,4 +1,0 @@
-REM generated from catkin/cmake/env-hooks/05.catkin-test-results.bat.develspace.in
-
-set CATKIN_TEST_RESULTS_DIR="@CATKIN_TEST_RESULTS_DIR@"
-set ROS_TEST_RESULTS_DIR=%CATKIN_TEST_RESULTS_DIR%

--- a/cmake/env-hooks/05.catkin-test-results.sh.develspace.in
+++ b/cmake/env-hooks/05.catkin-test-results.sh.develspace.in
@@ -1,4 +1,0 @@
-# generated from catkin/cmake/env-hooks/05.catkin-test-results.sh.develspace.in
-
-export CATKIN_TEST_RESULTS_DIR="@CATKIN_TEST_RESULTS_DIR@"
-export ROS_TEST_RESULTS_DIR="$CATKIN_TEST_RESULTS_DIR"

--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -84,7 +84,7 @@ endif()
 # Create a test target, integrate it with the run_tests infrastructure
 # and post-process the junit result.
 #
-# All test results go under ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/..
+# All test results go under ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}
 #
 # This function is only used internally by the various
 # catkin_add_*test() functions.

--- a/doc/dev_guide/generated_cmake_api.rst
+++ b/doc/dev_guide/generated_cmake_api.rst
@@ -590,7 +590,7 @@ Non-public CMake functions / macros
  Create a test target, integrate it with the run_tests infrastructure
  and post-process the junit result.
 
- All test results go under ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/..
+ All test results go under ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}
 
  This function is only used internally by the various
  catkin_add_*test() functions.


### PR DESCRIPTION
This patch removes the CATKIN_TEST_RESULTS_DIR environment variable. That should prevent any kind of "cross talk" between packages build in parallel since the location is only depending on configure-time information.

The user can still override the location by setting the CMake variable via `-DCATKIN_TEST_RESULTS_DIR=...`.

Addresses #719.

@esteve @tfoote @wjwwood Please review.
