### PR TITLE
Remove -x in python distutils shell script

### DIFF
--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -12,12 +12,14 @@ if [ -n "$DESTDIR" ] ; then
     DESTDIR_ARG="--root=$DESTDIR"
 fi
 
-cd "@INSTALL_CMD_WORKING_DIRECTORY@"
+echo_and_run() { echo "+ $@" ; "$@" ; }
+
+echo_and_run cd "@INSTALL_CMD_WORKING_DIRECTORY@"
 
 # Note that PYTHONPATH is pulled from the environment to support installing
 # into one location when some dependencies were installed in another
 # location, #123.
-/usr/bin/env \
+echo_and_run /usr/bin/env \
     PYTHONPATH="@CMAKE_INSTALL_PREFIX@/@PYTHON_INSTALL_DIR@:@CMAKE_BINARY_DIR@/@PYTHON_INSTALL_DIR@:$PYTHONPATH" \
     CATKIN_BINARY_DIR="@CMAKE_BINARY_DIR@" \
     "@PYTHON_EXECUTABLE@" \

--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 if [ -n "$DESTDIR" ] ; then
     case $DESTDIR in


### PR DESCRIPTION
This prevents extraneous output in the installation step. According to the man page:

http://heirloom.sourceforge.net/sh/sh.1.html

> -x    Print commands and their arguments as they are executed.

This is the same as activating `BASH_XTRACEFD` (http://linux.die.net/man/1/sh). This is the type of output it prevents:

```
+ '[' -n '' ']'
+ cd /Users/william/jade/src/catkin
+ /usr/bin/env PYTHONPATH=/Users/william/jade/install/lib/python2.7/site-packages:/Users/william/jade/build/catkin/lib/python2.7/site-packages: CATKIN_BINARY_DIR=/Users/william/jade/build/catkin /usr/bin/python /Users/william/jade/src/catkin/setup.py build --build-base /Users/william/jade/build/catkin install --prefix=/Users/william/jade/install --install-scripts=/Users/william/jade/install/bin
```

The reason I noticed and tracked it down was because this is also output on stderr, which the `catkin_tools` command picked up on and reported as a warning (perhaps incorrectly).
