### PR TITLE
use environment variable to extend environment in plain shell

### DIFF
--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -5,6 +5,8 @@
 # It tries it's best to undo changes from a previously sourced setup file before.
 # Supported command line options:
 # --extend: skips the undoing of changes from a previously sourced setup file
+#   (in plain sh shell which does't support arguments for sourced scripts you
+#   can set the environment variable `CATKIN_SETUP_UTIL_ARGS=--extend` instead)
 
 # since this file is sourced either use the provided _CATKIN_SETUP_DIR
 # or fall back to the destination set at configure time
@@ -55,7 +57,7 @@ if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
   echo "Could not create temporary file: $_SETUP_TMP"
   return 1
 fi
-CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ >> "$_SETUP_TMP"
+CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ $CATKIN_SETUP_UTIL_ARGS >> "$_SETUP_TMP"
 _RC=$?
 if [ $_RC -ne 0 ]; then
   if [ $_RC -eq 2 ]; then


### PR DESCRIPTION
In a plain shell the following doesn't work: `. setup.sh --extend`

To allow extending the environment in plain shells this patch adds an environment variable which can be use to pass arguments to the `_setup_util.py` invocation: `CATKIN_SETUP_UTIL_ARGS=--extend , setup.sh`

If the environment variable is not set (default) nothing changes. So this should have no side effects if not being used.

@ros/ros_team Please review.