### PR TITLE
Fixes #839: Adding disabled tests to catkin_test_results summary.

### DIFF
--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -26,8 +26,9 @@ def main():
     try:
         results = test_results(
             test_results_dir, show_verbose=args.verbose, show_all=args.all)
-        _, sum_errors, sum_failures = aggregate_results(results)
+        _, sum_errors, sum_failures, _ = aggregate_results(results)
         print_summary(results, show_stable=args.all)
+        # Skipped tests alone should not count as a failure
         if sum_errors or sum_failures:
             sys.exit(1)
     except Exception as e:

--- a/test/unit_tests/test_test_results.py
+++ b/test/unit_tests/test_test_results.py
@@ -26,9 +26,21 @@ class TestResultsTest(unittest.TestCase):
 
             result_file = os.path.join(rootdir, 'test1.xml')
             with open(result_file, 'w') as fhand:
-                fhand.write('<testsuites tests="5" failures="3" errors="1" time="35" name="AllTests"></testsuites>')
-            (num_tests, num_errors, num_failures) = catkin_test_results.read_junit(result_file)
-            self.assertEqual((5, 1, 3), (num_tests, num_errors, num_failures))
+                fhand.write('<testsuites tests="5" failures="3" errors="1" disabled="1" time="35" name="AllTests"></testsuites>')
+            (num_tests, num_errors, num_failures, num_skipped) = catkin_test_results.read_junit(result_file)
+            self.assertEqual((5, 1, 3, 1), (num_tests, num_errors, num_failures, num_skipped))
+        finally:
+            shutil.rmtree(rootdir)
+
+    def test_read_junit_skip(self):
+        try:
+            rootdir = tempfile.mkdtemp()
+
+            result_file = os.path.join(rootdir, 'test1.xml')
+            with open(result_file, 'w') as fhand:
+                fhand.write('<testsuites tests="5" failures="3" errors="1" skip="1" time="35" name="AllTests"></testsuites>')
+            (num_tests, num_errors, num_failures, num_skipped) = catkin_test_results.read_junit(result_file)
+            self.assertEqual((5, 1, 3, 1), (num_tests, num_errors, num_failures, num_skipped))
         finally:
             shutil.rmtree(rootdir)
 
@@ -39,9 +51,9 @@ class TestResultsTest(unittest.TestCase):
             for filename in ['test1.xml', 'test2.xml', 'foo.bar']:
                 result_file = os.path.join(rootdir, filename)
                 with open(result_file, 'w') as fhand:
-                    fhand.write('<testsuites tests="5" failures="3" errors="1" time="35" name="AllTests"></testsuites>')
+                    fhand.write('<testsuites tests="5" failures="3" errors="1" disabled="1" time="35" name="AllTests"></testsuites>')
             results = catkin_test_results.test_results(rootdir)
-            self.assertEqual({'test1.xml': (5, 1, 3), 'test2.xml': (5, 1, 3)}, results)
+            self.assertEqual({'test1.xml': (5, 1, 3, 1), 'test2.xml': (5, 1, 3, 1)}, results)
         finally:
             shutil.rmtree(rootdir)
 
@@ -56,7 +68,7 @@ class TestResultsTest(unittest.TestCase):
             with open(result_file, 'w') as fhand:
                 fhand.write(test_suites)
             results = catkin_test_results.test_results(rootdir, show_verbose=True)
-            self.assertEqual({test_xml: (5, 1, 3)}, results)
+            self.assertEqual({test_xml: (5, 1, 3, 0)}, results)
             summary = sys.stdout.getvalue()
             self.assertTrue(test_xml in summary, summary)
             self.assertTrue(test_suites in summary, summary)
@@ -75,7 +87,7 @@ class TestResultsTest(unittest.TestCase):
             with open(result_file, 'w') as fhand:
                 fhand.write(test_suites)
             results = catkin_test_results.test_results(rootdir, show_verbose=True)
-            self.assertEqual({test_xml: (5, 1, 3)}, results)
+            self.assertEqual({test_xml: (5, 1, 3, 0)}, results)
             summary = sys.stdout.getvalue()
             self.assertTrue(test_xml in summary, summary)
             self.assertTrue(test_suites in summary, summary)
@@ -85,15 +97,15 @@ class TestResultsTest(unittest.TestCase):
             print(summary)
 
     def test_print_summary(self):
-        results = {'test1.xml': (5, 1, 3), 'test2.xml': (7, 2, 4)}
+        results = {'test1.xml': (5, 1, 3, 1), 'test2.xml': (7, 2, 4, 1)}
         try:
             oldstdout = sys.stdout
             sys.stdout = StringIO()
             catkin_test_results.print_summary(results)
             summary = sys.stdout.getvalue()
-            self.assertTrue('5 tests, 1 errors, 3 failures' in summary, summary)
-            self.assertTrue('7 tests, 2 errors, 4 failures' in summary, summary)
-            self.assertTrue('12 tests, 3 errors, 7 failures' in summary, summary)
+            self.assertTrue('5 tests, 1 errors, 3 failures, 1 skipped' in summary, summary)
+            self.assertTrue('7 tests, 2 errors, 4 failures, 1 skipped' in summary, summary)
+            self.assertTrue('12 tests, 3 errors, 7 failures, 2 skipped' in summary, summary)
 
         finally:
             sys.stdout = oldstdout


### PR DESCRIPTION
I set it to read from both `disabled` (gtest) and `skip`attributes. I myself haven't seen `skip` but it appeared in the ament commit: https://github.com/ament/ament_tools/commit/0c6003b58ff0e5442034c7e643dab9035cdaeff8.