### PR TITLE
[Windows][kinetic] Fix devel and install space intermixes in %PATH% after devel\setup.bat is sourced

### DIFF
--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -51,8 +51,8 @@ IS_WINDOWS = (system == 'Windows')
 
 PATH_TO_ADD_SUFFIX = ['@CATKIN_GLOBAL_BIN_DESTINATION@']
 if IS_WINDOWS:
-    # 3rdparty packages often put dll's into lib (convention is bin) and
-    # windows finds it's dll's via the PATH variable. Make that happen here!
+    # while catkin recommends putting dll's into bin, 3rd party packages often put dll's into lib
+    # since Windows finds dll's via the PATH variable, prepend it with path to lib
     PATH_TO_ADD_SUFFIX.extend([@CATKIN_LIB_ENVIRONMENT_PATHS@])
 
 # subfolder of workspace prepended to CMAKE_PREFIX_PATH

--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -49,11 +49,17 @@ system = platform.system()
 IS_DARWIN = (system == 'Darwin')
 IS_WINDOWS = (system == 'Windows')
 
+PATH_TO_ADD_SUFFIX = ['@CATKIN_GLOBAL_BIN_DESTINATION@']
+if IS_WINDOWS:
+    # 3rdparty packages often put dll's into lib (convention is bin) and
+    # windows finds it's dll's via the PATH variable. Make that happen here!
+    PATH_TO_ADD_SUFFIX.extend([@CATKIN_LIB_ENVIRONMENT_PATHS@])
+
 # subfolder of workspace prepended to CMAKE_PREFIX_PATH
 ENV_VAR_SUBFOLDERS = {
     'CMAKE_PREFIX_PATH': '',
     'LD_LIBRARY_PATH' if not IS_DARWIN else 'DYLD_LIBRARY_PATH': @CATKIN_LIB_ENVIRONMENT_PATHS@,
-    'PATH': '@CATKIN_GLOBAL_BIN_DESTINATION@',
+    'PATH': PATH_TO_ADD_SUFFIX,
     'PKG_CONFIG_PATH': @CATKIN_PKGCONFIG_ENVIRONMENT_PATHS@,
     'PYTHONPATH': '@PYTHON_INSTALL_DIR@',
 }

--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -82,10 +82,6 @@ if %_HOOK_COUNT% LSS %_CATKIN_ENVIRONMENT_HOOKS_COUNT% (
   goto :hook_loop
 )
 
-REM 3rdparty packages often put dll's into lib (convention is bin) and 
-REM windows finds it's dll's via the PATH variable. Make that happen here!
-set PATH=%LD_LIBRARY_PATH%;%PATH%
-
 REM unset temporary variables
 set _SETUP_UTIL=
 set _PYTHON=


### PR DESCRIPTION
This change is to address an issue originally reported here: https://github.com/ms-iot/ROSOnWindows/issues/69

On Windows, we observed that `%PATH%` intermixes `devel` and `install` space for `bin` and `lib`. Ideally the `devel\bin` and `devel\lib` should always come before the `install` space after `devel\setup.bat` is sourced. Otherwise, for example, at runtime, it could favor the content from `install space` over the one in `devel space` and subsequently cause unexpected problems, especially when we build\test a package both existed in `devel space` and `install space`.

This change is to propose to make sure `bin` and `lib` on Windows for `ENV_VAR_SUBFOLDERS['PATH']` in `_setup_util.py`, and then let `_setup_util.py` to prepend the workspace prefix accordingly. In this case, `_setup_util.py` can produce `%PATH%` like:
`C:\catkin_ws\devel\bin;C:\catkin_ws\devel\lib;C:\opt\ros\melodic\x64\bin;C:\opt\ros\melodic\x64\lib;...`

