### PR TITLE
"Reproduce this error" instructions are not escaped correctly

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -36,6 +36,10 @@ import copy
 import multiprocessing
 import os
 import platform
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 import re
 import stat
 try:
@@ -234,7 +238,7 @@ def run_command(cmd, cwd, quiet=False, colorize=False, add_env=None):
     if proc.returncode:
         if quiet:
             print(out.getvalue())
-        raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
+        raise subprocess.CalledProcessError(proc.returncode, cmd)
     return out.getvalue() if quiet else ''
 
 blue_arrow = '@!@{bf}==>@|@!'
@@ -922,9 +926,14 @@ def build_workspace_isolated(
                 _print_build_error(package, e)
                 # Let users know how to reproduce
                 # First add the cd to the build folder of the package
-                cmd = 'cd ' + os.path.join(buildspace, package.name) + ' && '
+                cmd = 'cd ' + quote(os.path.join(buildspace, package.name)) + ' && '
                 # Then reproduce the command called
-                cmd += ' '.join(e.cmd) if isinstance(e.cmd, list) else e.cmd
+                if isinstance(e.cmd, list):
+                    # Escape individual arguments if possible
+                    cmd += ' '.join([quote(arg) for arg in e.cmd])
+                else:
+                    # Simply append the command if it is already joined
+                    cmd += e.cmd
                 print(fmt("\n@{rf}Reproduce this error by running:"))
                 print(fmt("@{gf}@!==> @|") + cmd + "\n")
                 sys.exit('Command failed, exiting.')


### PR DESCRIPTION
When `catkin_make` encounters an error, it does not print the error message it encountered (doing so would be very hard to read), but instead it instructs the user how to reproduce the error:

```
Reproduce this error by running:
==> cd /Users/jjclark/ros_catkin_ws/build_isolated/asmo && /Users/jjclark/ros_catkin_ws/install_isolated/env.sh cmake /Users/jjclark/ros_catkin_ws/src/asmo_ros -DCATKIN_DEVEL_PREFIX=/Users/jjclark/ros_catkin_ws/devel_isolated/asmo -DCMAKE_INSTALL_PREFIX=/Users/jjclark/ros_catkin_ws/install_isolated -DCMAKE_BUILD_TYPE=Release -G Unix Makefiles
```

However, the printed command is not escaped correctly to support running without modification. In this example, the argument `Unix Makefiles` is not quoted. Any special characters in directory names would also cause problems. So when the user tries to run this command and see the error, they will see a different error instead.

I propose using `pipes.quote()` to escape this command so that it can be copied and pasted to produce the expected result.
