### PR TITLE
add double quotes around cmake_command to handle spaces

### DIFF
--- a/cmake/test/nosetests.cmake
+++ b/cmake/test/nosetests.cmake
@@ -73,7 +73,15 @@ function(catkin_add_nosetests path)
   set(output_path ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})
   # make --xunit-file argument an absolute path (https://github.com/nose-devs/nose/issues/779)
   get_filename_component(output_path "${output_path}" ABSOLUTE)
-  set(cmd "${CMAKE_COMMAND} -E make_directory ${output_path}")
+
+  if(WIN32)
+    # add quotes to handle spaces properly
+    set(cmd \"${CMAKE_COMMAND}\")
+  else()
+    set(cmd ${CMAKE_COMMAND})
+  endif()
+
+  set(cmd "${cmd} -E make_directory ${output_path}")
   if(IS_DIRECTORY ${_path_name})
     set(tests "--where=${_path_name}")
   else()

--- a/cmake/test/nosetests.cmake
+++ b/cmake/test/nosetests.cmake
@@ -73,7 +73,6 @@ function(catkin_add_nosetests path)
   set(output_path ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})
   # make --xunit-file argument an absolute path (https://github.com/nose-devs/nose/issues/779)
   get_filename_component(output_path "${output_path}" ABSOLUTE)
-
   set(cmd "\"${CMAKE_COMMAND}\" -E make_directory ${output_path}")
   if(IS_DIRECTORY ${_path_name})
     set(tests "--where=${_path_name}")

--- a/cmake/test/nosetests.cmake
+++ b/cmake/test/nosetests.cmake
@@ -74,14 +74,7 @@ function(catkin_add_nosetests path)
   # make --xunit-file argument an absolute path (https://github.com/nose-devs/nose/issues/779)
   get_filename_component(output_path "${output_path}" ABSOLUTE)
 
-  if(WIN32)
-    # add quotes to handle spaces properly
-    set(cmd \"${CMAKE_COMMAND}\")
-  else()
-    set(cmd ${CMAKE_COMMAND})
-  endif()
-
-  set(cmd "${cmd} -E make_directory ${output_path}")
+  set(cmd "\"${CMAKE_COMMAND}\" -E make_directory ${output_path}")
   if(IS_DIRECTORY ${_path_name})
     set(tests "--where=${_path_name}")
   else()


### PR DESCRIPTION
there might be spaces within `${CMAKE_COMMAND}` so need to wrap it with double quotation marks