### PR TITLE
use ${PYTHON_EXECUTABLE} in catkin_download

### DIFF
--- a/cmake/catkin_download.cmake
+++ b/cmake/catkin_download.cmake
@@ -56,7 +56,7 @@ function(catkin_download target url)
   # this is because we want to check the md5 sum if it's given, and redownload
   # the target if the md5 sum does not match.
   add_custom_target(${target}
-    COMMAND ${PYTHON} ${catkin_EXTRAS_DIR}/test/download_checkmd5.py ${url} ${output} ${ARG_MD5} ${required}
+    COMMAND ${PYTHON_EXECUTABLE} ${catkin_EXTRAS_DIR}/test/download_checkmd5.py ${url} ${output} ${ARG_MD5} ${required}
     VERBATIM)
 
   if(ARG_EXCLUDE_FROM_ALL)


### PR DESCRIPTION
use `${PYTHON_EXECUTABLE}` instead of `${PYTHON}` in the `catkin_download` function.

In execution, `${PYTHON}` is interpreted as an empty string, and the command would not be executed on Windows (a python script is not executable without extra setup). this might not be noticeable on Ubuntu since python scripts can be executed without the `python` prefix