### PR TITLE
Update gtest config documentation

### DIFF
--- a/doc/howto/format1/gtest_configuration.rst
+++ b/doc/howto/format1/gtest_configuration.rst
@@ -8,14 +8,6 @@ pure C++ framework.  No ROS environment is available.  See:
 :ref:`rostest_configuration` if your tests need a running roscore_.
 
 
-package.xml
-:::::::::::
-
-The rosunit_ package is needed for testing::
-
-  <test_depend>rosunit</test_depend>
-
-
 CMakeLists.txt
 ::::::::::::::
 
@@ -34,4 +26,3 @@ If other libraries are needed to compile your test program, see
 
 .. _Gtest: http://www.ros.org/wiki/gtest
 .. _roscore: http://www.ros.org/wiki/roscore
-.. _rosunit: http://www.ros.org/wiki/rosunit

--- a/doc/howto/format2/gtest_configuration.rst
+++ b/doc/howto/format2/gtest_configuration.rst
@@ -8,14 +8,6 @@ pure C++ framework.  No ROS environment is available.  See:
 :ref:`rostest_configuration` if your tests need a running roscore_.
 
 
-package.xml
-:::::::::::
-
-The rosunit_ package is needed for testing::
-
-  <test_depend>rosunit</test_depend>
-
-
 CMakeLists.txt
 ::::::::::::::
 
@@ -34,4 +26,3 @@ If other libraries are needed to compile your test program, see
 
 .. _Gtest: http://wiki.ros.org/gtest
 .. _roscore: http://wiki.ros.org/roscore
-.. _rosunit: http://wiki.ros.org/rosunit


### PR DESCRIPTION
Following up on fkie/catkin_lint#76 and ros-controls/ros_control#408:

This doc is a bit out of date, and the `rosunit` dependency is no longer needed for the `catkin_add_XXXtest()` commands.