### PR TITLE
update builder.py to add Windows support

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1074,8 +1074,9 @@ def build_workspace_isolated(
     if not os.path.exists(develspace):
         os.makedirs(develspace)
     if not build_packages:
+        env_script = 'env'
         if sys.platform == 'win32':
-            env_script = 'env.bat'
+            env_script += '.bat'
             env_script_content = """\
 @echo off
 REM generated from catkin.builder module
@@ -1089,7 +1090,7 @@ REM generated from catkin.builder module
 call "{0}/setup.{1}"
 """
         else:
-            env_script = 'evn.sh'
+            env_script += '.sh'
             env_script_content = """\
 #!/usr/bin/env sh
 # generated from catkin.builder module
@@ -1102,6 +1103,7 @@ call "{0}/setup.{1}"
 
 . "{0}/setup.{1}"
 """
+
         generated_env_sh = os.path.join(develspace, env_script)
         generated_setup_util_py = os.path.join(develspace, '_setup_util.py')
         if not merge and pkg_develspace:
@@ -1120,7 +1122,7 @@ call "{0}/setup.{1}"
                 os.remove(generated_setup_util_py)
 
         elif not pkg_develspace:
-            # generate env script and setup.sh|bash|zsh or setup.bat for an empty devel space
+            # generate env.* and setup.* scripts for an empty devel space
             if 'CMAKE_PREFIX_PATH' in os.environ.keys():
                 variables = {
                     'CATKIN_GLOBAL_BIN_DESTINATION': 'bin',
@@ -1148,7 +1150,8 @@ call "{0}/setup.{1}"
 
             variables = {
                 'PYTHON_EXECUTABLE': sys.executable,
-                'SETUP_DIR': develspace}
+                'SETUP_DIR': develspace
+            }
             shells_to_write = ['bat'] if sys.platform == 'win32' else ['sh', 'bash', 'zsh']
             for shell in shells_to_write:
                 with open(os.path.join(develspace, 'setup.%s' % shell), 'w') as f:

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -466,6 +466,8 @@ def has_make_target(path, target, use_ninja=False, use_nmake=False):
 def get_additional_environment(install, destdir, installspace):
     add_env = {}
     if install and destdir:
+        # skip the drive letter if on Windows
+        installspace = os.path.splitdrive(installspace)[1]
         add_env['_CATKIN_SETUP_DIR'] = os.path.join(destdir, installspace[1:])
     return add_env
 
@@ -764,6 +766,8 @@ def get_new_env(package, develspace, installspace, install, last_env, destdir=No
 
 def prefix_destdir(path, destdir=None):
     if destdir is not None:
+        # skip the drive letter if on Windows
+        path = os.path.splitdrive(path)[1]
         path = os.path.join(destdir, path[1:])
     return path
 

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -466,8 +466,9 @@ def has_make_target(path, target, use_ninja=False, use_nmake=False):
 def get_additional_environment(install, destdir, installspace):
     add_env = {}
     if install and destdir:
-        # skip the drive letter if on Windows
-        installspace = os.path.splitdrive(installspace)[1]
+        # exclude drive letter if on Windows, returns the same string on Linux since there is no drive specifications
+        _, installspace = os.path.splitdrive(installspace)
+
         add_env['_CATKIN_SETUP_DIR'] = os.path.join(destdir, installspace[1:])
     return add_env
 
@@ -767,8 +768,9 @@ def get_new_env(package, develspace, installspace, install, last_env, destdir=No
 
 def prefix_destdir(path, destdir=None):
     if destdir is not None:
-        # skip the drive letter if on Windows
-        path = os.path.splitdrive(path)[1]
+        # exclude drive letter if on Windows, returns the same string on Linux since there is no drive specifications
+        _, path = os.path.splitdrive(path)
+
         path = os.path.join(destdir, path[1:])
     return path
 

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -503,7 +503,7 @@ set PATH={path};%PATH%
 set PKG_CONFIG_PATH={pkgcfg_path};%PKG_CONFIG_PATH%
 set PYTHONPATH={pythonpath};%PYTHONPATH%
 """.format(**variables))
-    
+
 def write_env_script_sh(dest_file, variables):
     with open(os.path.join(dest_file), 'w') as f:
         f.write("""\
@@ -680,8 +680,8 @@ def build_cmake_package(
         subs['path'] = os.path.join(install_target, 'bin')
         arch = get_multiarch()
         if arch:
-            subs['ld_path'] += os.path.join(install_target, 'lib', arch)
-            subs['pkgcfg_path'] += os.path.join(install_target, 'lib', arch, 'pkgconfig')
+            subs['ld_path'] = os.pathsep.join([subs['ld_path'], os.path.join(install_target, 'lib', arch)])
+            subs['pkgcfg_path'] = os.pathsep.join([subs['pkgcfg_path'], os.path.join(install_target, 'lib', arch, 'pkgconfig')])
         if not os.path.exists(os.path.dirname(new_setup_path)):
             os.mkdir(os.path.dirname(new_setup_path))
 

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -672,7 +672,8 @@ def build_cmake_package(
     last_setup_env = os.path.join(os.path.dirname(last_env), setup_script) if last_env is not None else None
     if new_setup_path != last_setup_env:
         subs = {}
-        subs['cmake_prefix_path'] = install_target
+        # CMAKE_PREFIX_PATH uses forward slash on all platforms.
+        subs['cmake_prefix_path'] = install_target.replace(os.sep, '/')
         subs['ld_path'] = os.path.join(install_target, 'lib')
         pythonpath = os.path.join(install_target, get_python_install_dir())
         subs['pythonpath'] = pythonpath

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -503,7 +503,7 @@ set PATH={path};%PATH%
 set PKG_CONFIG_PATH={pkgcfg_path};%PKG_CONFIG_PATH%
 set PYTHONPATH={pythonpath};%PYTHONPATH%
 """.format(**variables))
-
+    
 def write_env_script_sh(dest_file, variables):
     with open(os.path.join(dest_file), 'w') as f:
         f.write("""\

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -476,7 +476,7 @@ def get_additional_environment(install, destdir, installspace):
 def write_env_bat(dest_file, variables):
     env_bat_template = """\
 @echo off
-REM generated from catkin.builder module
+REM generated from catkin.builder Python module
 
 if "%1"=="" (
   echo "Usage: env.bat COMMANDS"
@@ -494,7 +494,7 @@ if "%1"=="" (
 def write_setup_bat(dest_file, last_setup_basename, variables):
     setup_bat_header = """\
 @echo off
-REM generated from catkin.builder module
+REM generated from catkin.builder Python module
 """
     setup_bat_template = """\
 REM Prepend to the environment
@@ -514,7 +514,7 @@ set PYTHONPATH={pythonpath};%PYTHONPATH%
 def write_env_sh(dest_file, variables):
     env_sh_template = """\
 #!/usr/bin/env sh
-# generated from catkin.builder module
+# generated from catkin.builder Python module
 
 if [ $# -eq 0 ] ; then
   /bin/echo "Usage: env.sh COMMANDS"
@@ -538,7 +538,7 @@ exec "$@"
 def write_setup_sh(dest_file, last_setup_basename, variables):
     setup_sh_header = """\
 #!/usr/bin/env sh
-# generated from catkin.builder module
+# generated from catkin.builder Python module
 
 # remember type of shell if not already set
 if [ -z "$CATKIN_SHELL" ]; then
@@ -673,7 +673,7 @@ def build_cmake_package(
         if not os.path.exists(os.path.dirname(new_env_path)):
             os.makedirs(os.path.dirname(new_env_path))
         env_script_writer = write_env_bat if sys.platform == 'win32' else write_env_sh
-        env_script_writer(dest_file = new_env_path, variables = variables)
+        env_script_writer(dest_file=new_env_path, variables=variables)
 
     # Generate setup script for chaining to catkin packages
     # except if using --merge which implies that new_setup_path equals last_setup_env
@@ -699,13 +699,13 @@ def build_cmake_package(
             os.mkdir(os.path.dirname(new_setup_path))
         setup_script_writer = write_setup_bat if sys.platform == 'win32' else write_setup_sh
         last_setup_basename = os.path.splitext(last_setup_env)[0] if last_setup_env is not None else None
-        setup_script_writer(dest_file = new_setup_path, last_setup_basename = last_setup_basename, variables = subs)
+        setup_script_writer(dest_file=new_setup_path, last_setup_basename=last_setup_basename, variables=subs)
 
         if sys.platform != 'win32':
             # generate setup.bash|zsh scripts
             setup_script_template = """\
 #!/usr/bin/env {1}
-# generated from catkin.builder module
+# generated from catkin.builder Python module
 
 CATKIN_SHELL={1}
 . "{0}/setup.sh"
@@ -1079,13 +1079,13 @@ def build_workspace_isolated(
             env_script += '.bat'
             env_script_content = """\
 @echo off
-REM generated from catkin.builder module
+REM generated from catkin.builder Python module
 
 call {0} %*
 """
             setup_script_content = """\
 @echo off
-REM generated from catkin.builder module
+REM generated from catkin.builder Python module
 
 call "{0}/setup.{1}"
 """
@@ -1093,13 +1093,13 @@ call "{0}/setup.{1}"
             env_script += '.sh'
             env_script_content = """\
 #!/usr/bin/env sh
-# generated from catkin.builder module
+# generated from catkin.builder Python module
 
 {0} "$@"
 """
             setup_script_content = """\
 #!/usr/bin/env {1}
-# generated from catkin.builder module
+# generated from catkin.builder Python module
 
 . "{0}/setup.{1}"
 """
@@ -1142,7 +1142,7 @@ call "{0}/setup.{1}"
 
             variables = {
                 'SETUP_DIR': develspace,
-                'SETUP_FILENAME': 'setup'
+                'SETUP_FILENAME': 'setup',
             }
             with open(generated_env_sh, 'w') as f:
                 f.write(configure_file(os.path.join(get_cmake_path(), 'templates', env_script + '.in'), variables))
@@ -1150,7 +1150,7 @@ call "{0}/setup.{1}"
 
             variables = {
                 'PYTHON_EXECUTABLE': sys.executable,
-                'SETUP_DIR': develspace
+                'SETUP_DIR': develspace,
             }
             shells_to_write = ['bat'] if sys.platform == 'win32' else ['sh', 'bash', 'zsh']
             for shell in shells_to_write:


### PR DESCRIPTION
update `builder.py` to support building on Windows:
- exclude drive letter so that `path[1:]` gives the correct result on Windows
- abstract the action of writing env and setup scripts into script writers
- define script templates in a separate step (for better readability)
- add templates for Windows batch scripts
- expand variables for [env.bat template](https://github.com/ros/catkin/blob/kinetic-devel/cmake/templates/env.bat.in) and [setup.bat template](https://github.com/ros/catkin/blob/kinetic-devel/cmake/templates/setup.bat.in)

this code change does not alter the existing logic on Linux