### PR TITLE
fix project specific clean_test_results targets

### DIFF
--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -79,11 +79,6 @@ if(NOT TARGET clean_test_results)
   add_custom_target(clean_test_results
     COMMAND ${PYTHON_EXECUTABLE} "${catkin_EXTRAS_DIR}/test/remove_test_results.py" "${CATKIN_TEST_RESULTS_DIR}")
 endif()
-# create target to clean project specific test results
-if(NOT TARGET clean_test_results_${PROJECT_NAME})
-  add_custom_target(clean_test_results_${PROJECT_NAME}
-    COMMAND ${PYTHON_EXECUTABLE} "${catkin_EXTRAS_DIR}/test/remove_test_results.py" "${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}")
-endif()
 
 #
 # Create a test target, integrate it with the run_tests infrastructure
@@ -145,5 +140,11 @@ function(catkin_run_tests_target type name xunit_filename)
   add_custom_target(_run_tests_${PROJECT_NAME}_${type}_${name}
     COMMAND ${cmd})
   add_dependencies(_run_tests_${PROJECT_NAME}_${type} _run_tests_${PROJECT_NAME}_${type}_${name})
+
+  # create target to clean project specific test results
+  if(NOT TARGET clean_test_results_${PROJECT_NAME})
+    add_custom_target(clean_test_results_${PROJECT_NAME}
+      COMMAND ${PYTHON_EXECUTABLE} "${catkin_EXTRAS_DIR}/test/remove_test_results.py" "${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}")
+  endif()
   add_dependencies(_run_tests_${PROJECT_NAME}_${type}_${name} clean_test_results_${PROJECT_NAME} tests ${_testing_DEPENDENCIES})
 endfunction()


### PR DESCRIPTION
Related to #738.

This only happend when a workspace is built with a single CMake invocation. In that case the catkin cmake files are being included before the CMake project name  is set.

Fixes #761.
