### PR TITLE
Proposed fix for #868

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -100,7 +100,7 @@ if(NOT GTEST_FOUND)
     endif()
     find_file(_CATKIN_GTEST_SRC "gtest.cc"
       PATHS ${_paths}
-      NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+      NO_DEFAULT_PATH)
 
     # fall back to system installed path (i.e. on Ubuntu)
     set(_paths "/usr/include/gtest")
@@ -110,7 +110,7 @@ if(NOT GTEST_FOUND)
     endif()
     find_file(_CATKIN_GTEST_INCLUDE "gtest.h"
       PATHS ${_paths}
-      NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+      NO_DEFAULT_PATH)
 
     if(_CATKIN_GTEST_SRC)
       get_filename_component(_CATKIN_GTEST_SOURCE_DIR ${_CATKIN_GTEST_SRC} PATH)


### PR DESCRIPTION
This change will make the search for gtest sources and includes check for the files as specified in an optional toolchain file instead of skipping the CMAKE_FIND_ROOT_PATH and should resolve #868.

The current behavior causes CMake to search for gtest in the root filesystem. If it succeeds to find gtest, e.g. /usr/include will be added to the INCLUDE_DIRECTORIES such that cross-compilation builds might fail.