### PR TITLE
use condition attributes to specify Python 2 and 3 dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>catkin</name>
   <version>0.7.18</version>
   <description>Low-level build system macros and infrastructure for ROS.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://www.ros.org/wiki/catkin</url>
+  <url type="website">http://wiki.ros.org/catkin</url>
   <url type="bugtracker">https://github.com/ros/catkin/issues</url>
   <url type="repository">https://github.com/ros/catkin</url>
 
@@ -15,21 +18,24 @@
   <author>Brian Gerkey</author>
   <author>Dirk Thomas</author>
 
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-argparse</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2" version_gt="0.4.3">python-catkin-pkg</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3" version_gt="0.4.3">python3-catkin-pkg</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-empy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-empy</depend>
+
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_export_depend>cmake</buildtool_export_depend>
 
-  <depend>python-argparse</depend>
-  <depend version_gt="0.4.3">python-catkin-pkg</depend>
-
-  <build_depend>python-empy</build_depend>
-
   <build_export_depend>google-mock</build_export_depend>
   <build_export_depend>gtest</build_export_depend>
-  <build_export_depend>python-empy</build_export_depend>
-  <build_export_depend>python-nose</build_export_depend>
+  <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python-nose</build_export_depend>
+  <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-nose</build_export_depend>
 
-  <test_depend>python-mock</test_depend>
-  <test_depend>python-nose</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-mock</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-mock</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-nose</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-nose</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>


### PR DESCRIPTION
Uses condition attributes introduced in format 3 to declare Python 2 specific as well as Python 3 specific dependencies.