### PR TITLE
Fix python 3 version used by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
-  - "2.7_with_system_site_packages"
-  - "3.4_with_system_site_packages"
+  - "2.7"
+  - "3.5"
+virtualenv:
+  system_site_packages: true
 # command to install dependencies
 install:
   - pip install argparse catkin-pkg empy mock nose


### PR DESCRIPTION
Travis now uses [xenial](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) as the default build environment. The CI uses system site packages, but this option only works with the default python 3 version. In xenial this version is [python 3.5](https://packages.ubuntu.com/xenial/python3).

This PR bumps the python version to 3.5, and uses `system_site_packages: true` since [that's what the travis documentation does](https://docs.travis-ci.com/user/languages/python/#travis-ci-uses-isolated-virtualenvs).