### PR TITLE
fix catkin_make on Windows

### DIFF
--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -87,7 +87,7 @@ def init_workspace(workspace_dir):
     # look in to-be-initialized workspace first
     src = os.path.join(workspace_dir, 'catkin', 'cmake', 'toplevel.cmake')
     if os.path.isfile(src):
-        src_file_path = os.path.relpath(src, workspace_dir)
+        src_file_path = src
     else:
         checked.append(src)
 

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -60,12 +60,12 @@ def _fine_toplevel_cmake_in_current_workspace(workspace_dir):
     if os.path.isfile(src):
         if sys.platform.startswith('win32'):
             # use absolute path on Windows due to lack of support for os.symlink
-            src_file_path = src
+            return (src, checked)
         else:
-            src_file_path = os.path.relpath(src, workspace_dir)
+            return (os.path.relpath(src, workspace_dir), checked)
     else:
         checked.append(src)
-    return (src_file_path, checked)
+    return (None, checked)
 
 
 def _find_toplevel_cmake_in_workspaces():

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -52,6 +52,49 @@ def _symlink_or_copy(src, dst):
             raise RuntimeError('Could neither symlink nor copy file "%s" to "%s":\n- %s\n- %s' % (src, dst, str(ex_symlink), str(ex_copy)))
 
 
+def _find_toplevel_cmake_in_workspaces():
+    checked = []
+
+    workspaces = get_workspaces()
+    for workspace in workspaces:
+        source_paths = get_source_paths(workspace)
+        if len(source_paths) == 0:
+            # try from install space
+            src = os.path.join(workspace, 'catkin', 'cmake', 'toplevel.cmake')
+            if os.path.isfile(src):
+                return (src, checked)
+            else:
+                checked.append(src)
+        else:
+            # try from all source spaces
+            for source_path in source_paths:
+                src = os.path.join(source_path, 'catkin', 'cmake', 'toplevel.cmake')
+                if os.path.isfile(src):
+                    return (src, checked)
+                else:
+                    checked.append(src)
+    return (None, checked)
+
+
+def _find_toplevel_cmake_in_relative_locations():
+    checked = []
+
+    relative_cmake_paths = []
+    # when catkin is in source space
+    relative_cmake_paths.append(os.path.join('..', '..', 'cmake'))
+    # when catkin is installed (with Python code in lib/pythonX.Y/[dist|site]-packages)
+    relative_cmake_paths.append(os.path.join('..', '..', '..', '..', 'share', 'catkin', 'cmake'))
+    # when catkin is installed (with Python code in lib/site-packages)
+    relative_cmake_paths.append(os.path.join('..', '..', '..', 'share', 'catkin', 'cmake'))
+    for relative_cmake_path in relative_cmake_paths:
+        src = os.path.abspath(os.path.join(os.path.dirname(__file__), relative_cmake_path, 'toplevel.cmake'))
+        if os.path.isfile(src):
+            return (src, checked)
+        else:
+            checked.append(src)
+    return (None, checked)
+
+
 def init_workspace(workspace_dir):
     """
     Create a toplevel CMakeLists.txt in the root of a workspace.
@@ -87,49 +130,20 @@ def init_workspace(workspace_dir):
     # look in to-be-initialized workspace first
     src = os.path.join(workspace_dir, 'catkin', 'cmake', 'toplevel.cmake')
     if os.path.isfile(src):
-        src_file_path = src
+        # src_file_path = src
+        src_file_path = os.path.relpath(src, workspace_dir)
     else:
         checked.append(src)
 
     # search for toplevel file in all workspaces
     if src_file_path is None:
-        workspaces = get_workspaces()
-        for workspace in workspaces:
-            source_paths = get_source_paths(workspace)
-            if len(source_paths) == 0:
-                # try from install space
-                src = os.path.join(workspace, 'catkin', 'cmake', 'toplevel.cmake')
-                if os.path.isfile(src):
-                    src_file_path = src
-                    break
-                else:
-                    checked.append(src)
-            else:
-                # try from all source spaces
-                for source_path in source_paths:
-                    src = os.path.join(source_path, 'catkin', 'cmake', 'toplevel.cmake')
-                    if os.path.isfile(src):
-                        src_file_path = src
-                        break
-                    else:
-                        checked.append(src)
+        src_file_path, _checked = _find_toplevel_cmake_in_workspaces()
+        checked += _checked
 
     # search for toplevel file in relative locations
     if src_file_path is None:
-        relative_cmake_paths = []
-        # when catkin is in source space
-        relative_cmake_paths.append(os.path.join('..', '..', 'cmake'))
-        # when catkin is installed (with Python code in lib/pythonX.Y/[dist|site]-packages)
-        relative_cmake_paths.append(os.path.join('..', '..', '..', '..', 'share', 'catkin', 'cmake'))
-        # when catkin is installed (with Python code in lib/site-packages)
-        relative_cmake_paths.append(os.path.join('..', '..', '..', 'share', 'catkin', 'cmake'))
-        for relative_cmake_path in relative_cmake_paths:
-            src = os.path.abspath(os.path.join(os.path.dirname(__file__), relative_cmake_path, 'toplevel.cmake'))
-            if os.path.isfile(src):
-                src_file_path = src
-                break
-            else:
-                checked.append(src)
+        src_file_path, _checked = _find_toplevel_cmake_in_relative_locations()
+        checked += _checked
 
     if src_file_path is None:
         raise RuntimeError('Could neither find file "toplevel.cmake" in any workspace nor relative, checked the following paths:\n%s' % ('\n'.join(checked)))

--- a/python/catkin/init_workspace.py
+++ b/python/catkin/init_workspace.py
@@ -88,7 +88,7 @@ def init_workspace(workspace_dir):
     # look in to-be-initialized workspace first
     src = os.path.join(workspace_dir, 'catkin', 'cmake', 'toplevel.cmake')
     if os.path.isfile(src):
-        if sys.platform.startswith('win32'):
+        if sys.platform == 'win32':
             # use absolute path on Windows due to lack of support for os.symlink
             src_file_path = src
         else:


### PR DESCRIPTION
on Windows, `catkin_make` fails without executing `catkin_init_workspace` first for a workspace that contains `catkin`:

```
src
  |- catkin
  |- pkg1
  |- ...
```

When the workspace is built for the first time, there is no top-level `CMakeLists.txt` under `src`, so `catkin` would attempt to find and copy from an existing source. When `catkin` is also in the workspace, `init_workspace.py` goes to https://github.com/ros/catkin/blob/kinetic-devel/python/catkin/init_workspace.py#L88, and by calling

```python
src_file_path = os.path.relpath(src, workspace_dir)
```

the source path is assigned to this relative path: `catkin/cmake/toplevel.cmake`. This works with `os.symlink()`; however, since `os.symlink()` is not available on Windows, `_symlink_or_copy()` would instead attempt to copy from `catkin/cmake/toplevel.cmake`. Since `catkin_make` is usally called from a level higher, this would fail since the relative path points to nowhere.

Changing to use absolute path on Windows to ensure proper copying.