### PR TITLE
change relay script to use current Python executable

### DIFF
--- a/cmake/templates/script.py.in
+++ b/cmake/templates/script.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON_EXECUTABLE@
 # -*- coding: utf-8 -*-
 # generated from catkin/cmake/template/script.py.in
 # creates a relay to a python script source file, acting as that file.


### PR DESCRIPTION
Instead of a hard coded `/usr/bin/env python`. That matches the same behavior of `setuptools` which updates the shebang line with the Python interpreter used to install a Python package.