### PR TITLE
use verbatim on test target to fix testing with ninja

### DIFF
--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -142,7 +142,9 @@ function(catkin_run_tests_target type name xunit_filename)
   endif()
   # hidden test target which depends on building all tests and cleaning test results
   add_custom_target(_run_tests_${PROJECT_NAME}_${type}_${name}
-    COMMAND ${cmd})
+    COMMAND ${cmd}
+    VERBATIM
+  )
   add_dependencies(_run_tests_${PROJECT_NAME}_${type} _run_tests_${PROJECT_NAME}_${type}_${name})
 
   # create target to clean project specific test results

--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -128,7 +128,9 @@ function(catkin_run_tests_target type name xunit_filename)
     # for the run_tests target the command needs to return zero so that testing is not aborted
     set(cmd ${cmd_wrapper} ${_testing_COMMAND})
     add_custom_target(run_tests_${PROJECT_NAME}_${type}_${name}
-      COMMAND ${cmd})
+      COMMAND ${cmd}
+      VERBATIM
+    )
   else()
     # create empty dummy target
     set(cmd "${CMAKE_COMMAND}" "-E" "echo" "Skipping test target \\'run_tests_${PROJECT_NAME}_${type}_${name}\\'. Enable testing via -DCATKIN_ENABLE_TESTING.")
@@ -146,7 +148,9 @@ function(catkin_run_tests_target type name xunit_filename)
   # create target to clean project specific test results
   if(NOT TARGET clean_test_results_${PROJECT_NAME})
     add_custom_target(clean_test_results_${PROJECT_NAME}
-      COMMAND ${PYTHON_EXECUTABLE} "${catkin_EXTRAS_DIR}/test/remove_test_results.py" "${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}")
+      COMMAND ${PYTHON_EXECUTABLE} "${catkin_EXTRAS_DIR}/test/remove_test_results.py" "${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}"
+      VERBATIM
+    )
   endif()
   add_dependencies(_run_tests_${PROJECT_NAME}_${type}_${name} clean_test_results_${PROJECT_NAME} tests ${_testing_DEPENDENCIES})
 endfunction()


### PR DESCRIPTION
TL;DR VERBATIM is needed for the run_tests* target to work with ninja

## More details:

https://answers.ros.org/question/288290/catkin_make_isolated-run_tests/ unveiled that the run_tests target is not able to run_tests when using ninja as the build system.

The issue comes from the backslashes appended to the commands in the build files.

### How to reproduce the issue:

```
source /opt/ros/<ROSDISTRO>/setup.bash
mkdir -p /tmp/run_tests_ws/src && /tmp/run_tests_ws/src
git clone https://github.com/gocarlos/ros_unit_tests_example
cd /tmp/run_tests_ws
```

#### Build and run with ninja:
```
rm -r build_isolated/ devel_isolated/ install_isolated/; \
  CTEST_OUTPUT_ON_FAILURE=1  catkin_make_isolated --use-ninja --install && \
  CTEST_OUTPUT_ON_FAILURE=1  catkin_make_isolated --use-ninja --install --catkin-make-args run_tests
```
error message: `[/tmp/run_tests_ws/src/ros_unit_tests_example/launch/node_launcher.launch\] is not a launch file name`

#### Build and run with make:
```
rm -r build_isolated/ devel_isolated/ install_isolated/; \
  CTEST_OUTPUT_ON_FAILURE=1  catkin_make_isolated --install && \
  CTEST_OUTPUT_ON_FAILURE=1  catkin_make_isolated --install --catkin-make-args run_tests
```
Test is ran successfully.

#### With this patch
Apply this patch and retry build and run with ninja and Make. The test is ran successfully in both cases.
```
This comes form inside of one test case


... logging to /root/.ros/log/rostest-f6506ac887d3-14588.log
[ROSUNIT] Outputting test results to /root/test_ws/build_isolated/ros_unit_tests_example/test_results/ros_unit_tests_example/rostest-launch_node_launcher.xml
[Testcase: testmy_unit_test] ... ok

[ROSTEST]-----------------------------------------------------------------------

[ros_unit_tests_example.rosunit-my_unit_test/test_case_1][passed]

SUMMARY
 * RESULT: SUCCESS
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 0
```