### PR TITLE
show skipped test results file only when using --all

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package catkin
 Forthcoming
 -----------
 * remove CATKIN_TEST_RESULTS_DIR environment variable (`#728 <https://github.com/ros/catkin/issues/728>`_)
+* catkin_test_results will output skipped xml files only when --all is being passed (`#733 <https://github.com/ros/catkin/pull/733>`_)
 * extract catkin_add_executable_with_gtest() from catkin_add_gtest() (`#726 <https://github.com/ros/catkin/issues/726>`_)
 * separate download function from tests (`#633 <https://github.com/ros/catkin/issues/633>`_)
 * only install environment hooks for catkin_make(_isolated) completion in the catkin package (`#732 <https://github.com/ros/catkin/issues/732>`_)

--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -14,7 +14,7 @@ from catkin.test_results import aggregate_results, print_summary, test_results
 def main():
     parser = argparse.ArgumentParser(description='Outputs a summary of the test results. If there are any test errors or failures the scripts return code is 1.')
     parser.add_argument('test_results_dir', nargs='?', default=os.curdir, help='The path to the test results')
-    parser.add_argument('--all', action='store_true', default=False, help='Show all test results even the ones without errors/failures')
+    parser.add_argument('--all', action='store_true', default=False, help='Show all test results even the ones without errors/failures as well as skipped xml files')
     parser.add_argument('--verbose', action='store_true', default=False, help='Show all tests which have errors or failed')
     args = parser.parse_args()
 
@@ -24,7 +24,8 @@ def main():
         sys.exit('Test results directory "%s" does not exist' % test_results_dir)
 
     try:
-        results = test_results(test_results_dir, args.verbose)
+        results = test_results(
+            test_results_dir, show_verbose=args.verbose, show_all=args.all)
         _, sum_errors, sum_failures = aggregate_results(results)
         print_summary(results, show_stable=args.all)
         if sum_errors or sum_failures:

--- a/python/catkin/test_results.py
+++ b/python/catkin/test_results.py
@@ -113,7 +113,7 @@ def read_junit(filename):
     return (num_tests, num_errors, num_failures)
 
 
-def test_results(test_results_dir, show_verbose=False):
+def test_results(test_results_dir, show_verbose=False, show_all=False):
     '''
     Collects test results by parsing all xml files in given path,
     attempting to interpret them as junit results.
@@ -132,7 +132,8 @@ def test_results(test_results_dir, show_verbose=False):
             try:
                 num_tests, num_errors, num_failures = read_junit(filename_abs)
             except Exception as e:
-                print('Skipping "%s": %s' % (name, str(e)))
+                if show_all:
+                    print('Skipping "%s": %s' % (name, str(e)))
                 continue
             results[name] = (num_tests, num_errors, num_failures)
             if show_verbose and (num_errors + num_failures > 0):


### PR DESCRIPTION
With #728 being merged the script `catkin_test_results` will not be able to crawl the test results folder by default. Instead it uses the current directory (commonly the workspace root). This usually results in more xml files to be found which are not actually test result files.

Therefore this patch only outputs the skipped result files when the `--all` option is passed to reduce the verbosity of the tool.

@esteve @tfoote @wjwwood Please review.
