### PR TITLE
Updated regex that matches function names 

### DIFF
--- a/doc/generate_cmake_rst.py
+++ b/doc/generate_cmake_rst.py
@@ -82,7 +82,7 @@ def generate_rst(files, skip_private=False, skip_undocumented=False):
                 else:
                     last_block.append(line.rstrip('\n'))
             else:
-                declaration = re.match('[a-zA-Z]+\([a-zA-Z_ ]+\)', line)
+                declaration = re.match('[a-zA-Z]+ *\([a-zA-Z0-9_ ]+\)', line)
                 if declaration is None:
                     last_block = []
                     last_block_public = False


### PR DESCRIPTION
It now supports whitespace between function or macro and the parenthesis and supports numbers in the function names and parameter names.

This is a little closer to the cmake grammar (http://www.cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#grammar-token-argument).  I know this is for version 3 but I couldn't find the grammar for version 2+.

I stopped short of actually implementing the grammar because that isn't what this script is for. I just wanted to expand it simply to find a few more valid cases. It will accept non-valid function names like `function (9functionname)` but I am not relying on this for syntax checking.

This is my first open source pull request so if there is something I need to do differently let me know.

Thanks.

Thaddeus
