### PR TITLE
fix reinstalling Python files installed by catkin_install_python after modifying them

### DIFF
--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -26,6 +26,7 @@ function(catkin_install_python signature)
       set(file "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
     endif()
     if(EXISTS ${file})
+      stamp(${file})
       # read file and check shebang line
       file(READ ${file} data)
       set(regex "^#!/([^\r\n]+)/env python([\r\n])")


### PR DESCRIPTION
Addresses #764 by ensuring that CMake is being rerun when the file has changed.
