### PR TITLE
remove executable bit and shebang line

### DIFF
--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.

--- a/cmake/order_paths.py
+++ b/cmake/order_paths.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 from argparse import ArgumentParser

--- a/cmake/parse_package_xml.py
+++ b/cmake/parse_package_xml.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.

--- a/cmake/test/download_checkmd5.py
+++ b/cmake/test/download_checkmd5.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 import errno
 import os

--- a/cmake/test/remove_test_results.py
+++ b/cmake/test/remove_test_results.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 import argparse

--- a/cmake/test/run_tests.py
+++ b/cmake/test/run_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
All scripts are invoked with a specific Python interpreter before the script name, e.g. https://github.com/ros/catkin/blob/4a7310348298089837f70c434788cdb83928ccbb/cmake/catkin_python_setup.cmake#L62-L63