### PR TITLE
all.cmake: use CMP0054 NEW if available

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -95,6 +95,7 @@ _set_cmake_policy_to_new_if_available(CMP0014)
 _set_cmake_policy_to_new_if_available(CMP0015)
 _set_cmake_policy_to_new_if_available(CMP0016)
 _set_cmake_policy_to_new_if_available(CMP0017)
+_set_cmake_policy_to_new_if_available(CMP0054)
 
 # the following operations must be performed inside a project context
 if(NOT PROJECT_NAME)


### PR DESCRIPTION
[CMP0054 is defined here](http://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html) and is available in cmake 3.1+.
The OLD version of this policy allows quoted strings in if statements to be implicitly dereferenced,
even without ${} brackets, which seems absolutely crazy.
There are lots of warnings about this policy being unset on OS X (which uses a recent cmake), since there are if statements with quoted strings in pkgConfig.cmake.in. For example, building `roscpp_serialization` generates [multiple warnings](https://gist.github.com/scpeters/c15a121475efe08271d2) about this policy being unset. I suppose it might break things to set it to NEW, but I don't think many people are using cmake 3.1 yet, so I'm guessing it won't break things for too many people yet.
