### PR TITLE
Fix setup.sh/env.sh filename

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -655,7 +655,7 @@ def build_cmake_package(
         make_install_cmd = [last_env] + make_install_cmd
     run_command(make_install_cmd, build_dir, quiet)
 
-    env_script = 'env' + '.bat' if sys.platform == 'win32' else '.sh'
+    env_script = 'env' + ('.bat' if sys.platform == 'win32' else '.sh')
     # If an env script already exists, don't overwrite it
     if install and os.path.exists(prefix_destdir(os.path.join(install_target, env_script), destdir)):
         return
@@ -677,7 +677,7 @@ def build_cmake_package(
 
     # Generate setup script for chaining to catkin packages
     # except if using --merge which implies that new_setup_path equals last_setup_env
-    setup_script = 'setup' + '.bat' if sys.platform == 'win32' else '.sh'
+    setup_script = 'setup' + ('.bat' if sys.platform == 'win32' else '.sh')
     new_setup_path = os.path.join(install_target, setup_script)
     if install:
         new_setup_path = prefix_destdir(new_setup_path, destdir)


### PR DESCRIPTION
Filenames `setup.sh` and `env.sh` get `.sh` after https://github.com/ros/catkin/pull/982.
This seems to cause test failures of pure cmake packages on the buildfarm.

Following builds on the buildfarm looks affected by this bug.

http://build.ros.org/view/Mdev/job/Mdev__yp-spur__ubuntu_bionic_amd64/18/console
```
02:29:23 Invoking '. /opt/ros/melodic/setup.sh && . /tmp/ws/devel_isolated/setup.sh && PYTHONIOENCODING=utf_8 PYTHONUNBUFFERED=1 catkin_make_isolated --force-cmake --cmake-args -DBUILD_TESTING=1 -DCATKIN_ENABLE_TESTING=1 -DCATKIN_SKIP_TESTING=0 -DCATKIN_TEST_RESULTS_DIR=/tmp/ws/test_results --catkin-make-args run_tests' in '/tmp/ws'
02:29:23 /bin/sh: 9: .: Can't open /tmp/ws/devel_isolated/ypspur/setup.sh
```
http://build.ros.org/view/Mdev/job/Mdev__rc_genicam_api__ubuntu_bionic_amd64/17/console
```
09:42:52 Invoking '. /opt/ros/melodic/setup.sh && . /tmp/ws/devel_isolated/setup.sh && PYTHONIOENCODING=utf_8 PYTHONUNBUFFERED=1 catkin_make_isolated --force-cmake --cmake-args -DBUILD_TESTING=1 -DCATKIN_ENABLE_TESTING=1 -DCATKIN_SKIP_TESTING=0 -DCATKIN_TEST_RESULTS_DIR=/tmp/ws/test_results --catkin-make-args run_tests' in '/tmp/ws'
09:42:52 /bin/sh: 4: .: Can't open /tmp/ws/devel_isolated/rc_genicam_api/setup.sh
```

---
Expression evaluation order of python:
```python
>>> 'a' + 'b' if True else 'c'
'ab'
>>> 'a' + 'b' if False else 'c'
'c'
```