### PR TITLE
Correcly use ${prefix} variable in generated pkg-config

### DIFF
--- a/cmake/catkin_package.cmake
+++ b/cmake/catkin_package.cmake
@@ -401,7 +401,7 @@ function(_catkin_package)
   set(INSTALLSPACE TRUE)
 
   set(PROJECT_SPACE_DIR ${CMAKE_INSTALL_PREFIX})
-  set(PKG_INCLUDE_PREFIX ${PROJECT_SPACE_DIR})
+  set(PKG_INCLUDE_PREFIX "\\\${prefix}")
 
   # absolute path to include dir under install prefix if any include dir is set
   set(PROJECT_CMAKE_CONFIG_INCLUDE_DIRS "")

--- a/cmake/em/pkg.pc.em
+++ b/cmake/em/pkg.pc.em
@@ -4,5 +4,5 @@ Name: @(CATKIN_PACKAGE_PREFIX + PROJECT_NAME)
 Description: Description of @PROJECT_NAME
 Version: @PROJECT_VERSION
 Cflags: @(' '.join(['-I%s' % include for include in PROJECT_PKG_CONFIG_INCLUDE_DIRS]))
-Libs: -L@PROJECT_SPACE_DIR/lib @(' '.join(PKG_CONFIG_LIBRARIES_WITH_PREFIX))
+Libs: -L${prefix}/lib @(' '.join(PKG_CONFIG_LIBRARIES_WITH_PREFIX))
 Requires: @(PROJECT_CATKIN_DEPENDS)


### PR DESCRIPTION
When generating the package files for the install space, correctly use
${prefix} instead of repeating the package root dir.

Fixes  #1036.