### PR TITLE
fix symbolic link

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -84,9 +84,8 @@ def create_catkin_workspace(pth):
     workspace_cmake = os.path.join(pth, "CMakeLists.txt")
     if os.path.isfile(workspace_cmake):
         os.remove(workspace_cmake)
-    succeed(["/bin/ln", "-s", "catkin/cmake/toplevel.cmake",
-             "CMakeLists.txt"],
-            cwd=pth)
+    succeed(["/bin/ln", "-s", pth + "/catkin/cmake/toplevel.cmake",
+             pth + "/CMakeLists.txt"])
 
 
 def succeed(cmd, **kwargs):


### PR DESCRIPTION
travis fails because CMakeLists.txt cannot be found.
- https://travis-ci.org/ros/catkin/jobs/439639963

It's because the way to create a symbolic link of CMakeLists.txt is not correct.