### PR TITLE
Test in parallel on Python 2.7, 3.4, and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: python
 python:
   - "2.7_with_system_site_packages"
   - "3.4_with_system_site_packages"
+  - "3.6_with_system_site_packages"
 # command to install dependencies
 install:
-  # fetch "normal" debian python for 3.3
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.3" ]; then sudo add-apt-repository -y ppa:fkrull/deadsnakes && sudo apt-get -y update && sudo apt-get install python3.3 python3.3-dev && virtualenv -p /usr/bin/python3.3 ~/virtualenvs/3.3_debian && source ~/virtualenvs/3.3_debian/bin/activate; fi
   - pip install argparse catkin-pkg empy mock nose
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7_with_system_site_packages"
   - "3.4_with_system_site_packages"
-  - "3.5_with_system_site_packages"
+  - "3.6"
 # command to install dependencies
 install:
   - pip install argparse catkin-pkg empy mock nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7_with_system_site_packages"
   - "3.4_with_system_site_packages"
-  - "3.6_with_system_site_packages"
+  - "3.5_with_system_site_packages"
 # command to install dependencies
 install:
   - pip install argparse catkin-pkg empy mock nose


### PR DESCRIPTION
Remove the special case that was leftover for Python 3.3 which is [EOL](https://devguide.python.org/#branchstatus).