### PR TITLE
pkgConfig.cmake: add lib/x86_64-linux-gnu to search path

### DIFF
--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -80,6 +80,9 @@
 #
 # @public
 #
+
+include(GNUInstallDirs)
+
 macro(catkin_package)
   debug_message(10 "catkin_package() called in file ${CMAKE_CURRENT_LIST_FILE}")
 
@@ -243,6 +246,7 @@ function(_catkin_package)
   set(lib_paths "")
   foreach(workspace ${CATKIN_WORKSPACES})
     list_append_unique(lib_paths ${workspace}/lib)
+    list_append_unique(lib_paths ${workspace}/${CMAKE_INSTALL_LIBDIR})
   endforeach()
 
   # merge explicitly listed libraries and libraries from non-catkin but find_package()-ed packages


### PR DESCRIPTION
This search path is added to the run-time environment, but
is missing from the build-time environment, which results in
binaries not linking properly, or linking against the wrong
version of a library.

Using the GNUInstallDirs CMake module:
https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html