### PR TITLE
prefix install target with project name

### DIFF
--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -50,7 +50,8 @@ function(catkin_install_python signature)
 
       get_filename_component(name "${file}" NAME)
       add_python_executable(SCRIPT_NAME ${name}
-        TARGET_NAME ${name}_executable_install_python
+        # add project name as prefix (set in the most recent project() call)
+        TARGET_NAME ${PROJECT_NAME}_${name}_exec_install_python
         DESTINATION "${ARG_DESTINATION}")
     elseif(NOT ARG_OPTIONAL)
       message(FATAL_ERROR "catkin_install_python() called with non-existing file '${file}'.")

--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -50,7 +50,7 @@ function(catkin_install_python signature)
 
       get_filename_component(name "${file}" NAME)
       add_python_executable(SCRIPT_NAME ${name}
-        # add project name as prefix (set in the most recent project() call)
+        # prefix with project name to avoid collisions across packages
         TARGET_NAME ${PROJECT_NAME}_${name}_exec_install_python
         DESTINATION "${ARG_DESTINATION}")
     elseif(NOT ARG_OPTIONAL)

--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -154,11 +154,13 @@ function(catkin_python_setup)
       @ONLY)
 
     add_python_executable(SCRIPT_NAME ${name}
-      TARGET_NAME ${name}_executable_devel
+      # add project name as prefix (set in the most recent project() call)
+      TARGET_NAME ${PROJECT_NAME}_${name}_exec_devel
       DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION})
 
     add_python_executable(SCRIPT_NAME ${name}
-      TARGET_NAME ${name}_executable_install
+      # add project name as prefix (set in the most recent project() call)
+      TARGET_NAME ${PROJECT_NAME}_${name}_exec_install
       DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
   endforeach()
 endfunction()

--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -154,12 +154,12 @@ function(catkin_python_setup)
       @ONLY)
 
     add_python_executable(SCRIPT_NAME ${name}
-      # add project name as prefix (set in the most recent project() call)
+      # prefix with project name to avoid collisions across packages
       TARGET_NAME ${PROJECT_NAME}_${name}_exec_devel
       DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION})
 
     add_python_executable(SCRIPT_NAME ${name}
-      # add project name as prefix (set in the most recent project() call)
+      # prefix with project name to avoid collisions across packages
       TARGET_NAME ${PROJECT_NAME}_${name}_exec_install
       DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
   endforeach()


### PR DESCRIPTION
`catkin_make` for [rosserial](https://github.com/ros-drivers/rosserial) fails to build with the current Windows wrapper implementation:

```
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 13 packages in topological order:
-- ~~  - rosserial (metapackage)
-- ~~  - rosserial_arduino
-- ~~  - rosserial_mbed
-- ~~  - rosserial_msgs
-- ~~  - rosserial_python
-- ~~  - rosserial_tivac
-- ~~  - rosserial_vex_cortex
-- ~~  - rosserial_xbee
-- ~~  - rosserial_client
-- ~~  - rosserial_server
-- ~~  - rosserial_embeddedlinux
-- ~~  - rosserial_test
-- ~~  - rosserial_windows
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin metapackage: 'rosserial'
-- ==> add_subdirectory(rosserial/rosserial)
-- +++ processing catkin package: 'rosserial_arduino'
-- ==> add_subdirectory(rosserial/rosserial_arduino)
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- rosserial_arduino: 1 messages, 1 services
-- +++ processing catkin package: 'rosserial_mbed'
-- ==> add_subdirectory(rosserial/rosserial_mbed)
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- rosserial_mbed: 1 messages, 1 services
CMake Error at catkin/cmake/platform/windows.cmake:140 (add_executable):
  add_executable cannot create target
  "make_libraries.py_executable_install_python" because another target with
  the same name already exists.  The existing target is an executable created
  in source directory
  "C:/ros/catkin_ws/dev_catkin_make/src/rosserial/rosserial_arduino".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  catkin/cmake/catkin_install_python.cmake:52 (add_python_executable)
  rosserial/rosserial_mbed/CMakeLists.txt:27 (catkin_install_python)
```

this issue exists because `catkin_make` treats the entire workspace as a single project (all projects as subfolders), and so the Windows wrapper for `_setup_util.py` gets redefined for multiple times, leading to name collision. Since this leads to a fatal error message, it would terminate the build and break the entire building experience

while `catkin_make` is gradually getting retired, this change would still be needed as maintenance for existing CLI interface. Meantime, pre-pending with `${PROJECT_NAME}` would not cause any trouble for the `catkin_make_isolated` usage

related issue: https://github.com/ms-iot/ROSOnWindows/issues/94
related ros.answers discussion: https://answers.ros.org/question/320613/catkin_make-vs-catkin_make_isolated-which-is-preferred/