### PR TITLE
fix default value for _workspaces in find_in_workspaces

### DIFF
--- a/python/catkin/find_in_workspaces.py
+++ b/python/catkin/find_in_workspaces.py
@@ -87,7 +87,7 @@ def _get_valid_search_dirs(search_dirs, project):
 #      except for s == 'share', cand is a list of two paths: ws[0] + s + project (+ path) and ws[1] + project (+ path)
 #      add cand to result list if it exists
 #      is not defined for s in ['bin', 'lib'], bailing out
-def find_in_workspaces(search_dirs=None, project=None, path=None, _workspaces=get_workspaces(), considered_paths=None, first_matching_workspace_only=False, first_match_only=False, workspace_to_source_spaces=None, source_path_to_packages=None):
+def find_in_workspaces(search_dirs=None, project=None, path=None, _workspaces=None, considered_paths=None, first_matching_workspace_only=False, first_match_only=False, workspace_to_source_spaces=None, source_path_to_packages=None):
     '''
     Find all paths which match the search criteria.
     All workspaces are searched in order.
@@ -110,7 +110,8 @@ def find_in_workspaces(search_dirs=None, project=None, path=None, _workspaces=ge
     search_dirs = _get_valid_search_dirs(search_dirs, project)
     if 'libexec' in search_dirs:
         search_dirs.insert(search_dirs.index('libexec'), 'lib')
-
+    if _workspaces is None:
+        _workspaces = get_workspaces()
     if workspace_to_source_spaces is None:
         workspace_to_source_spaces = {}
     if source_path_to_packages is None:

--- a/test/unit_tests/test_find_in_workspace.py
+++ b/test/unit_tests/test_find_in_workspace.py
@@ -33,14 +33,14 @@ class FindInWorkspaceTest(unittest.TestCase):
         self.assertRaises(ValueError, _get_valid_search_dirs, ['libexec'], None)
 
     def test_find_in_workspaces(self):
-        existing = find_in_workspaces([], _workspaces=None)
+        existing = find_in_workspaces([], _workspaces=[])
         self.assertEqual([], existing)
-        existing = find_in_workspaces([], 'foo', _workspaces=None)
+        existing = find_in_workspaces([], 'foo', _workspaces=[])
         self.assertEqual([], existing)
-        existing = find_in_workspaces([], 'foo', 'foopath', _workspaces=None)
+        existing = find_in_workspaces([], 'foo', 'foopath', _workspaces=[])
         self.assertEqual([], existing)
 
-        existing = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=None)
+        existing = find_in_workspaces(['include'], 'foo', 'foopath', _workspaces=[])
         self.assertEqual([], existing)
 
         checked = []


### PR DESCRIPTION
Fixes #767.

While this changes the behavior when being invoked with an explicit `None` value this is hopefully not done anywhere :pray:

A change to not change the default behavior in any case would be to choose a special default value (e.g. `_workspaces="some_default_value_nobody_is_guessing_and_using"`) but it doesn't seem to be worth in this case.
