### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
   - "3.4_with_system_site_packages"
 # command to install dependencies
 install:
-  # fetch "normal" debian python for 3.3
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.3" ]; then sudo add-apt-repository -y ppa:fkrull/deadsnakes && sudo apt-get -y update && sudo apt-get install python3.3 python3.3-dev && virtualenv -p /usr/bin/python3.3 ~/virtualenvs/3.3_debian && source ~/virtualenvs/3.3_debian/bin/activate; fi
   - pip install argparse catkin-pkg empy mock nose
 # command to run tests
 script:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -190,8 +190,8 @@ htmlhelp_basename = 'catkin-cmakedoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'catkin.tex', ur'Catkin',
-   ur'troy d. straszheim', 'manual'),
+  ('index', 'catkin.tex', r'Catkin',
+   r'troy d. straszheim', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/test/checks/fuerte/distro-to-install.py
+++ b/test/checks/fuerte/distro-to-install.py
@@ -5,13 +5,12 @@ import sys
 
 def go(argv):
   if len(argv) != 2:
-    print 'wrong number args'
+    print('wrong number args')
     sys.exit(1)
 
   d=rospkg.distro.load_distro(argv[1])
   ri=rospkg.distro.distro_to_rosinstall(d, 'release')
-  print ri
+  print(ri)
 
 if __name__ == '__main__':
   go(sys.argv)
-

--- a/test/local_tests/test_with_mock_workspace.py
+++ b/test/local_tests/test_with_mock_workspace.py
@@ -74,7 +74,7 @@ class MockTest(AbstractCatkinWorkspaceTest):
 
         out = self.cmake(CMAKE_PREFIX_PATH=self.installdir,
                          expect=fail)
-        print("failed as expected, out=", out)
+        print("failed as expected, out={}".format(out))
 
         self.assertTrue(b"catkin_package() PROJECT_NAME is set to 'Project'" in out, out)
         # assert 'You must call project() with the same name before.' in out

--- a/test/mock_resources/src/catkin_test/a/src/a/__init__.py
+++ b/test/mock_resources/src/catkin_test/a/src/a/__init__.py
@@ -2,7 +2,5 @@ import std_msgs.msg
 
 s = std_msgs.msg.String()
 
-print "<<< a >>>"
-print type(s)
-
-
+print("<<< a >>>")
+print(type(s))

--- a/test/mock_resources/src/catkin_test/b/src/b/__init__.py
+++ b/test/mock_resources/src/catkin_test/b/src/b/__init__.py
@@ -5,6 +5,4 @@ s = std_msgs.msg.String()
 a = a.msg.AMsg()
 b = b.msg.BMsg()
 
-print "<<< b >>>"
-
-
+print("<<< b >>>")

--- a/test/mock_resources/src/catkin_test/c/src/c/__init__.py
+++ b/test/mock_resources/src/catkin_test/c/src/c/__init__.py
@@ -1,1 +1,1 @@
-print "IMPORTING"
+print("IMPORTING")

--- a/test/mock_resources/src/catkin_test/d/src/d/__init__.py
+++ b/test/mock_resources/src/catkin_test/d/src/d/__init__.py
@@ -1,1 +1,1 @@
-print "IMPORTING"
+print("IMPORTING")

--- a/test/mock_resources/src/python_test_a/src/a_uses_std_msgs.py
+++ b/test/mock_resources/src/python_test_a/src/a_uses_std_msgs.py
@@ -4,4 +4,4 @@ import std_msgs.msg
 
 some_string = std_msgs.msg.String
 some_string.data = "Some Data in a std_msgs.msg.String"
-print (some_string.data)
+print(some_string.data)


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes