### PR TITLE
[Noetic] create relay scripts in devel space to ensure correct Python shebang

### DIFF
--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -58,6 +58,24 @@ function(catkin_install_python signature)
         # prefix with project name to avoid collisions across packages
         TARGET_NAME ${PROJECT_NAME}_${name}_exec_install_python
         DESTINATION "${ARG_DESTINATION}")
+
+      # Create devel-space wrapper if the destination is relative to the install prefix
+      if(NOT IS_ABSOLUTE ${ARG_DESTINATION})
+        message(STATUS "Installing devel-space wrapper ${source_file} to ${CATKIN_DEVEL_PREFIX}/${ARG_DESTINATION}")
+        # Create wrapper in devel space that uses source_file with correct shebang
+        set(PYTHON_SCRIPT ${source_file})
+        atomic_configure_file(${catkin_EXTRAS_DIR}/templates/script.py.in
+          ${CATKIN_DEVEL_PREFIX}/${ARG_DESTINATION}/${name}
+          @ONLY)
+
+        # Hook for a platform specific wrapper around the modified python script
+        add_python_executable(SCRIPT_NAME ${name}
+          # prefix with project name to avoid collisions across packages
+          # cip: avoid conflicting with targets created for scripts installed via setup.py
+          TARGET_NAME ${PROJECT_NAME}_${name}_exec_cip_devel_python
+          DESTINATION "${CATKIN_DEVEL_PREFIX}/${ARG_DESTINATION}")
+      endif()
+
     elseif(NOT ARG_OPTIONAL)
       message(FATAL_ERROR "catkin_install_python() called with non-existing file '${source_file}'.")
     endif()


### PR DESCRIPTION
[PEP 394](https://www.python.org/dev/peps/pep-0394/#recommendation) recommends python scripts have their shebangs re-written to a specific version of python when they're installed. The CMake macro `catkin_install_python()` does this; however, when the devel space is sourced the script is executed from the `src` space which does not have rewritten shebangs. This PR creates a relay script in the devel space to make sure the right version of python is invoked. It reuses an existing relay script created by `catkin` for scripts passed in the `scripts` argument to `setup()` in a `setup.py`.

I think this is appropriate, but I would not release this into `kinetic` because it changes the behavior of `rosrun` if the script is executable in the `src` space. For example, [urdfdom_py installs a script `display_urdf`](https://github.com/ros/urdf_parser_py/blob/b213e6e5846800b4873be349d605b906e78d681e/CMakeLists.txt#L10) which [is executable and has a shebang `#!/usr/bin/env python`](https://github.com/ros/urdf_parser_py/blob/b213e6e5846800b4873be349d605b906e78d681e/scripts/display_urdf#L1). When there is also a relay script in the `devel` space then `rosrun` complains about there being multiple options.

```
$ rosrun urdfdom_py display_urdf 
[rosrun] You have chosen a non-unique executable, please pick one of the following:
1) /home/sloretz/ws/noetic/devel_isolated/urdfdom_py/lib/urdfdom_py/display_urdf
2) /home/sloretz/ws/noetic/src/urdfdom_py/scripts/display_urdf
#?
```

A solution is to remove the executable permissions from `display_urdf` in `src` space, which I think is fine for Noetic, but it would mean changing downstream code in an already released distro if this PR was released into `kinetic` or `melodic`.

Another solution would be to make `rosrun` just take the first option, [which is what roslaunch does](https://github.com/ros/ros_comm/blob/d93fcae779f5eb9a62dba5d7e9210ef635f8dd38/tools/roslaunch/src/roslaunch/node_args.py#L260-L261), but that seems like a large change for a stable distro like `kinetic`.

This is similar to ros/ros_comm#1830, but it does not solve that particular issue since tests shouldn't be installed.