### PR TITLE
[windows][kinetic-devel] update a typo in local_setup.bat.in

### DIFF
--- a/cmake/templates/local_setup.bat.in
+++ b/cmake/templates/local_setup.bat.in
@@ -2,5 +2,5 @@
 REM generated from catkin/cmake/template/local_setup.bat.in
 
 set _CATKIN_SETUP_DIR=@SETUP_DIR@
-call %_CATKIN_SETUP_DIR%/setup.sh --extend --local
+call %_CATKIN_SETUP_DIR%/setup.bat --extend --local
 set _CATKIN_SETUP_DIR=


### PR DESCRIPTION
On Windows, the file extension for `setup` script should be `.bat`.