### PR TITLE
need to sanitize catkin_ws paths before cprint

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -355,7 +355,7 @@ def build_catkin_package(
     if last_env is not None:
         cprint(
             blue_arrow + " Building with env: " +
-            "'{0}'".format(last_env)
+            "'{0}'".format(sanitize(last_env))
         )
 
     # Check for Makefile and maybe call cmake
@@ -483,7 +483,7 @@ def build_cmake_package(
     # Check last_env
     if last_env is not None:
         cprint(blue_arrow + " Building with env: " +
-               "'{0}'".format(last_env))
+               "'{0}'".format(sanitize(last_env)))
 
     # Check for Makefile and maybe call cmake
     if not use_ninja:


### PR DESCRIPTION
When the catkin_ws includes "@" (at sign), catkin_make_isolated does not work since ``ColorTemplate`` of ``terminal_color.py`` uses "@" as delimiter.
So ``terminal_color.py`` has a function named ``sanitize`` to replace "@" to "@@", but the authors seem to miss to apply ``sanitize`` at some points at ``builder.py``.
