### PR TITLE
[Windows][kinetic] Add catkin default parameter for Windows developers

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -19,6 +19,7 @@ from catkin.builder import handle_make_arguments
 from catkin.builder import print_command_banner
 from catkin.builder import run_command
 from catkin.builder import run_command_colorized
+from catkin.builder import build_platform_specific_defaults
 from catkin_pkg.packages import find_packages
 from catkin_pkg.tool_detection import get_previous_tool_used_on_the_space
 from catkin_pkg.tool_detection import mark_space_as_built_by
@@ -27,6 +28,7 @@ from catkin_pkg.workspaces import ensure_workspace_marker
 
 def main():
     args = _parse_args()
+    args = build_platform_specific_defaults(args)
     cmake_args = args.cmake_args
 
     # force --no-color if stdout is non-interactive

--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -28,7 +28,7 @@ from catkin_pkg.workspaces import ensure_workspace_marker
 
 def main():
     args = _parse_args()
-    args = apply_platform_specific_defaults(args)
+    apply_platform_specific_defaults(args)
     cmake_args = args.cmake_args
 
     # force --no-color if stdout is non-interactive

--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -19,7 +19,7 @@ from catkin.builder import handle_make_arguments
 from catkin.builder import print_command_banner
 from catkin.builder import run_command
 from catkin.builder import run_command_colorized
-from catkin.builder import build_platform_specific_defaults
+from catkin.builder import apply_platform_specific_defaults
 from catkin_pkg.packages import find_packages
 from catkin_pkg.tool_detection import get_previous_tool_used_on_the_space
 from catkin_pkg.tool_detection import mark_space_as_built_by
@@ -28,7 +28,7 @@ from catkin_pkg.workspaces import ensure_workspace_marker
 
 def main():
     args = _parse_args()
-    args = build_platform_specific_defaults(args)
+    args = apply_platform_specific_defaults(args)
     cmake_args = args.cmake_args
 
     # force --no-color if stdout is non-interactive

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -14,6 +14,7 @@ from catkin.builder import colorize_line
 from catkin.builder import determine_path_argument
 from catkin.builder import extract_cmake_and_make_and_catkin_make_arguments
 from catkin.builder import extract_jobs_flags
+from catkin.builder import build_platform_specific_defaults
 
 
 def parse_args(args=None):
@@ -113,6 +114,8 @@ def handle_cmake_args(cmake_args, opts):
 
 def main():
     opts = parse_args()
+    opts = build_platform_specific_defaults(opts)
+
     cmake_args, opts = handle_cmake_args(opts.cmake_args, opts)
 
     # force --no-color if stdout is non-interactive

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -115,7 +115,6 @@ def handle_cmake_args(cmake_args, opts):
 def main():
     opts = parse_args()
     apply_platform_specific_defaults(opts)
-
     cmake_args, opts = handle_cmake_args(opts.cmake_args, opts)
 
     # force --no-color if stdout is non-interactive

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -114,7 +114,7 @@ def handle_cmake_args(cmake_args, opts):
 
 def main():
     opts = parse_args()
-    opts = apply_platform_specific_defaults(opts)
+    apply_platform_specific_defaults(opts)
 
     cmake_args, opts = handle_cmake_args(opts.cmake_args, opts)
 

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -14,7 +14,7 @@ from catkin.builder import colorize_line
 from catkin.builder import determine_path_argument
 from catkin.builder import extract_cmake_and_make_and_catkin_make_arguments
 from catkin.builder import extract_jobs_flags
-from catkin.builder import build_platform_specific_defaults
+from catkin.builder import apply_platform_specific_defaults
 
 
 def parse_args(args=None):
@@ -114,7 +114,7 @@ def handle_cmake_args(cmake_args, opts):
 
 def main():
     opts = parse_args()
-    opts = build_platform_specific_defaults(opts)
+    opts = apply_platform_specific_defaults(opts)
 
     cmake_args, opts = handle_cmake_args(opts.cmake_args, opts)
 

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1221,7 +1221,7 @@ def get_package_names_with_recursive_dependencies(packages, pkg_names):
                     check_pkg_names.add(dep)
     return dependencies
 
-def build_platform_specific_defaults(args):
+def apply_platform_specific_defaults(args):
     # add Windows specific defaults
     if sys.platform == 'win32':
         # default to use nmake if on Windows and if not using ninja

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1231,4 +1231,3 @@ def apply_platform_specific_defaults(args):
         build_type_prefix = [a for a in args.cmake_args if a.startswith(prefix)]
         if not build_type_prefix:
             args.cmake_args.append('-DCMAKE_BUILD_TYPE=RelWithDebInfo')
-    return args

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1225,7 +1225,8 @@ def apply_platform_specific_defaults(args):
     # add Windows specific defaults
     if sys.platform == 'win32':
         # default to use nmake if on Windows and if not using ninja
-        if not args.use_ninja: args.use_nmake = True
+        if not args.use_ninja:
+            args.use_nmake = True
         # use RelWithDebInfo as default build type if on Windows
         prefix = '-DCMAKE_BUILD_TYPE='
         build_type_prefix = [a for a in args.cmake_args if a.startswith(prefix)]

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1230,4 +1230,4 @@ def apply_platform_specific_defaults(args):
         # use RelWithDebInfo as default build type if on Windows
         prefix = '-DCMAKE_BUILD_TYPE='
         if not any(a.startswith(prefix) for a in args.cmake_args):
-            args.cmake_args.append('-DCMAKE_BUILD_TYPE=RelWithDebInfo')
+            args.cmake_args.append(prefix + 'RelWithDebInfo')

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1229,6 +1229,5 @@ def apply_platform_specific_defaults(args):
             args.use_nmake = True
         # use RelWithDebInfo as default build type if on Windows
         prefix = '-DCMAKE_BUILD_TYPE='
-        build_type_prefix = [a for a in args.cmake_args if a.startswith(prefix)]
-        if not build_type_prefix:
+        if not any(a.startswith(prefix) for a in args.cmake_args):
             args.cmake_args.append('-DCMAKE_BUILD_TYPE=RelWithDebInfo')

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -1220,3 +1220,15 @@ def get_package_names_with_recursive_dependencies(packages, pkg_names):
                 if dep in packages_by_name and dep not in check_pkg_names and dep not in dependencies:
                     check_pkg_names.add(dep)
     return dependencies
+
+def build_platform_specific_defaults(args):
+    # add Windows specific defaults
+    if sys.platform == 'win32':
+        # default to use nmake if on Windows and if not using ninja
+        if not args.use_ninja: args.use_nmake = True
+        # use RelWithDebInfo as default build type if on Windows
+        prefix = '-DCMAKE_BUILD_TYPE='
+        build_type_prefix = [a for a in args.cmake_args if a.startswith(prefix)]
+        if not build_type_prefix:
+            args.cmake_args.append('-DCMAKE_BUILD_TYPE=RelWithDebInfo')
+    return args


### PR DESCRIPTION
This change is to make `catkin` more convenient for Windows developers to kick off a build.

* Currently the `catkin` is using `make` as the Makefile tool by default but it doesn't exist in MSVC toolchain on Windows, so Windows developers most likely need to add `--use-nmake` every time to successfully kick off  a build.

* Favor `RelWithDebInfo` over  the default `Debug`, which makes the Windows developers by default to build out portable `Release` binaries + its debug symbol files. CMake `Debug` configuration will link against the debug MSVC runtime (e.g., `vcruntime140d.dll`) which is not redistributable separately from Visual Studio.