### PR TITLE
Ignore _CATKIN_SETUP_DIR in devel_isolated setup scripts

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1101,7 +1101,7 @@ call "{0}/setup.{1}"
 #!/usr/bin/env {1}
 # generated from catkin.builder Python module
 
-. "{0}/setup.{1}"
+_CATKIN_SETUP_DIR= . "{0}/setup.{1}"
 """
 
         generated_env_sh = os.path.join(develspace, env_script)


### PR DESCRIPTION
Due to the chaining of the setup scripts, the `_CATKIN_SETUP_DIR` variable doesn't act the same in `devel_isolated` as it does in `install_isolated` or non-isolated `devel` space.

We could feasibly make it act in the same way, but since `devel_isolated` isn't relocatable to begin with, it would have no benefit.

Needed by https://github.com/ros-infrastructure/ros_buildfarm/pull/607