### PR TITLE
add custom message explaining CMake find_package error messages

### DIFF
--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -72,8 +72,17 @@ if(catkin_FIND_COMPONENTS)
 
       # find package component
       if(catkin_FIND_REQUIRED)
-        find_package(${component} REQUIRED NO_MODULE PATHS ${paths}
+        # try without REQUIRED first
+        find_package(${component} NO_MODULE PATHS ${paths}
           NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+        if(NOT ${component}_FOUND)
+          # show better message to help users with the CMake error message coming up
+          message(STATUS "Could not find the required component '${component}'. "
+            "The following CMake error indicates that you either need to install the package "
+            "with the same name or change your environment so that it can be found.")
+          find_package(${component} REQUIRED NO_MODULE PATHS ${paths}
+            NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+        endif()
       elseif(catkin_FIND_QUIETLY)
         find_package(${component} QUIET NO_MODULE PATHS ${paths}
           NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)


### PR DESCRIPTION
Many user questions are based on the not easy to read and interpret CMake error message in the case that `find_package(... REQUIRED)` can't find a certain CMake config file, e.g.:
- http://answers.ros.org/question/227296/catkin_make-error-when-using-mavros/
- http://answers.ros.org/question/189686/catkin_make-fails-weirdly-after-trying-to-create-a-new-package/
- http://answers.ros.org/question/227151/adding-rplidar_ros-as-package-dependency/
- http://answers.ros.org/question/221359/ros_controlconfigcmake-not-found/
- http://answers.ros.org/question/222041/rosaria-make-error-jade/
- http://answers.ros.org/question/67079/how-to-depend-on-pr2_controllers_msgs/

This patch prints a custom message before that which should provide a more helpful description.
