### PR TITLE
use NO_MODULE to find exported catkin dependencies

### DIFF
--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -162,12 +162,12 @@ foreach(depend ${depends})
   if(${count} EQUAL 1)
     # simple dependencies must only be find_package()-ed once
     if(NOT ${@PROJECT_NAME@_dep}_FOUND)
-      find_package(${@PROJECT_NAME@_dep} REQUIRED)
+      find_package(${@PROJECT_NAME@_dep} REQUIRED NO_MODULE)
     endif()
   else()
     # dependencies with components must be find_package()-ed again
     list(REMOVE_AT depend_list 0)
-    find_package(${@PROJECT_NAME@_dep} REQUIRED ${depend_list})
+    find_package(${@PROJECT_NAME@_dep} REQUIRED NO_MODULE ${depend_list})
   endif()
   _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${${@PROJECT_NAME@_dep}_INCLUDE_DIRS})
 


### PR DESCRIPTION
Addresses #760.

Replaces #772 since the patch will only be applied to Kinetic.
