### PR TITLE
parse_package_xml.py: Always write output file as UTF-8 for python3.

### DIFF
--- a/cmake/parse_package_xml.py
+++ b/cmake/parse_package_xml.py
@@ -98,8 +98,14 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
     package = parse_package(args.package_xml)
 
+    # Force utf8 encoding for python3.
+    # This way unicode files can still be processed on non-unicode locales.
+    kwargs = {}
+    if sys.version_info.major >= 3:
+        kwargs['encoding'] = 'utf8'
+
     lines = _get_output(package)
-    with open(args.outfile, 'w') as ofile:
+    with open(args.outfile, 'w', **kwargs) as ofile:
         ofile.write('\n'.join(lines))
 
 


### PR DESCRIPTION
In python3, reading or writing text files by use a default encoding depending on your locale. That means that handling of `package.xml` file containing UTF-8 without a UTF-8 locale doesn't work. See below for an example error.

This PR makes sure UTF-8 is used as encoding with python3 regardless of your locale. Note that this is a essentially the same issue as fixed in ros-infrastructure/catkin_pkg#143.

```
Traceback (most recent call last):
  File "/opt/ros/kinetic/share/catkin/cmake/parse_package_xml.py", line 107, in <module>
    main()
  File "/opt/ros/kinetic/share/catkin/cmake/parse_package_xml.py", line 103, in main
    ofile.write('\n'.join(lines))
UnicodeEncodeError: 'ascii' codec can't encode character '\u0160' in position 107: ordinal not in range(128)
```
