### PR TITLE
ensure that Python install destination exists

### DIFF
--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -16,6 +16,9 @@ echo_and_run() { echo "+ $@" ; "$@" ; }
 
 echo_and_run cd "@INSTALL_CMD_WORKING_DIRECTORY@"
 
+# snsure that Python install destination exists
+echo_and_run mkdir -p "@CMAKE_INSTALL_PREFIX@/@PYTHON_INSTALL_DIR@"
+
 # Note that PYTHONPATH is pulled from the environment to support installing
 # into one location when some dependencies were installed in another
 # location, #123.


### PR DESCRIPTION
Otherwise `python setup.py install` might fail: e.g. http://build.ros.org/view/Jdoc/job/Jdoc__rospeex__ubuntu_trusty_amd64/6/console
