### PR TITLE
changes between 0.6.18 and 0.7.6 for backporting

### DIFF
--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -53,7 +53,7 @@ def parse_args(args=None):
         help='Disables colored output (only for catkin_make and CMake)')
     pkg = parser.add_mutually_exclusive_group(required=False)
     pkg.add_argument('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
-                     help="Invoke 'make' on specific packages "
+                     help="Process only specific packages "
                           "(only after catkin_make_isolated has been invoked before with the same install flag)")
     pkg.add_argument('--from-pkg', metavar='PKGNAME', dest='from_package',
                      help='Restart catkin_make_isolated at the given package continuing from there '

--- a/bin/catkin_test_results
+++ b/bin/catkin_test_results
@@ -8,7 +8,7 @@ import sys
 # find the import relatively if available to work before installing catkin or overlaying installed version
 if os.path.exists(os.path.join(os.path.dirname(__file__), '..', 'python', 'catkin', '__init__.py')):
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
-from catkin.test_results import aggregate_results, print_summary, test_results
+from catkin.test_results import aggregate_results, print_summary2, test_results2
 
 
 def main():
@@ -24,10 +24,11 @@ def main():
         sys.exit('Test results directory "%s" does not exist' % test_results_dir)
 
     try:
-        results = test_results(
+        results = test_results2(
             test_results_dir, show_verbose=args.verbose, show_all=args.all)
         _, sum_errors, sum_failures = aggregate_results(results)
-        print_summary(results, show_stable=args.all)
+        print_summary2(results, show_stable=args.all)
+        # Skipped tests alone should not count as a failure
         if sum_errors or sum_failures:
             sys.exit(1)
     except Exception as e:

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -72,42 +72,42 @@ def rollback_env_variables(environ, env_var_subfolders):
         subfolders = env_var_subfolders[key]
         if not isinstance(subfolders, list):
             subfolders = [subfolders]
-        for subfolder in subfolders:
-            value = _rollback_env_variable(unmodified_environ, key, subfolder)
-            if value is not None:
-                environ[key] = value
-                lines.append(assignment(key, value))
+        value = _rollback_env_variable(unmodified_environ, key, subfolders)
+        if value is not None:
+            environ[key] = value
+            lines.append(assignment(key, value))
     if lines:
         lines.insert(0, comment('reset environment variables by unrolling modifications based on all workspaces in CMAKE_PREFIX_PATH'))
     return lines
 
 
-def _rollback_env_variable(environ, name, subfolder):
+def _rollback_env_variable(environ, name, subfolders):
     '''
     For each catkin workspace in CMAKE_PREFIX_PATH remove the first entry from env[NAME] matching workspace + subfolder.
 
-    :param subfolder: str '' or subfoldername that may start with '/'
+    :param subfolders: list of str '' or subfoldername that may start with '/'
     :returns: the updated value of the environment variable.
     '''
     value = environ[name] if name in environ else ''
     env_paths = [path for path in value.split(os.pathsep) if path]
     value_modified = False
-    if subfolder:
-        if subfolder.startswith(os.path.sep) or (os.path.altsep and subfolder.startswith(os.path.altsep)):
-            subfolder = subfolder[1:]
-        if subfolder.endswith(os.path.sep) or (os.path.altsep and subfolder.endswith(os.path.altsep)):
-            subfolder = subfolder[:-1]
-    for ws_path in _get_workspaces(environ, include_fuerte=True, include_non_existing=True):
-        path_to_find = os.path.join(ws_path, subfolder) if subfolder else ws_path
-        path_to_remove = None
-        for env_path in env_paths:
-            env_path_clean = env_path[:-1] if env_path and env_path[-1] in [os.path.sep, os.path.altsep] else env_path
-            if env_path_clean == path_to_find:
-                path_to_remove = env_path
-                break
-        if path_to_remove:
-            env_paths.remove(path_to_remove)
-            value_modified = True
+    for subfolder in subfolders:
+        if subfolder:
+            if subfolder.startswith(os.path.sep) or (os.path.altsep and subfolder.startswith(os.path.altsep)):
+                subfolder = subfolder[1:]
+            if subfolder.endswith(os.path.sep) or (os.path.altsep and subfolder.endswith(os.path.altsep)):
+                subfolder = subfolder[:-1]
+        for ws_path in _get_workspaces(environ, include_fuerte=True, include_non_existing=True):
+            path_to_find = os.path.join(ws_path, subfolder) if subfolder else ws_path
+            path_to_remove = None
+            for env_path in env_paths:
+                env_path_clean = env_path[:-1] if env_path and env_path[-1] in [os.path.sep, os.path.altsep] else env_path
+                if env_path_clean == path_to_find:
+                    path_to_remove = env_path
+                    break
+            if path_to_remove:
+                env_paths.remove(path_to_remove)
+                value_modified = True
     new_value = os.pathsep.join(env_paths)
     return new_value if value_modified else None
 

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -6,7 +6,7 @@ REM It tries it's best to undo changes from a previously sourced setup file befo
 REM Supported command line options:
 REM --extend: skips the undoing of changes from a previously sourced setup file
 
-set _SETUP_UTIL="@SETUP_DIR@/_setup_util.py"
+set _SETUP_UTIL=@SETUP_DIR@/_setup_util.py
 
 if NOT EXIST "%_SETUP_UTIL%" (
   echo "Missing Python script: %_SETUP_UTIL%"
@@ -33,7 +33,7 @@ if NOT EXIST %_SETUP_TMP% (
 )
 
 REM invoke Python script to generate necessary exports of environment variables
-%_PYTHON% %_SETUP_UTIL% %* > %_SETUP_TMP%
+%_PYTHON% "%_SETUP_UTIL%" %* > %_SETUP_TMP%
 if NOT EXIST %_SETUP_TMP% (
   echo "Could not create temporary file: %_SETUP_TMP%"
   return 1

--- a/doc/dev_guide/generated_cmake_api.rst
+++ b/doc/dev_guide/generated_cmake_api.rst
@@ -160,7 +160,7 @@ Public CMake functions / macros
  .. note:: The test can be executed by calling ``nosetests``
    directly or using:
    `` make run_tests_${PROJECT_NAME}_nosetests_${dir}``
-   (where slashes in the ``dir`` are replaced with underscores)
+   (where slashes in the ``dir`` are replaced with periods)
 
  :param path: a relative or absolute directory to search for
    nosetests in or a relative or absolute file containing tests
@@ -374,8 +374,10 @@ Public CMake functions / macros
  :param CFG_EXTRAS: a CMake file containing extra stuff that should
    be accessible to users of this package after
    ``find_package``\ -ing it.  This file must live in the
-   subdirectory ``cmake`` or be an absolute path.  Various additional
-   file extension are possible:
+   subdirectory ``cmake`` or be an absolute path.
+   All passed extra files must have unique basenames since they are
+   being installed into a single folder.
+   Various additional file extension are possible:
    for a plain cmake file just ``.cmake``, for files expanded using
    CMake's ``configure_file()`` use ``.cmake.in`` or for files expanded
    by empy use ``.cmake.em``.  The templates can distinguish between

--- a/doc/howto/format1/installing_cmake.rst
+++ b/doc/howto/format1/installing_cmake.rst
@@ -10,6 +10,9 @@ want to export::
 
   catkin_package(CFG_EXTRAS your_macros.cmake your_modules.cmake)
 
+When another package uses ``find_package()`` on this package, the listed
+CMake files are automatically included.
+
 Since these data are platform-independent, they should be installed in
 your package's **share/** subtree.  This example assumes your CMake
 sources are in the customary **cmake/** subdirectory::

--- a/doc/howto/format1/python_nose_configuration.rst
+++ b/doc/howto/format1/python_nose_configuration.rst
@@ -26,6 +26,20 @@ You can also let nosetest find all tests recursively::
     catkin_add_nosetests(tests)
   endif()
 
+If you used a message of the current package in the nosetest, make sure to
+specify the nosetest like this::
+
+  catkin_add_nosetests(tests/test_your_node.py
+                       DEPENDENCIES ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
+If you used messages from other packages, use::
+
+  catkin_add_nosetests(tests/test_your_node.py
+                       DEPENDENCIES ${catkin_EXPORTED_TARGETS})
+
+The test will then make sure that the messages used in the test are built
+before they are used.
+
 For more info, please have a look at the :ref:`API <catkin_add_nosetests_ref>`.
 
 .. _Nosetest: http://www.ros.org/wiki/nosetest

--- a/doc/howto/format2/installing_cmake.rst
+++ b/doc/howto/format2/installing_cmake.rst
@@ -10,6 +10,9 @@ want to export::
 
   catkin_package(CFG_EXTRAS your_macros.cmake your_modules.cmake)
 
+When another package uses ``find_package()`` on this package, the listed
+CMake files are automatically included.
+
 Since these data are platform-independent, they should be installed in
 your package's **share/** subtree.  This example assumes your CMake
 sources are in the customary **cmake/** subdirectory::

--- a/doc/howto/format2/python_nose_configuration.rst
+++ b/doc/howto/format2/python_nose_configuration.rst
@@ -26,6 +26,20 @@ You can also let nosetest find all tests recursively::
     catkin_add_nosetests(tests)
   endif()
 
+If you used a message of the current package in the nosetest, make sure to
+specify the nosetest like this::
+
+  catkin_add_nosetests(tests/test_your_node.py
+                       DEPENDENCIES ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
+If you used messages from other packages, use::
+
+  catkin_add_nosetests(tests/test_your_node.py
+                       DEPENDENCIES ${catkin_EXPORTED_TARGETS})
+
+The test will then make sure that the messages used in the test are built
+before they are used.
+
 For more info, please have a look at the :ref:`API <catkin_add_nosetests_ref>`.
 
 .. _Nosetest: http://www.ros.org/wiki/nosetest

--- a/doc/user_guide/setup_dot_py.rst
+++ b/doc/user_guide/setup_dot_py.rst
@@ -67,6 +67,30 @@ sourcespace using the python exec() function.
 The version will be compared to that declared in package.xml, and
 raise an error on mismatch.
 
+.. note::
+
+  If you have written non-ROS Python packages before, you have 
+  probably used the ``requires`` field in the distuils setup function.
+  This field, however, *has no meaning* in ROS. 
+  
+  All your Python
+  dependencies should be specified in ``package.xml`` as e.g.
+  ``<run_depend>python-numpy</run_depend>`` (for older version 1
+  of package.xml) or ``<exec_depend>python-numpy</exec_depend>``
+  (if you use format 2 of package.xml).
+  
+  Not all Python or pip packages are mapped to ROS dependencies.
+  For a quick check, try running ``rosdep resolve python-mypackage``
+  or ``rosdep resolve python-mypackage-pip`` if you want to 
+  add a dependency on ``mypackage`` Python package. If these calls
+  return error, you may want to search through the 
+  `python.yaml file in rosdep`_ for similar names. If you don't 
+  find the requested package, you may consider 
+  `creating a Pull request to add it`_.
+  
+  .. _python.yaml file in rosdep: https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml
+  .. _creating a Pull request to add it: http://docs.ros.org/independent/api/rosdep/html/contributing_rules.html
+
 Using package.xml in setup.py
 =============================
 
@@ -99,6 +123,12 @@ one distributes to pypi.
 
     catkin_install_python(PROGRAMS scripts/myscript
       DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+.. note::
+
+  See the note in previous section about the otherwise useful
+  field ``requires`` that's usually a part of distutils setup.
+  *Do not use it* in ROS.
 
 
 Develspace limitations

--- a/test/unit_tests/test_setup_util.py
+++ b/test/unit_tests/test_setup_util.py
@@ -101,20 +101,20 @@ class SetupUtilTest(unittest.TestCase):
             mock_env = {varname: os.pathsep.join([foolib, barlib]),
                         'CMAKE_PREFIX_PATH': barws}
             # since workspace foo is not in CMAKE_PREFIX_PATH, it remains in varname
-            self.assertEqual(foolib, _rollback_env_variable(mock_env, varname, '/lib'))
+            self.assertEqual(foolib, _rollback_env_variable(mock_env, varname, ['/lib']))
 
             # mock_env with both ws in CPP
             mock_env = {varname: os.pathsep.join([foolib, barlib]),
                         wsvarname: os.pathsep.join([foows, barws]),
                         'CMAKE_PREFIX_PATH': os.pathsep.join([foows, barws])}
 
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ''))
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, 'nolib'))
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, '/nolib'))
-            self.assertEqual('', _rollback_env_variable(mock_env, varname, 'lib'))
-            self.assertEqual('', _rollback_env_variable(mock_env, varname, '/lib'))
-            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ''))
-            self.assertEqual('', _rollback_env_variable(mock_env, wsvarname, ''))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['']))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['nolib']))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['/nolib']))
+            self.assertEqual('', _rollback_env_variable(mock_env, varname, ['lib']))
+            self.assertEqual('', _rollback_env_variable(mock_env, varname, ['/lib']))
+            self.assertEqual(None, _rollback_env_variable(mock_env, varname, ['']))
+            self.assertEqual('', _rollback_env_variable(mock_env, wsvarname, ['']))
 
             # nows: not a workspace
             nows = os.path.join(rootdir, 'nows')
@@ -125,12 +125,12 @@ class SetupUtilTest(unittest.TestCase):
             mock_env = {'varname': os.pathsep.join([foolib, nowslib, barlib, foolib]),
                         'CMAKE_PREFIX_PATH': os.pathsep.join([foows, barws])}
             # checks nows/lib remains, and second mention of foolib
-            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', '/lib'))
-            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', 'lib'))
+            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', ['/lib']))
+            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', ['lib']))
 
             # windows pathsep
             os.path.altsep = '\\'
-            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', '\\lib'))
+            self.assertEqual(os.pathsep.join([nowslib, foolib]), _rollback_env_variable(mock_env, 'varname', ['\\lib']))
         finally:
             os.path.altsep = altsep
             shutil.rmtree(rootdir)

--- a/test/unit_tests/test_test_results.py
+++ b/test/unit_tests/test_test_results.py
@@ -26,9 +26,25 @@ class TestResultsTest(unittest.TestCase):
 
             result_file = os.path.join(rootdir, 'test1.xml')
             with open(result_file, 'w') as fhand:
-                fhand.write('<testsuites tests="5" failures="3" errors="1" time="35" name="AllTests"></testsuites>')
+                fhand.write('<testsuites tests="5" failures="3" errors="1" disabled="2" time="35" name="AllTests"></testsuites>')
             (num_tests, num_errors, num_failures) = catkin_test_results.read_junit(result_file)
             self.assertEqual((5, 1, 3), (num_tests, num_errors, num_failures))
+            (num_tests, num_errors, num_failures, num_skipped) = catkin_test_results.read_junit2(result_file)
+            self.assertEqual((5, 1, 3, 2), (num_tests, num_errors, num_failures, num_skipped))
+        finally:
+            shutil.rmtree(rootdir)
+
+    def test_read_junit_skip(self):
+        try:
+            rootdir = tempfile.mkdtemp()
+
+            result_file = os.path.join(rootdir, 'test1.xml')
+            with open(result_file, 'w') as fhand:
+                fhand.write('<testsuites tests="5" failures="3" errors="1" skip="2" time="35" name="AllTests"></testsuites>')
+            (num_tests, num_errors, num_failures) = catkin_test_results.read_junit(result_file)
+            self.assertEqual((5, 1, 3), (num_tests, num_errors, num_failures))
+            (num_tests, num_errors, num_failures, num_skipped) = catkin_test_results.read_junit2(result_file)
+            self.assertEqual((5, 1, 3, 2), (num_tests, num_errors, num_failures, num_skipped))
         finally:
             shutil.rmtree(rootdir)
 
@@ -39,9 +55,11 @@ class TestResultsTest(unittest.TestCase):
             for filename in ['test1.xml', 'test2.xml', 'foo.bar']:
                 result_file = os.path.join(rootdir, filename)
                 with open(result_file, 'w') as fhand:
-                    fhand.write('<testsuites tests="5" failures="3" errors="1" time="35" name="AllTests"></testsuites>')
+                    fhand.write('<testsuites tests="5" failures="3" errors="1" disabled="2" time="35" name="AllTests"></testsuites>')
             results = catkin_test_results.test_results(rootdir)
             self.assertEqual({'test1.xml': (5, 1, 3), 'test2.xml': (5, 1, 3)}, results)
+            results = catkin_test_results.test_results2(rootdir)
+            self.assertEqual({'test1.xml': (5, 1, 3, 2), 'test2.xml': (5, 1, 3, 2)}, results)
         finally:
             shutil.rmtree(rootdir)
 
@@ -85,7 +103,7 @@ class TestResultsTest(unittest.TestCase):
             print(summary)
 
     def test_print_summary(self):
-        results = {'test1.xml': (5, 1, 3), 'test2.xml': (7, 2, 4)}
+        results = {'test1.xml': (5, 1, 3, 2), 'test2.xml': (7, 2, 4, 1)}
         try:
             oldstdout = sys.stdout
             sys.stdout = StringIO()
@@ -94,6 +112,13 @@ class TestResultsTest(unittest.TestCase):
             self.assertTrue('5 tests, 1 errors, 3 failures' in summary, summary)
             self.assertTrue('7 tests, 2 errors, 4 failures' in summary, summary)
             self.assertTrue('12 tests, 3 errors, 7 failures' in summary, summary)
+
+            sys.stdout = StringIO()
+            catkin_test_results.print_summary2(results)
+            summary = sys.stdout.getvalue()
+            self.assertTrue('5 tests, 1 errors, 3 failures, 2 skipped' in summary, summary)
+            self.assertTrue('7 tests, 2 errors, 4 failures, 1 skipped' in summary, summary)
+            self.assertTrue('12 tests, 3 errors, 7 failures, 3 skipped' in summary, summary)
 
         finally:
             sys.stdout = oldstdout


### PR DESCRIPTION
The following list of changes has been integrated into catkin 0.7.6 (Lunar / Kinetic) since the last Jade / Indigo release (0.6.18).

**Backported:** (these changes are part of this PR)

* handle paths with spaces on Windows #808
  * low impact
* fix rollback logic #819
  * fix bug
* nosetests dependencies docs #847
  * improve docs, safe to backport
* list skipped / disabled in result summary #848
  * useful enhancement
* Python setup.py docs #849
  * improve docs, safe to backport
* cmi --pkg help #853
  * improve help, safe to backport
* CMake config doc #854
  * improve docs, safe to backport

**Not backported:**

* use NO_MODULE #782
  * change of logic, high chance of breaking compatibility
* remove CPATH #783 
  * remove env var, high chance of breaking compatibility
* change `DEPENDS` #813, #825
  * change of logic, high chance of breaking compatibility
* maintain file context for Python scripts #820 
  * minor improvement, no need to backport
* support Ninja #816, #827
  * new feature, no need to backport
* change warning to status when nosetests was not found #823
  * change to comply with Kinetic buildfarm, no need to backport
* Python 3 writeas UTF-8 #828
  * Python 3 is not support, no need to backport
* macros to functions #835
  * minor improvement, no need to backport
* support newer gtest version #857
  * not necessary for platforms targeted by Indigo / Jade

@ros/ros_team Please comment on the decision which changes to (not) backport.