### PR TITLE
Provide default values to unbound variables

### DIFF
--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -7,7 +7,6 @@
 # --extend: skips the undoing of changes from a previously sourced setup file
 #   (in plain sh shell which does't support arguments for sourced scripts you
 #   can set the environment variable `CATKIN_SETUP_UTIL_ARGS=--extend` instead)
-: ${CATKIN_SETUP_UTIL_ARGS:=}
 
 # since this file is sourced either use the provided _CATKIN_SETUP_DIR
 # or fall back to the destination set at configure time
@@ -58,7 +57,7 @@ if [ $? -ne 0 -o ! -f "$_SETUP_TMP" ]; then
   echo "Could not create temporary file: $_SETUP_TMP"
   return 1
 fi
-CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ $CATKIN_SETUP_UTIL_ARGS >> "$_SETUP_TMP"
+CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ ${CATKIN_SETUP_UTIL_ARGS:-} >> "$_SETUP_TMP"
 _RC=$?
 if [ $_RC -ne 0 ]; then
   if [ $_RC -eq 2 ]; then

--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -7,6 +7,7 @@
 # --extend: skips the undoing of changes from a previously sourced setup file
 #   (in plain sh shell which does't support arguments for sourced scripts you
 #   can set the environment variable `CATKIN_SETUP_UTIL_ARGS=--extend` instead)
+: ${CATKIN_SETUP_UTIL_ARGS:=}
 
 # since this file is sourced either use the provided _CATKIN_SETUP_DIR
 # or fall back to the destination set at configure time
@@ -46,7 +47,7 @@ fi
 
 # invoke Python script to generate necessary exports of environment variables
 # use TMPDIR if it exists, otherwise fall back to /tmp
-if [ -d "${TMPDIR}" ]; then
+if [ -d "${TMPDIR:-}" ]; then
   _TMPDIR="${TMPDIR}"
 else
   _TMPDIR=/tmp


### PR DESCRIPTION
This commit provides default values to unbound variables in setup.sh.in.
This change makes `source setup.sh` work with `set -u`.

---
fix #904 