### PR TITLE
Remove Python 3.3 specific code because it is end of life

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
   - "3.4_with_system_site_packages"
 # command to install dependencies
 install:
-  # fetch "normal" debian python for 3.3
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.3" ]; then sudo add-apt-repository -y ppa:fkrull/deadsnakes && sudo apt-get -y update && sudo apt-get install python3.3 python3.3-dev && virtualenv -p /usr/bin/python3.3 ~/virtualenvs/3.3_debian && source ~/virtualenvs/3.3_debian/bin/activate; fi
   - pip install argparse catkin-pkg empy mock nose
 # command to run tests
 script:


### PR DESCRIPTION
Remove the special case that was leftover for Python 3.3 which is [EOL](https://devguide.python.org/#branchstatus).