### PR TITLE
generate CTest and dart config to avoid warnings

### DIFF
--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -49,6 +49,17 @@ if(NOT CATKIN_BUILD_BINARY_PACKAGE)
   if(NOT ROSBUILD_init_called)
     message(STATUS "Call enable_testing()")
     enable_testing()
+    if(DEFINED CATKIN_ENABLE_TESTING)
+      # configure CTest not to truncate the dashboard summary
+      file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.cmake"
+        "set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 0)\n"
+        "set(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 0)\n")
+      # create dart configuration from template
+      site_name(SITE)
+      configure_file(
+        ${CMAKE_ROOT}/Modules/DartConfiguration.tcl.in
+        ${PROJECT_BINARY_DIR}/CTestConfiguration.ini)
+    endif()
   else()
     message(STATUS "Skip enable_testing() for dry packages")
   endif()


### PR DESCRIPTION
Similar to ament/ament_cmake#153.