### PR TITLE
add script.bat.in template for general use

### DIFF
--- a/cmake/templates/script.bat.in
+++ b/cmake/templates/script.bat.in
@@ -1,4 +1,4 @@
 @echo off
 REM generated from catkin/cmake/templates/script.bat.in
 
-"@BAT_SCRIPT@" %*
+call "@BAT_SCRIPT@" %*

--- a/cmake/templates/script.bat.in
+++ b/cmake/templates/script.bat.in
@@ -1,0 +1,4 @@
+@echo off
+REM generated from catkin/cmake/templates/script.bat.in
+
+"@BAT_SCRIPT@" %*


### PR DESCRIPTION
similar to the use of the bash script template, `script.bat.in` will be used as a batch script wrapper for `rosrun.bat` (https://github.com/ms-iot/ros/blob/init_windows/tools/rosbash/CMakeLists.txt#L27)