### PR TITLE
maintain file context when invoking Python scripts through relay

### DIFF
--- a/cmake/templates/relay.py.in
+++ b/cmake/templates/relay.py.in
@@ -1,5 +1,14 @@
 # -*- coding: utf-8 -*-
+# generated from catkin/cmake/template/relay.py.in
 # creates a relay to a python script source file, acting as that file.
 # The purpose is that of a symlink
-with open("@PYTHON_SCRIPT@", 'r') as fh:
-    exec(fh.read())
+python_script = '@PYTHON_SCRIPT@'
+with open(python_script, 'r') as fh:
+    context = {
+        '__builtins__': __builtins__,
+        '__doc__': None,
+        '__file__': python_script,
+        '__name__': __name__,
+        '__package__': None,
+    }
+    exec(compile(fh.read(), python_script, 'exec'), context)

--- a/cmake/templates/script.py.in
+++ b/cmake/templates/script.py.in
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# generated from catkin/cmake/template/script.py.in
 # creates a relay to a python script source file, acting as that file.
 # The purpose is that of a symlink
-with open("@PYTHON_SCRIPT@", 'r') as fh:
-    exec(fh.read())
+python_script = '@PYTHON_SCRIPT@'
+with open(python_script, 'r') as fh:
+    context = {
+        '__builtins__': __builtins__,
+        '__doc__': None,
+        '__file__': python_script,
+        '__name__': __name__,
+        '__package__': None,
+    }
+    exec(compile(fh.read(), python_script, 'exec'), context)


### PR DESCRIPTION
Without the patch the stacktrace only show `<string>` for the file the relay scripts are redirecting to.

With this patch the stacktrace contains the correct file path of the Python script.
