### PR TITLE
only install environment hooks for catkin_make(_isolated) completion in the catkin package

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -195,7 +195,7 @@ set(CATKIN_ENV ${SETUP_DIR}/env_cached.${script_ext} CACHE INTERNAL "catkin envi
 if(CATKIN_BUILD_BINARY_PACKAGE)
   set(catkin_skip_install_env_hooks "SKIP_INSTALL")
 endif()
-if(CMAKE_HOST_UNIX)
+if(CMAKE_HOST_UNIX AND PROJECT_NAME STREQUAL "catkin")
   catkin_add_env_hooks(05.catkin_make SHELLS bash DIRECTORY ${catkin_EXTRAS_DIR}/env-hooks ${catkin_skip_install_env_hooks})
   catkin_add_env_hooks(05.catkin_make_isolated SHELLS bash DIRECTORY ${catkin_EXTRAS_DIR}/env-hooks ${catkin_skip_install_env_hooks})
 endif()


### PR DESCRIPTION
This will address #718.
