### PR TITLE
fix includedir order when overlaying with setup.bash in symlinked develspace

### DIFF
--- a/cmake/templates/setup.bash.in
+++ b/cmake/templates/setup.bash.in
@@ -4,5 +4,5 @@
 CATKIN_SHELL=bash
 
 # source setup.sh from same directory as this file
-_CATKIN_SETUP_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)
+_CATKIN_SETUP_DIR=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd -P)
 . "$_CATKIN_SETUP_DIR/setup.sh"


### PR DESCRIPTION
We have workspace with `devel` symlink to develspace dir `devel_ninja`:
```
aurzenligl@dell7510-docker:/code/work_ws$ ll /code/silo_ws/
total 4736
drwxr-xr-x  6 aurzenligl 1000    4096 Jul 22 16:37 ./
drwxrwxr-x 31 aurzenligl 1000 4771840 Jul 19 18:44 ../
-rw-r--r--  1 aurzenligl 1000      98 Jul 16 20:31 .catkin_workspace
drwxr-xr-x 18 aurzenligl 1000    4096 Jul 22 16:38 build_ninja/
lrwxrwxrwx  1 aurzenligl 1000      12 Jul 16 20:41 devel -> devel_ninja//
drwxr-xr-x  5 aurzenligl 1000    4096 Jul 22 21:04 devel_ninja/
drwxr-xr-x 13 aurzenligl 1000    4096 Jul 22 16:32 src/
```

When sourcing `setup.bash` script via `devel` symlink, we get symlink path prepended to CMAKE_PREFIX_PATH instead of actual develspace dir:
```
aurzenligl@dell7510-docker:/code/work_ws$ (. /code/silo_ws/devel/setup.bash && env | grep CMAKE_PREFIX_PATH)
CMAKE_PREFIX_PATH=/code/silo_ws/devel:/code/hardware_ws/devel:/code/ext_ws/devel:/opt/ros/kinetic
```

This results in incorrect sorting of workspace dirs by `/opt/ros/*/share/catkin/cmake/order_paths.py` script, for example:
```
aurzenligl@dell7510-docker:/code/work_ws$ /code/work_ws/build_ninja/catkin_generated/env_cached.sh /usr/bin/python /opt/ros/kinetic/share/catkin/cmake/order_paths.py /code/work_ws/build_ninja/foo/catkin_generated/ordered_paths.cmake --paths-to-order /code/silo_ws/devel_ninja/include /opt/ros/kinetic/include /usr/include --prefixes /code/work_ws/devel_ninja /code/work_ws/src /code/silo_ws/devel /code/silo_ws/src /code/hardware_ws/devel /code/hardware_ws/src /code/ext_ws/devel /code/ext_ws/src /opt/ros/kinetic && cat /code/work_ws/build_ninja/foo/catkin_generated/ordered_paths.cmake && echo
set(ORDERED_PATHS "/opt/ros/kinetic/include;/code/silo_ws/devel_ninja/include;/usr/include")
```

Obviously, doing so will cause message headers of rospackage `foo` in `/code/silo_ws/devel_ninja/include` to have lower priority than those in `/opt/ros/kinetic/include`.

This fix resolves the symlink in `setup.bash`, which sets `_CATKIN_SETUP_DIR`, that `setup.sh` reuses.
```
aurzenligl@dell7510-docker:/code/work_ws$ (. /code/silo_ws/devel/setup.bash && env | grep CMAKE_PREFIX_PATH)CMAKE_PREFIX_PATH=/code/silo_ws/devel_ninja:/code/hardware_ws/devel:/code/ext_ws/devel:/opt/ros/kinetic
```