### PR TITLE
Fix add_dependencies() to refer to targets instead of libraries.

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -173,9 +173,6 @@ function(_catkin_add_executable_with_google_test type target)
 
   assert(${type_upper}_LIBRARIES)
   target_link_libraries(${target} ${${type_upper}_LIBRARIES} ${THREADS_LIBRARY})
-
-  # make sure gtest/gmock is built before the target
-  add_dependencies(${target} ${${type_upper}_LIBRARIES})
 endfunction()
 
 # Internal function for finding gtest or gmock sources


### PR DESCRIPTION
`add_dependencies(...)` is for cmake targets, not for libraries. I believe that the intended behaviour is what this PR does.

Without this PR, adding a gtest results in an error like this if gtest is already pre-built:
```
CMake Error at /opt/ros/lunar/share/catkin/cmake/test/gtest.cmake:178 (add_dependencies):
  The dependency target "/usr/lib/libgtest.so" of target
  "dr_camera_parameters_test_camera_parameters" does not exist.
Call Stack (most recent call first):
  /opt/ros/lunar/share/catkin/cmake/test/gtest.cmake:79 (_catkin_add_executable_with_google_test)
  /opt/ros/lunar/share/catkin/cmake/test/gtest.cmake:28 (_catkin_add_google_test)
  /home/maarten/dev/ros/base/src/dr_base/dr_cmake/cmake/dr_cmake.cmake:38 (catkin_add_gtest)
  CMakeLists.txt:45 (dr_add_gtest)
```