### PR TITLE
Make devel_isolated scripts relocatable

### DIFF
--- a/cmake/templates/relay_env.bat.in
+++ b/cmake/templates/relay_env.bat.in
@@ -1,0 +1,4 @@
+@echo off
+REM generated from catkin.builder Python module
+
+call @SETUP_DIR@/@PACKAGE_NAME@/env.bat %*

--- a/cmake/templates/relay_env.sh.in
+++ b/cmake/templates/relay_env.sh.in
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# generated from catkin.builder Python module
+
+: ${_CATKIN_SETUP_DIR:=@SETUP_DIR@}
+$_CATKIN_SETUP_DIR/@PACKAGE_NAME@/env.sh "$@"

--- a/cmake/templates/relay_setup.bash.in
+++ b/cmake/templates/relay_setup.bash.in
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# generated from catkin/cmake/templates/relay_setup.bash.in
+
+_CATKIN_SETUP_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)/@PACKAGE_NAME@
+. "$_CATKIN_SETUP_DIR/@SETUP_FILENAME@.bash"

--- a/cmake/templates/relay_setup.bat.in
+++ b/cmake/templates/relay_setup.bat.in
@@ -1,0 +1,4 @@
+@echo off
+REM generated from catkin/cmake/templates/relay_setup.bat.in
+
+call "@SETUP_DIR@/@PACKAGE_NAME@/@SETUP_FILENAME@.bat"

--- a/cmake/templates/relay_setup.sh.in
+++ b/cmake/templates/relay_setup.sh.in
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# generated from catkin/cmake/templates/relay_setup.sh.in
+
+: ${_CATKIN_SETUP_DIR:=@SETUP_DIR@}
+_CATKIN_SETUP_DIR=$_CATKIN_SETUP_DIR/@PACKAGE_NAME@
+. "$_CATKIN_SETUP_DIR/@SETUP_FILENAME@.sh"

--- a/cmake/templates/relay_setup.zsh.in
+++ b/cmake/templates/relay_setup.zsh.in
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+# generated from catkin/cmake/templates/relay_setup.zsh.in
+
+_CATKIN_SETUP_DIR=$(builtin cd -q "`dirname "$0"`" > /dev/null && pwd)/@PACKAGE_NAME@
+. "$_CATKIN_SETUP_DIR/@SETUP_FILENAME@.zsh"


### PR DESCRIPTION
The bash/sh/zsh scripts in a typical install or devel space can be relocated to a different path and sourced from the new location. This change also makes that possible for devel_isolated spaces, which relay to one of the packages within the space.

Supersedes #995