### PR TITLE
Document how to install python subpackages

### DIFF
--- a/doc/howto/format1/installing_python.rst
+++ b/doc/howto/format1/installing_python.rst
@@ -73,6 +73,14 @@ layout, it looks like this::
   
   setup(**setup_args)
 
+Note: `As in setuptools
+<https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages>`_,
+the ``packages`` list is not recursive, and sub-packages must be
+included explicitly (e.g. ``your_package.tools.my_util`` which would
+contain the python modules defined in the folder
+``src/your_package/tools/my_util/``, along with an ``__init__.py``
+file).
+
 This ``setup.py`` is only for use with catkin. Remember *not* to
 invoke it yourself.
 

--- a/doc/howto/format1/installing_python.rst
+++ b/doc/howto/format1/installing_python.rst
@@ -73,7 +73,7 @@ layout, it looks like this::
   
   setup(**setup_args)
 
-Note: `As in setuptools
+Note: As in `setuptools
 <https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages>`_,
 the ``packages`` list is not recursive, and sub-packages must be
 included explicitly (e.g. ``your_package.tools.my_util`` which would

--- a/doc/howto/format2/installing_python.rst
+++ b/doc/howto/format2/installing_python.rst
@@ -73,6 +73,14 @@ layout, it looks like this::
   
   setup(**setup_args)
 
+Note: `As in setuptools
+<https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages>`_,
+the ``packages`` list is not recursive, and sub-packages must be
+included explicitly (e.g. ``your_package.tools.my_util`` which would
+contain the python modules defined in the folder
+``src/your_package/tools/my_util/``, along with an ``__init__.py``
+file).
+
 This ``setup.py`` is only for use with catkin. Remember *not* to
 invoke it yourself.
 

--- a/doc/howto/format2/installing_python.rst
+++ b/doc/howto/format2/installing_python.rst
@@ -73,7 +73,7 @@ layout, it looks like this::
   
   setup(**setup_args)
 
-Note: `As in setuptools
+Note: As in `setuptools
 <https://packaging.python.org/guides/distributing-packages-using-setuptools/#packages>`_,
 the ``packages`` list is not recursive, and sub-packages must be
 included explicitly (e.g. ``your_package.tools.my_util`` which would


### PR DESCRIPTION
As I recently discovered via ROS Answers [#273090](https://answers.ros.org/question/273090/setuppy-not-installing-python-module-during-catkin-build/), there is a non-obvious method to make catkin install python subpackages. Hopefully an explicit note in the docs will help one or two other people faster down the road.

Thanks,
Josh