### PR TITLE
normalize paths in CMAKE_PREFIX_PATH for proper comparison

### DIFF
--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -265,8 +265,8 @@ if __name__ == '__main__':
         CMAKE_PREFIX_PATH = '@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
         # prepend current workspace if not already part of CPP
         base_path = os.path.dirname(__file__)
-        if base_path not in CMAKE_PREFIX_PATH:
-            CMAKE_PREFIX_PATH.insert(0, base_path)
+        if base_path not in [os.path.normpath(os.path.normcase(p)) for p in CMAKE_PREFIX_PATH]:
+            CMAKE_PREFIX_PATH.insert(0, base_path.replace(os.path.sep, '/'))
         CMAKE_PREFIX_PATH = os.pathsep.join(CMAKE_PREFIX_PATH)
 
         environ = dict(os.environ)

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -265,6 +265,9 @@ if __name__ == '__main__':
         CMAKE_PREFIX_PATH = '@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
         # prepend current workspace if not already part of CPP
         base_path = os.path.dirname(__file__)
+
+        # CMAKE_PREFIX_PATH uses forward slash on all platforms, but os.path.dirname is platform dependent
+        # base_path on Windows contains backward slashes, need to normalize paths in CMAKE_PREFIX_PATH with os.path.normpath for comparison
         if base_path not in [os.path.normpath(os.path.normcase(p)) for p in CMAKE_PREFIX_PATH]:
             CMAKE_PREFIX_PATH.insert(0, base_path.replace(os.path.sep, '/'))
         CMAKE_PREFIX_PATH = os.pathsep.join(CMAKE_PREFIX_PATH)

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -265,11 +265,13 @@ if __name__ == '__main__':
         CMAKE_PREFIX_PATH = '@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
         # prepend current workspace if not already part of CPP
         base_path = os.path.dirname(__file__)
-
         # CMAKE_PREFIX_PATH uses forward slash on all platforms, but __file__ is platform dependent
-        # base_path on Windows contains backward slashes, need to normalize paths in CMAKE_PREFIX_PATH with os.path.normpath for comparison
-        if base_path not in [os.path.normcase(p) for p in CMAKE_PREFIX_PATH]:
-            CMAKE_PREFIX_PATH.insert(0, base_path.replace(os.path.sep, '/'))
+        # base_path on Windows contains backward slashes, need to be converted to forward slashes before comparison
+        if os.path.sep != '/':
+            base_path = base_path.replace(os.path.sep, '/')
+
+        if base_path not in CMAKE_PREFIX_PATH:
+            CMAKE_PREFIX_PATH.insert(0, base_path)
         CMAKE_PREFIX_PATH = os.pathsep.join(CMAKE_PREFIX_PATH)
 
         environ = dict(os.environ)

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -266,9 +266,9 @@ if __name__ == '__main__':
         # prepend current workspace if not already part of CPP
         base_path = os.path.dirname(__file__)
 
-        # CMAKE_PREFIX_PATH uses forward slash on all platforms, but os.path.dirname is platform dependent
+        # CMAKE_PREFIX_PATH uses forward slash on all platforms, but __file__ is platform dependent
         # base_path on Windows contains backward slashes, need to normalize paths in CMAKE_PREFIX_PATH with os.path.normpath for comparison
-        if base_path not in [os.path.normpath(os.path.normcase(p)) for p in CMAKE_PREFIX_PATH]:
+        if base_path not in [os.path.normcase(p) for p in CMAKE_PREFIX_PATH]:
             CMAKE_PREFIX_PATH.insert(0, base_path.replace(os.path.sep, '/'))
         CMAKE_PREFIX_PATH = os.pathsep.join(CMAKE_PREFIX_PATH)
 


### PR DESCRIPTION
`CMAKE_PREFIX_PATH` uses forward slash on all platforms, but `os.path.dirname()` is platform dependent. this problem is not noticeable on Linux/Ubuntu since `os.path.sep` is also `/`, yet `os.path.dirname` on Windows would contain `\` in the returned result; leading to mismatch during comparison. Normalizing paths in `CMAKE_PREFIX_PATH` would get rid of this issue by using the same separator in both path strings

meantime, `\` in `base_path` needs to be converted to `/` to match other paths already in `CMAKE_PREFIX_PATH`