### PR TITLE
fix rollback logic for more than one value per environment variable and workspace

### DIFF
--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -71,42 +71,42 @@ def rollback_env_variables(environ, env_var_subfolders):
         subfolders = env_var_subfolders[key]
         if not isinstance(subfolders, list):
             subfolders = [subfolders]
-        for subfolder in subfolders:
-            value = _rollback_env_variable(unmodified_environ, key, subfolder)
-            if value is not None:
-                environ[key] = value
-                lines.append(assignment(key, value))
+        value = _rollback_env_variable(unmodified_environ, key, subfolders)
+        if value is not None:
+            environ[key] = value
+            lines.append(assignment(key, value))
     if lines:
         lines.insert(0, comment('reset environment variables by unrolling modifications based on all workspaces in CMAKE_PREFIX_PATH'))
     return lines
 
 
-def _rollback_env_variable(environ, name, subfolder):
+def _rollback_env_variable(environ, name, subfolders):
     '''
     For each catkin workspace in CMAKE_PREFIX_PATH remove the first entry from env[NAME] matching workspace + subfolder.
 
-    :param subfolder: str '' or subfoldername that may start with '/'
+    :param subfolders: list of str '' or subfoldername that may start with '/'
     :returns: the updated value of the environment variable.
     '''
     value = environ[name] if name in environ else ''
     env_paths = [path for path in value.split(os.pathsep) if path]
     value_modified = False
-    if subfolder:
-        if subfolder.startswith(os.path.sep) or (os.path.altsep and subfolder.startswith(os.path.altsep)):
-            subfolder = subfolder[1:]
-        if subfolder.endswith(os.path.sep) or (os.path.altsep and subfolder.endswith(os.path.altsep)):
-            subfolder = subfolder[:-1]
-    for ws_path in _get_workspaces(environ, include_fuerte=True, include_non_existing=True):
-        path_to_find = os.path.join(ws_path, subfolder) if subfolder else ws_path
-        path_to_remove = None
-        for env_path in env_paths:
-            env_path_clean = env_path[:-1] if env_path and env_path[-1] in [os.path.sep, os.path.altsep] else env_path
-            if env_path_clean == path_to_find:
-                path_to_remove = env_path
-                break
-        if path_to_remove:
-            env_paths.remove(path_to_remove)
-            value_modified = True
+    for subfolder in subfolders:
+        if subfolder:
+            if subfolder.startswith(os.path.sep) or (os.path.altsep and subfolder.startswith(os.path.altsep)):
+                subfolder = subfolder[1:]
+            if subfolder.endswith(os.path.sep) or (os.path.altsep and subfolder.endswith(os.path.altsep)):
+                subfolder = subfolder[:-1]
+        for ws_path in _get_workspaces(environ, include_fuerte=True, include_non_existing=True):
+            path_to_find = os.path.join(ws_path, subfolder) if subfolder else ws_path
+            path_to_remove = None
+            for env_path in env_paths:
+                env_path_clean = env_path[:-1] if env_path and env_path[-1] in [os.path.sep, os.path.altsep] else env_path
+                if env_path_clean == path_to_find:
+                    path_to_remove = env_path
+                    break
+            if path_to_remove:
+                env_paths.remove(path_to_remove)
+                value_modified = True
     new_value = os.pathsep.join(env_paths)
     return new_value if value_modified else None
 

--- a/test/unit_tests/test_setup_util.py
+++ b/test/unit_tests/test_setup_util.py
@@ -101,20 +101,20 @@ class SetupUtilTest(unittest.TestCase):
             mock_env = {varname: os.pathsep.join([foolib, barlib]),
                         'CMAKE_PREFIX_PATH': barws}
             # since workspace foo is not in CMAKE_PREFIX_PATH, it remains in varname
-            self.assertEqual(foolib, _rollback_env_variable(mock_env, varname, '/lib'))
+            self.assertEqual(foolib, _rollback_env_variable(mock_env, varname, ['/lib']))
 
             # mock_env with both ws in CPP
             mock_env = {varname: os.pathsep.join([foolib, barlib]),
                         wsvarname: os.pathsep.join([foows, barws]),
                         'CMAKE_PREFIX_PATH': os.pathsep.join([foows, barws])}
 
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ''))
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, 'nolib'))
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, '/nolib'))
-            self.assertEqual('', _rollback_env_variable(mock_env, varname, 'lib'))
-            self.assertEqual('', _rollback_env_variable(mock_env, varname, '/lib'))
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ''))
-            self.assertEqual('', _rollback_env_variable(mock_env, wsvarname, ''))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['']))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['nolib']))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['/nolib']))
+            self.assertEqual('', _rollback_env_variable(mock_env, varname, ['lib']))
+            self.assertEqual('', _rollback_env_variable(mock_env, varname, ['/lib']))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['']))
+            self.assertEqual('', _rollback_env_variable(mock_env, wsvarname, ['']))
 
             # nows: not a workspace
             nows = os.path.join(rootdir, 'nows')
@@ -125,12 +125,12 @@ class SetupUtilTest(unittest.TestCase):
             mock_env = {'varname': os.pathsep.join([foolib, nowslib, barlib, foolib]),
                         'CMAKE_PREFIX_PATH': os.pathsep.join([foows, barws])}
             # checks nows/lib remains, and second mention of foolib
-            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', '/lib'))
-            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', 'lib'))
+            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', ['/lib']))
+            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', ['lib']))
 
             # windows pathsep
             os.path.altsep = '\\'
-            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', '\\lib'))
+            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', ['\\lib']))
         finally:
             os.path.altsep = altsep
             shutil.rmtree(rootdir)


### PR DESCRIPTION
Fixes #809.

The `_rollback_env_variable` function operates on `unmodified_environ` (which it has to since otherwise the `CMAKE_PREFIX_PATH` has been rolled back already when trying to rollback other environment variables). It rolls back the first library path and generates a line for that. But when it encounters the second library path when trying to rollback it does so from the unmodified environment. So the first library path reappears.

This patch moves the loop of the subfolders into the function which makes it operate on the same environment and only generate a single line which removes both library paths.
