### PR TITLE
on OS X, enable absolute RPATH for everyone

### DIFF
--- a/cmake/catkinConfig.cmake.in
+++ b/cmake/catkinConfig.cmake.in
@@ -10,6 +10,37 @@
 # :outvar <comp>_INCLUDE_DIRS/_LIBRARY_DIRS/_LIBRARY:
 #    contains the include dirs / library dirs / libraries of the searched component <comp>.
 
+if(APPLE)
+  # Turn absolute RPATH directories on to avoid issues when DYLD_LIBRARY_PATH
+  # is not set. In 10.11 (el capitan) the SIP security feature prevents passing
+  # these DYLD_* environment variables down to sub-shells.
+  macro(_set_cmake_policy_to_new_if_available policy)
+    if(POLICY ${policy})
+      cmake_policy(SET ${policy} NEW)
+    endif()
+  endmacro()
+  _set_cmake_policy_to_new_if_available(CMP0042)
+  set(CMAKE_MACOSX_RPATH TRUE)
+  # use, i.e. don't skip the full RPATH for the build tree
+  SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+  # when building, don't use the install RPATH already
+  # (but later on when installing)
+  SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+  # add the automatically determined parts of the RPATH
+  # which point to directories outside the build tree to the install RPATH
+  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+  # the RPATH to be used when installing, but only if it's not a system directory
+  LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+  IF("${isSystemDir}" STREQUAL "-1")
+     SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  ENDIF("${isSystemDir}" STREQUAL "-1")
+endif()
+
 if(CATKIN_TOPLEVEL_FIND_PACKAGE OR NOT CATKIN_TOPLEVEL)
   set(catkin_EXTRAS_DIR "@PKG_CMAKE_DIR@")
 


### PR DESCRIPTION
See: https://github.com/ros/catkin/pull/498#issuecomment-196984967

I haven't tested this extensively. This is just my first crack at solving this problem with minimal changes to the ROS ecosystem.
