### PR TITLE
skip gtest install rules for newer gtest versions

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -117,7 +117,19 @@ if(NOT GTEST_FOUND)
       get_filename_component(_CATKIN_GTEST_BASE_DIR ${_CATKIN_GTEST_SOURCE_DIR} PATH)
       # add CMakeLists.txt from gtest dir
       set(_CATKIN_GTEST_BINARY_DIR ${CMAKE_BINARY_DIR}/gtest)
+
+      # overwrite CMake install command to skip install rules for gtest targets
+      # which have been added in version 1.8.0
+      set(_CATKIN_SKIP_INSTALL_RULES TRUE)
+      function(install)
+        if(_CATKIN_SKIP_INSTALL_RULES)
+          return()
+        endif()
+        _install(${ARGN})
+      endfunction()
       add_subdirectory(${_CATKIN_GTEST_BASE_DIR} ${_CATKIN_GTEST_BINARY_DIR})
+      set(_CATKIN_SKIP_INSTALL_RULES FALSE)
+
       # mark gtest targets with EXCLUDE_FROM_ALL to only build when tests are built which depend on them
       set_target_properties(gtest gtest_main PROPERTIES EXCLUDE_FROM_ALL 1)
       get_filename_component(_CATKIN_GTEST_INCLUDE_DIR ${_CATKIN_GTEST_INCLUDE} PATH)


### PR DESCRIPTION
As of version 1.8.0 the `CMakeLists.txt` file of `googletest` contains install rules. But `catkin` marks the targets with `EXCLUDE_FROM_ALL` which later fails when CMake is trying to install the libraries which haven't been build. The [CMake doc](https://cmake.org/cmake/help/v3.0/prop_tgt/EXCLUDE_FROM_ALL.html) explicitly says:

> Installing a target with EXCLUDE_FROM_ALL set to true has undefined behavior.

While it might be more appropriate to switch to `ExternalProject` that will likely break user code. Therefore this patch takes the "ugly" way of overriding the `install` function to skip the rule for the gtest targets.

In a future ROS distro (e.g. M-turtle) when all targeted platforms use the newer googletest version this should probably be updated to use the new `googletest` version which also comes bundled with `googlemock` via `ExternalProject`.

The change shouldn't harm Kinetic but would make it possible to build ROS Kinetic on systems which use the new googletest version. So I don't think it should go to a lunar-specific branch.

@ros/ros_team Please review.