### PR TITLE
Fix error with zsh when NOCLOBBER is enabled

### DIFF
--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -56,7 +56,7 @@ if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
   echo "Could not create temporary file: $_SETUP_TMP"
   return 1
 fi
-CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ > "$_SETUP_TMP"
+CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ >> "$_SETUP_TMP"
 _RC=$?
 if [ $_RC -ne 0 ]; then
   if [ $_RC -eq 2 ]; then


### PR DESCRIPTION
The following option is available in zsh:

> NOCLOBBER prevents you from accidentally overwriting an existing file.
> 
> % setopt noclobber
> % cat /dev/null >~/.zshrc
> zsh: file exists: /u/pfalstad/.zshrc

(cf. [zsh documentation](http://zsh.sourceforge.net/Intro/intro_16.html))

This option is not enabled by default, but when it is, sourcing `setup.[z]sh` fails with:

``` sh
.../catkin_ws/devel/setup.sh:52: file exists: /tmp/setup.sh.ixlgRQcPyh
Failed to run '".../catkin_ws/devel/_setup_util.py" ': return code 1
```

This is caused by [this line](https://github.com/ros/catkin/blob/3c91601d769984839c510fb5f448879db3e59eaf/cmake/templates/setup.sh.in#L59).  `>>` could be used instead since the file was just created and is empty. That way, `noclobber` does not need to be disabled, and zsh users with these crazy options are happy.
