### PR TITLE
update windows.cmake to fix common build issues on Windows

### DIFF
--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -60,4 +60,9 @@ if(WIN32)
   add_definitions(-DNOMINMAX)   # not to define min/max macros
   add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
   add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)
+  add_definitions(-D_USE_MATH_DEFINES)  # enable Math Constants https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+endif()
+
+if(MSVC)
+  add_compile_options(/Zc:__cplusplus) # https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/
 endif()

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -41,9 +41,10 @@ if(BUILD_SHARED_LIBS)
   if(WIN32)
     function(add_library library)
       # Check if its an external, imported library (e.g. boost libs via cmake module definition)
-      list(FIND ARGN "IMPORTED" FIND_POS)
+      list(FIND ARGN "IMPORTED" FIND_IMPORTED)
+      list(FIND ARGN "ALIAS" FIND_ALIAS)
       _add_library(${ARGV0} ${ARGN})
-      if(${FIND_POS} EQUAL -1)
+      if(${FIND_IMPORTED} EQUAL -1 AND ${FIND_ALIAS} EQUAL -1)
         set_target_properties(${ARGV0} 
           PROPERTIES 
               RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -55,7 +55,8 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
-# For MSVC, add difinitions to exclude the definitions for common names macros that cause name collision
-if(MSVC)
+# For Windows, add difinitions to exclude the definitions for common names macros that cause name collision
+if(WIN32)
   add_definitions(-DNOMINMAX)   # not to define min/max macros
+  add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
 endif()

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -56,6 +56,16 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
+# Add this as a remediation since not every project has implemented import/export macros.
+#   https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
+# It is still encouraged to follow this guide to make the code cross-platform:
+#   http://wiki.ros.org/win_ros/Contributing/Dll%20Exports
+if(BUILD_SHARED_LIBS)
+  if(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
+endif()
+
 # For Windows, add difinitions to exclude the definitions for common names macros that cause name collision
 if(WIN32)
   add_definitions(-DWIN32_LEAN_AND_MEAN) # keep minimum windows headers inclusion

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -54,3 +54,8 @@ if(BUILD_SHARED_LIBS)
     endfunction()
   endif()
 endif()
+
+# For MSVC, add difinitions to exclude the definitions for common names macros that cause name collision
+if(MSVC)
+  add_definitions(-DNOMINMAX)   # not to define min/max macros
+endif()

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -66,7 +66,7 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
-# For Windows, add difinitions to exclude definitions for common names macros that cause name collision
+# For Windows, add definitions to exclude defining common names macros that cause name collision
 if(WIN32)
   # enable Math Constants (https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants)
   add_definitions(-D_USE_MATH_DEFINES)

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -57,6 +57,7 @@ endif()
 
 # For Windows, add difinitions to exclude the definitions for common names macros that cause name collision
 if(WIN32)
+  add_definitions(-DWIN32_LEAN_AND_MEAN) # keep minimum windows headers inclusion
   add_definitions(-DNOMINMAX)   # not to define min/max macros
   add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
   add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -59,4 +59,5 @@ endif()
 if(WIN32)
   add_definitions(-DNOMINMAX)   # not to define min/max macros
   add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
+  add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)
 endif()

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -56,25 +56,35 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
-# Add this as a remediation since not every project has implemented import/export macros.
-#   https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
-# It is still encouraged to follow this guide to make the code cross-platform:
+# It is encouraged to follow this guide to enable exports for dll's in a cross-platform way:
 #   http://wiki.ros.org/win_ros/Contributing/Dll%20Exports
+# however, since not every project has implemented import/export macros, enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS as a workaround
+#   https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
 if(BUILD_SHARED_LIBS)
   if(WIN32)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
   endif()
 endif()
 
-# For Windows, add difinitions to exclude the definitions for common names macros that cause name collision
+# For Windows, add difinitions to exclude definitions for common names macros that cause name collision
 if(WIN32)
-  add_definitions(-DWIN32_LEAN_AND_MEAN) # keep minimum windows headers inclusion
-  add_definitions(-DNOMINMAX)   # not to define min/max macros
-  add_definitions(-DNO_STRICT)  # not to define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
-  add_definitions(-DQ_NOWINSTRICT)  # not to define STRICT macros (qtgui\qwindowdefs_win.h)
-  add_definitions(-D_USE_MATH_DEFINES)  # enable Math Constants https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+  # enable Math Constants (https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants)
+  add_definitions(-D_USE_MATH_DEFINES)
+
+  # do not define STRICT macros (minwindef.h or boost\winapi\basic_types.hpp)
+  add_definitions(-DNO_STRICT)
+
+  # do not define min/max macros
+  add_definitions(-DNOMINMAX)
+
+  # do not define STRICT macros (qtgui\qwindowdefs_win.h)
+  add_definitions(-DQ_NOWINSTRICT)
+
+  # keep minimum windows headers inclusion
+  add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif()
 
 if(MSVC)
-  add_compile_options(/Zc:__cplusplus) # https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/
+  # https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/
+  add_compile_options(/Zc:__cplusplus)
 endif()


### PR DESCRIPTION
while building on Windows, it's not uncommon to encounter various platform-specific issues and compiler-specific issues (if using visual c++ compiler, MSVC).

For the debug flags and compiler options, a lot of these issues are already known to the community, and most of them could be resolved with existing good practices:
- `-DNOMINMAX` helps avoid collision with `std::min`/`std::max` if there's `windows.h`/`windef.h`
- `-DNO_STRICT` (and `-DQ_NOWINSTRICT` for QT) disables STRICT type checking
- `-D_USE_MATH_DEFINES` allows using Math Constants since they are not defined in Standard C/C++
- `-DWIN32_LEAN_AND_MEAN` excludes various APIs from windows.h to improve build time since basic inclusion would be enough