### PR TITLE
add local_setup files

### DIFF
--- a/cmake/catkin_generate_environment.cmake
+++ b/cmake/catkin_generate_environment.cmake
@@ -52,6 +52,9 @@ function(catkin_generate_environment)
       atomic_configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.in
         ${CATKIN_DEVEL_PREFIX}/setup.${shell}
         @ONLY)
+      atomic_configure_file(${catkin_EXTRAS_DIR}/templates/local_setup.${shell}.in
+        ${CATKIN_DEVEL_PREFIX}/local_setup.${shell}
+        @ONLY)
     endforeach()
 
   else()
@@ -63,6 +66,9 @@ function(catkin_generate_environment)
     # generate setup
     atomic_configure_file(${catkin_EXTRAS_DIR}/templates/setup.bat.in
       ${CATKIN_DEVEL_PREFIX}/setup.bat
+      @ONLY)
+    atomic_configure_file(${catkin_EXTRAS_DIR}/templates/local_setup.bat.in
+      ${CATKIN_DEVEL_PREFIX}/local_setup.bat
       @ONLY)
   endif()
 
@@ -109,9 +115,13 @@ function(catkin_generate_environment)
       configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.in
         ${CMAKE_BINARY_DIR}/catkin_generated/installspace/setup.${shell}
         @ONLY)
+      configure_file(${catkin_EXTRAS_DIR}/templates/local_setup.${shell}.in
+        ${CMAKE_BINARY_DIR}/catkin_generated/installspace/local_setup.${shell}
+        @ONLY)
       if(CATKIN_INSTALL_INTO_PREFIX_ROOT)
         install(FILES
           ${CMAKE_BINARY_DIR}/catkin_generated/installspace/setup.${shell}
+          ${CMAKE_BINARY_DIR}/catkin_generated/installspace/local_setup.${shell}
           DESTINATION ${CMAKE_INSTALL_PREFIX})
       endif()
     endforeach()
@@ -129,8 +139,12 @@ function(catkin_generate_environment)
     configure_file(${catkin_EXTRAS_DIR}/templates/setup.bat.in
       ${CMAKE_BINARY_DIR}/catkin_generated/installspace/setup.bat
       @ONLY)
+    configure_file(${catkin_EXTRAS_DIR}/templates/local_setup.bat.in
+      ${CMAKE_BINARY_DIR}/catkin_generated/installspace/local_setup.bat
+      @ONLY)
     install(FILES
       ${CMAKE_BINARY_DIR}/catkin_generated/installspace/setup.bat
+      ${CMAKE_BINARY_DIR}/catkin_generated/installspace/local_setup.bat
       DESTINATION ${CMAKE_INSTALL_PREFIX})
   endif()
 

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -250,6 +250,7 @@ def find_env_hooks(environ, cmake_prefix_path):
 def _parse_arguments(args=None):
     parser = argparse.ArgumentParser(description='Generates code blocks for the setup.SHELL script.')
     parser.add_argument('--extend', action='store_true', help='Skip unsetting previous environment variables to extend context')
+    parser.add_argument('--local', action='store_true', help='Only consider this prefix path and ignore other prefix path in the environment')
     return parser.parse_known_args(args=args)[0]
 
 
@@ -261,8 +262,12 @@ if __name__ == '__main__':
             print(e, file=sys.stderr)
             sys.exit(1)
 
-        # environment at generation time
-        CMAKE_PREFIX_PATH = '@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
+        if not args.local:
+            # environment at generation time
+            CMAKE_PREFIX_PATH = '@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
+        else:
+            # don't consider any other prefix path than this one
+            CMAKE_PREFIX_PATH = []
         # prepend current workspace if not already part of CPP
         base_path = os.path.dirname(__file__)
         # CMAKE_PREFIX_PATH uses forward slash on all platforms, but __file__ is platform dependent

--- a/cmake/templates/local_setup.bash.in
+++ b/cmake/templates/local_setup.bash.in
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# generated from catkin/cmake/templates/local_setup.bash.in
+
+CATKIN_SHELL=bash
+
+# source setup.sh from same directory as this file
+_CATKIN_SETUP_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)
+. "$_CATKIN_SETUP_DIR/setup.sh" --extend --local

--- a/cmake/templates/local_setup.bat.in
+++ b/cmake/templates/local_setup.bat.in
@@ -1,0 +1,6 @@
+@echo off
+REM generated from catkin/cmake/template/local_setup.bat.in
+
+set _CATKIN_SETUP_DIR=@SETUP_DIR@
+call %_CATKIN_SETUP_DIR%/setup.sh --extend --local
+set _CATKIN_SETUP_DIR=

--- a/cmake/templates/local_setup.sh.in
+++ b/cmake/templates/local_setup.sh.in
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# generated from catkin/cmake/template/local_setup.sh.in
+
+# since this file is sourced either use the provided _CATKIN_SETUP_DIR
+# or fall back to the destination set at configure time
+: ${_CATKIN_SETUP_DIR:=@SETUP_DIR@}
+CATKIN_SETUP_UTIL_ARGS="--extend --local"
+. "$_CATKIN_SETUP_DIR/setup.sh"
+unset CATKIN_SETUP_UTIL_ARGS

--- a/cmake/templates/local_setup.zsh.in
+++ b/cmake/templates/local_setup.zsh.in
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+# generated from catkin/cmake/templates/local_setup.zsh.in
+
+CATKIN_SHELL=zsh
+
+# source setup.sh from same directory as this file
+_CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)
+emulate -R zsh -c 'source "$_CATKIN_SETUP_DIR/setup.sh" --extend --local'

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -5,6 +5,7 @@ REM Sets various environment variables and sources additional environment hooks.
 REM It tries it's best to undo changes from a previously sourced setup file before.
 REM Supported command line options:
 REM --extend: skips the undoing of changes from a previously sourced setup file
+REM --local: only considers this workspace but not the chained ones
 
 set _SETUP_UTIL=@SETUP_DIR@/_setup_util.py
 

--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -5,8 +5,9 @@
 # It tries it's best to undo changes from a previously sourced setup file before.
 # Supported command line options:
 # --extend: skips the undoing of changes from a previously sourced setup file
-#   (in plain sh shell which does't support arguments for sourced scripts you
-#   can set the environment variable `CATKIN_SETUP_UTIL_ARGS=--extend` instead)
+# --local: only considers this workspace but not the chained ones
+# In plain sh shell which doesn't support arguments for sourced scripts you can
+# set the environment variable `CATKIN_SETUP_UTIL_ARGS=--extend/--local` instead.
 
 # since this file is sourced either use the provided _CATKIN_SETUP_DIR
 # or fall back to the destination set at configure time


### PR DESCRIPTION
The existing setup files extend the environment with paths of the workspace they are located in as well as all chained workspaces. The newly added local setup files only extend the environment with paths of a single workspace. This enables the user to specifically select which workspaces to source - independently on how they have been chained during the build.