### PR TITLE
include threads library

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -158,7 +158,7 @@ foreach(filename
     tools/libraries
     tools/rt
 
-#    tools/threads
+    tools/threads
   )
   include(${catkin_EXTRAS_DIR}/${filename}.cmake)
 endforeach()


### PR DESCRIPTION
Due to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=868234 ligtest.a is now shipped with libgtest-dev. Consequently gtest targets in catkin link against this library on newer Debian / Ubuntu versions.
For some reason, the tools/threads.cmake file was commented out in all.cmake but the variable THREADS_LIBRARY is actually used when linking against the libgtest.a (https://github.com/ros/catkin/blob/kinetic-devel/cmake/test/gtest.cmake#L177). Removing the comment fixes the linking issues for me.