### PR TITLE
[doc] Recommend PACKAGE, not GLOBAL, in user's doc.

### DIFF
--- a/doc/howto/format1/building_libraries.rst
+++ b/doc/howto/format1/building_libraries.rst
@@ -82,7 +82,7 @@ library build target names for ``your_library``::
   install(TARGETS your_library
           ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
           LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-          RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+          RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 The runtime destination is used for `.dll` file on Windows which must
 be placed in the global bin folder.

--- a/doc/howto/format2/building_libraries.rst
+++ b/doc/howto/format2/building_libraries.rst
@@ -101,7 +101,7 @@ library build targets::
   install(TARGETS your_library your_other_library
           ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
           LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-          RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+          RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 The runtime destination is used for `.dll` file on Windows which must
 be placed in the global bin folder.


### PR DESCRIPTION
Installing executable into `CATKIN_GLOBAL_BIN_DESTINATION` makes it globally accesible. While it's certainly nice, I'm not sure if that's what Catkin's documentation that generally recommends installing into each package space should do. It makes sense for e.g. ROS core packages, but not so much for users' package IMO.

Although I found an old related thread https://github.com/ros/catkin/issues/410#issuecomment-17312357, I'm not sure if that was where the decision to use global space was made.