### PR TITLE
updated PYTHON_INSTALL_DIR generation

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -10,32 +10,26 @@ message(STATUS "Using PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
 
 set(_PYTHON_PATH_VERSION_SUFFIX "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 
-set(enable_setuptools_deb_layout OFF)
-if(EXISTS "/etc/debian_version")
-  set(enable_setuptools_deb_layout ON)
-endif()
-option(SETUPTOOLS_DEB_LAYOUT "Enable debian style python package layout" ${enable_setuptools_deb_layout})
-
-if(SETUPTOOLS_DEB_LAYOUT)
-  message(STATUS "Using Debian Python package layout")
-  set(PYTHON_PACKAGES_DIR dist-packages)
-  set(SETUPTOOLS_ARG_EXTRA "--install-layout=deb")
-  # use major version only when installing 3.x with debian layout
-  if("${PYTHON_VERSION_MAJOR}" STREQUAL "3")
-    set(_PYTHON_PATH_VERSION_SUFFIX "${PYTHON_VERSION_MAJOR}")
-  endif()
-else()
-  message(STATUS "Using default Python package layout")
-  set(PYTHON_PACKAGES_DIR site-packages)
-  # setuptools is fussy about windows paths, make sure the install prefix is in native format
+# setuptools is fussy about windows paths, make sure the install prefix is in native format
+if(WIN32)
   file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}" SETUPTOOLS_INSTALL_PREFIX)
 endif()
 
-if(NOT WIN32)
-  set(PYTHON_INSTALL_DIR lib/python${_PYTHON_PATH_VERSION_SUFFIX}/${PYTHON_PACKAGES_DIR}
-    CACHE INTERNAL "This needs to be in PYTHONPATH when 'setup.py install' is called.  And it needs to match.  But setuptools won't tell us where it will install things.")
-else()
-  # Windows setuptools installs to lib/site-packages not lib/python2.7/site-packages
-  set(PYTHON_INSTALL_DIR lib/${PYTHON_PACKAGES_DIR}
-    CACHE INTERNAL "This needs to be in PYTHONPATH when 'setup.py install' is called.  And it needs to match.  But setuptools won't tell us where it will install things.")
+# this block determines the same value as the Python function get_python_install_dir() from python/catkin/builder.py
+if(NOT DEFINED PYTHON_INSTALL_DIR)
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+    "-c" "from distutils.sysconfig import get_python_lib; import os; print(os.sep.join(get_python_lib().split(os.sep)[-2 if os.name == 'nt' else -3:]))"
+    RESULT_VARIABLE _res
+    OUTPUT_VARIABLE _var
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT _res EQUAL 0)
+    message(FATAL_ERROR "Failed to determine the PYTHON_INSTALL_DIR")
+  endif()
+  set(PYTHON_INSTALL_DIR "${_var}"
+  CACHE INTERNAL "This needs to be in PYTHONPATH when 'setup.py install' is called otherwise setuptools will fail.")
+endif()
+message(STATUS "Using PYTHON_INSTALL_DIR: " ${PYTHON_INSTALL_DIR})
+
+if(PYTHON_INSTALL_DIR MATCHES "[/\\]dist-packages$")
+  set(SETUPTOOLS_ARG_EXTRA "--install-layout=deb")
 endif()

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -33,6 +33,7 @@
 from __future__ import print_function
 
 import copy
+from distutils.sysconfig import get_python_lib
 import multiprocessing
 import os
 import platform
@@ -287,17 +288,8 @@ def get_multiarch():
 
 def get_python_install_dir():
     # this function returns the same value as the CMake variable PYTHON_INSTALL_DIR from catkin/cmake/python.cmake
-    python_install_dir = 'lib'
-    python_use_debian_layout = os.path.exists('/etc/debian_version')
-    if os.name != 'nt':
-        python_version_xdoty = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
-        if python_use_debian_layout and sys.version_info[0] == 3:
-            python_version_xdoty = str(sys.version_info[0])
-        python_install_dir = os.path.join(python_install_dir, 'python' + python_version_xdoty)
-
-    python_packages_dir = 'dist-packages' if python_use_debian_layout else 'site-packages'
-    python_install_dir = os.path.join(python_install_dir, python_packages_dir)
-    return python_install_dir
+    relevant_subfolders = 2 if os.name == 'nt' else 3
+    return os.sep.join(get_python_lib().split(os.sep)[-relevant_subfolders:])
 
 
 def handle_make_arguments(input_make_args):


### PR DESCRIPTION
Replaces #636.

@ros/ros_team Since this significantly affects the core I would like to have some feedback. Not only but especially on the following thought:
- It is a significant change. But it has been a long standing issue blocking some platforms. I would target Kinetic only for this patch.
- Invoking Python will be an overhead which we avoided before. I just don't see a better way to make this work consistently across Linux, OS X, Windows, Gentoo / Arch.....
- I tried to maintain the semantic of other variables like `SETUPTOOLS_ARG_EXTRA`.
