### PR TITLE
Correctly set gtest 1.8 root directory

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -280,9 +280,12 @@ function(catkin_find_google_test_source include_path src_path
   #In googletest 1.8, gmock and gtest where merged inside googletest
   #In this case, including gmock builds gmock twice, so instead we need to include googletest
   #which will include gtest and gmock once
-  set(_global_base_dir "${src_path}/googletest")
-  if(EXISTS "${_global_base_dir}/CMakeLists.txt")
-    set(${base_dir} ${_global_base_dir} PARENT_SCOPE)
+  if(_gtest_found)
+    get_filename_component(_gtest_base_dir_realpath ${_gtest_base_dir} REALPATH)
+    get_filename_component(_global_base_dir ${_gtest_base_dir_realpath} PATH)
+    if(EXISTS "${_global_base_dir}/CMakeLists.txt")
+      set(${base_dir} ${_global_base_dir} PARENT_SCOPE)
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
In gtest version 1.8 or higher, there is a CMakeLists.txt in the
parent directory of the gtest source directory which we need to find.
This can be either /usr/src/googletest or ${CMAKE_SOURCE_DIR}/googletest.

The current version would only check in /usr/src/googletest even if
gtest was found in the project's src/ directory.

This would break the build on Ubuntu 18.04, where the system install of gmock
is version 1.8, if your project includes a newer version of gtest in its src/ directory.
The result would be that headers from src/ would be used, but the test
executables would be linked to the binaries from /usr/src.