### PR TITLE
add separate option CATKIN_INSTALL_INTO_PREFIX_ROOT

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -70,6 +70,16 @@ if(_index EQUAL -1)
   list(INSERT CMAKE_PREFIX_PATH 0 ${CATKIN_DEVEL_PREFIX})
 endif()
 
+# set CATKIN_INSTALL_INTO_PREFIX_ROOT based on CATKIN_BUILD_BINARY_PACKAGE
+# if not defined already
+if(NOT DEFINED CATKIN_INSTALL_INTO_PREFIX_ROOT)
+  if(CATKIN_BUILD_BINARY_PACKAGE)
+    set(CATKIN_INSTALL_INTO_PREFIX_ROOT FALSE)
+  else()
+    set(CATKIN_INSTALL_INTO_PREFIX_ROOT TRUE)
+  endif()
+endif()
+
 
 # enable all new policies (if available)
 macro(_set_cmake_policy_to_new_if_available policy)
@@ -194,7 +204,7 @@ configure_file(${catkin_EXTRAS_DIR}/templates/env.${script_ext}.in
 set(CATKIN_ENV ${SETUP_DIR}/env_cached.${script_ext} CACHE INTERNAL "catkin environment")
 
 # add additional environment hooks
-if(CATKIN_BUILD_BINARY_PACKAGE)
+if(NOT CATKIN_INSTALL_INTO_PREFIX_ROOT)
   set(catkin_skip_install_env_hooks "SKIP_INSTALL")
 endif()
 if(CMAKE_HOST_UNIX AND PROJECT_NAME STREQUAL "catkin")

--- a/cmake/catkin_generate_environment.cmake
+++ b/cmake/catkin_generate_environment.cmake
@@ -74,7 +74,7 @@ function(catkin_generate_environment)
   # installspace
   set(SETUP_DIR ${CMAKE_INSTALL_PREFIX})
 
-  if(NOT CATKIN_BUILD_BINARY_PACKAGE)
+  if(CATKIN_INSTALL_INTO_PREFIX_ROOT)
     # install empty workspace marker if it doesn't already exist
     install(CODE "
       if (NOT EXISTS \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
@@ -99,7 +99,7 @@ function(catkin_generate_environment)
     configure_file(${catkin_EXTRAS_DIR}/templates/env.sh.in
       ${CMAKE_BINARY_DIR}/catkin_generated/installspace/env.sh
       @ONLY)
-    if(NOT CATKIN_BUILD_BINARY_PACKAGE)
+    if(CATKIN_INSTALL_INTO_PREFIX_ROOT)
       install(PROGRAMS
         ${CMAKE_BINARY_DIR}/catkin_generated/installspace/env.sh
         DESTINATION ${CMAKE_INSTALL_PREFIX})
@@ -109,7 +109,7 @@ function(catkin_generate_environment)
       configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.in
         ${CMAKE_BINARY_DIR}/catkin_generated/installspace/setup.${shell}
         @ONLY)
-      if(NOT CATKIN_BUILD_BINARY_PACKAGE)
+      if(CATKIN_INSTALL_INTO_PREFIX_ROOT)
         install(FILES
           ${CMAKE_BINARY_DIR}/catkin_generated/installspace/setup.${shell}
           DESTINATION ${CMAKE_INSTALL_PREFIX})
@@ -138,7 +138,7 @@ function(catkin_generate_environment)
   configure_file(${catkin_EXTRAS_DIR}/templates/rosinstall.in
     ${CMAKE_BINARY_DIR}/catkin_generated/installspace/.rosinstall
     @ONLY)
-  if(NOT CATKIN_BUILD_BINARY_PACKAGE)
+  if(CATKIN_INSTALL_INTO_PREFIX_ROOT)
     install(FILES
       ${CMAKE_BINARY_DIR}/catkin_generated/installspace/.rosinstall
       DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
The existing option `CATKIN_BUILD_BINARY_PACKAGE` is being used in the generated Debian rules files (except for `catkin` itself). Currently that flag has two effects:

* It disables tests:
  * https://github.com/ros/catkin/blob/cbe836852a8cff82ed2be3e8ade4392d1694fc49/cmake/test/tests.cmake#L47
* It skips the installation of files into the root of the install prefix:
  * https://github.com/ros/catkin/blob/cbe836852a8cff82ed2be3e8ade4392d1694fc49/cmake/all.cmake#L197
  * https://github.com/ros/catkin/blob/cbe836852a8cff82ed2be3e8ade4392d1694fc49/cmake/catkin_generate_environment.cmake#L77

When building ROS 1 packages with `colcon` the second side effect is desired when building with `--merge-install` but the first one is not. In order to select that combination this patch introduces a new flag named `CATKIN_INSTALL_INTO_PREFIX_ROOT`. The value of this new variable is being initialized based on the value of the existing variable `CATKIN_BUILD_BINARY_PACKAGE` (in case it is not being passed explicitly from the command line). This allows `colcon-ros` to pass `-DCATKIN_INSTALL_INTO_PREFIX_ROOT=0` while still keeping tests enabled (see colcon/colcon-ros#11).