### PR TITLE
ensure desired Python path is added into PATH in setup.bat

### DIFF
--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -16,6 +16,27 @@ if NOT EXIST "%_SETUP_UTIL%" (
 REM set the Python executable
 set _PYTHON="@PYTHON_EXECUTABLE@"
 
+REM compute Python home and normalize Python executable path
+set _PYTHONHOME=
+SET _PYTHONEXE=
+FOR /f "usebackq tokens=*" %%a IN ('%_PYTHON%') DO (
+  SET _PYTHONHOME=%%~dpa
+  SET _PYTHONEXE=%%~nxa
+  SET _PYTHON="%%~dpa%%~nxa"
+)
+
+REM add Python home to PATH when needed
+set _PYTHON_FOUND=
+for %%i in (%_PYTHONEXE%) do (
+  set _PYTHON_FOUND="%%~$PATH:i"
+  goto :done
+)
+
+:done
+if not "%_PYTHON_FOUND%" == "%_PYTHON%" (
+  set PATH=%_PYTHONHOME%;%_PYTHONHOME%Scripts;%PATH%
+)
+
 REM generate pseudo random temporary filename
 :GenerateTempFilename
 REM replace leading space of time with zero
@@ -66,6 +87,9 @@ set PATH=%LD_LIBRARY_PATH%;%PATH%
 REM unset temporary variables
 set _SETUP_UTIL=
 set _PYTHON=
+set _PYTHONEXE=
+set _PYTHONHOME=
+set _PYTHON_FOUND=
 set _SETUP_TMP=
 set _CATKIN_ENVIRONMENT_HOOKS_COUNT=
 set _HOOK_COUNT=

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -26,16 +26,16 @@ FOR /f "usebackq tokens=*" %%a IN ('%_PYTHON%') DO (
 )
 
 REM add Python home to PATH when needed
+setlocal enabledelayedexpansion
 set _PYTHON_FOUND=
 for %%i in (%_PYTHONEXE%) do (
   set _PYTHON_FOUND="%%~$PATH:i"
-  goto :done
 )
 
-:done
-if not "%_PYTHON_FOUND%" == "%_PYTHON%" (
-  set PATH=%_PYTHONHOME%;%_PYTHONHOME%Scripts;%PATH%
+if not "!_PYTHON_FOUND!" == "!_PYTHON!" (
+  set PATH=%_PYTHONHOME%;%_PYTHONHOME%Scripts;!PATH!
 )
+endlocal & set PATH=%PATH%
 
 REM generate pseudo random temporary filename
 :GenerateTempFilename

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -18,20 +18,21 @@ set _PYTHON="@PYTHON_EXECUTABLE@"
 
 REM compute Python home and normalize Python executable path
 set PYTHONHOME=
-SET _PYTHONEXE=
-FOR /f "usebackq tokens=*" %%a IN ('%_PYTHON%') DO (
-  SET PYTHONHOME=%%~dpa
-  SET _PYTHONEXE=%%~nxa
-  SET _PYTHON="%%~dpa%%~nxa"
+set _PYTHONEXE=
+for /f "usebackq tokens=*" %%a in ('%_PYTHON%') do (
+  set PYTHONHOME=%%~dpa
+  set _PYTHONEXE=%%~nxa
+  set _PYTHON="%%~dpa%%~nxa"
 )
 
-REM add Python home to PATH when needed
+REM add Python home to PATH if necessary to avoid using the wrong Python executable
 setlocal enabledelayedexpansion
 set _PYTHON_FOUND=
 for %%i in (%_PYTHONEXE%) do (
   set _PYTHON_FOUND="%%~$PATH:i"
 )
 
+REM delayed expansion is needed since there could be special characters in the PATH variable
 if not "!_PYTHON_FOUND!" == "!_PYTHON!" (
   set PATH=%PYTHONHOME%;%PYTHONHOME%Scripts;!PATH!
 )

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -17,10 +17,10 @@ REM set the Python executable
 set _PYTHON="@PYTHON_EXECUTABLE@"
 
 REM compute Python home and normalize Python executable path
-set _PYTHONHOME=
+set PYTHONHOME=
 SET _PYTHONEXE=
 FOR /f "usebackq tokens=*" %%a IN ('%_PYTHON%') DO (
-  SET _PYTHONHOME=%%~dpa
+  SET PYTHONHOME=%%~dpa
   SET _PYTHONEXE=%%~nxa
   SET _PYTHON="%%~dpa%%~nxa"
 )
@@ -33,7 +33,7 @@ for %%i in (%_PYTHONEXE%) do (
 )
 
 if not "!_PYTHON_FOUND!" == "!_PYTHON!" (
-  set PATH=%_PYTHONHOME%;%_PYTHONHOME%Scripts;!PATH!
+  set PATH=%PYTHONHOME%;%PYTHONHOME%Scripts;!PATH!
 )
 endlocal & set PATH=%PATH%
 
@@ -88,7 +88,6 @@ REM unset temporary variables
 set _SETUP_UTIL=
 set _PYTHON=
 set _PYTHONEXE=
-set _PYTHONHOME=
 set _PYTHON_FOUND=
 set _SETUP_TMP=
 set _CATKIN_ENVIRONMENT_HOOKS_COUNT=


### PR DESCRIPTION
thanks to the community's interest in the project and trying out ROS on Windows changes (thanks!), one (minor) issue that has been reported is that when there is existing Python on the build machine, it could be tricky to find and use the desired python version/path.

To address this, update `setup.bat` template to check for the desired python path and add that into the `PATH` variable