### PR TITLE
support build_type tag with condition attribute

### DIFF
--- a/cmake/em/order_packages.cmake.em
+++ b/cmake/em/order_packages.cmake.em
@@ -36,7 +36,21 @@ fatal_error = True
 list(APPEND CATKIN_ORDERED_PACKAGES "@(package.name)")
 list(APPEND CATKIN_ORDERED_PACKAGE_PATHS "@(path.replace('\\','/'))")
 list(APPEND CATKIN_ORDERED_PACKAGES_IS_META "@(str('metapackage' in [e.tagname for e in package.exports]))")
-list(APPEND CATKIN_ORDERED_PACKAGES_BUILD_TYPE "@(str([e.content for e in package.exports if e.tagname == 'build_type'][0]) if 'build_type' in [e.tagname for e in package.exports] else 'catkin')")
+@{
+package.evaluate_conditions(os.environ)
+try:
+    build_type = package.get_build_type()
+except InvalidPackage:
+    build_type = None
+}@
+@[if build_type is None]@
+message(FATAL_ERROR "Only one <build_type> element is permitted for package '@(package.name)'.")
+@{
+fatal_error = True
+}@
+@[else]@
+list(APPEND CATKIN_ORDERED_PACKAGES_BUILD_TYPE "@(package.get_build_type())")
+@[end if]@
 @{
 deprecated = [e for e in package.exports if e.tagname == 'deprecated']
 }@


### PR DESCRIPTION
Based on https://answers.ros.org/question/335437/possible-to-build-pure-python-package-for-ros1-and-ros2-with-one-packagexmlcmakelists-file/

Getting the `build_type` through the `catkin_pkg` API (while evaluating the conditions before) ensures that only matching build types are considered.

Also the dependencies need to take the condition into account.