### PR TITLE
Fix python3 support for builder.py

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -274,11 +274,11 @@ def get_multiarch():
     p = subprocess.Popen(
         ['gcc', '-print-multiarch'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = p.communicate()
+    out = p.communicate()[0].decode('utf-8')
     if p.returncode != 0:
-        out, err = subprocess.Popen(
+        out = subprocess.Popen(
             ['dpkg-architecture', '-qDEB_HOST_MULTIARCH'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].decode('utf-8')
 
     # be sure of returning empty string or a valid multiarch tuple format
     assert(not out.strip() or out.strip().count('-') == 2)


### PR DESCRIPTION
subprocess.Popen().communicate() returns a byte string in Python 3 (equal to a standard string in Python 2). Attempting to decode the string works on both Python 2 and Python 3 and fixes the following error:

```
==> Generating an env.sh
Unhandled exception of type 'TypeError':
Traceback (most recent call last):
  File "./src/catkin/bin/../python/catkin/builder.py", line 981, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "./src/catkin/bin/../python/catkin/builder.py", line 691, in build_package
    destdir=destdir, use_ninja=use_ninja
  File "./src/catkin/bin/../python/catkin/builder.py", line 606, in build_cmake_package
    arch = get_multiarch()
  File "./src/catkin/bin/../python/catkin/builder.py", line 284, in get_multiarch
    assert(not out.strip() or out.strip().count('-') == 2)
TypeError: a bytes-like object is required, not 'str'
<== Failed to process package 'octomap': 
  a bytes-like object is required, not 'str'
Command failed, exiting.
```

I also removed the err return since it wasn't being used for anything. 