### PR TITLE
Prefer setuptools with Python 3

### DIFF
--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -37,7 +37,7 @@ import sys
 
 setup_modules = []
 
-try
+try:
     import distutils.core
     setup_modules.append(distutils.core)
 except ImportError:

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -35,11 +35,21 @@ import os
 import runpy
 import sys
 
-import distutils.core
-try:
-    import setuptools
+setup_modules = []
+
+try
+    import distutils.core
+    setup_modules.append(distutils.core)
 except ImportError:
     pass
+
+try:
+    import setuptools
+    setup_modules.append(setuptools)
+except ImportError:
+    pass
+
+assert setup_modules, 'Must have distutils or setuptools installed'
 
 from argparse import ArgumentParser
 
@@ -227,25 +237,19 @@ def main():
 
     # patch setup() function of distutils and setuptools for the
     # context of evaluating setup.py
+    backup_modules = {}
     try:
         fake_setup = _create_mock_setup_function(package_name=args.package_name,
                                                 outfile=args.outfile)
 
-        distutils_backup = distutils.core.setup
-        distutils.core.setup = fake_setup
-        try:
-            setuptools_backup = setuptools.setup
-            setuptools.setup = fake_setup
-        except NameError:
-            pass
+        for module in setup_modules:
+            backup_modules[id(module)] = module.setup
+            module.setup = fake_setup
 
         runpy.run_path(args.setupfile_path)
     finally:
-        distutils.core.setup = distutils_backup
-        try:
-            setuptools.setup = setuptools_backup
-        except NameError:
-            pass
+        for module in setup_modules:
+            module.setup = backup_modules[id(module)]
 
 if __name__ == '__main__':
     main()

--- a/doc/howto/format1/installing_python.rst
+++ b/doc/howto/format1/installing_python.rst
@@ -63,7 +63,7 @@ layout, it looks like this::
 
   ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-  from distutils.core import setup
+  from setuptools import setup
   from catkin_pkg.python_setup import generate_distutils_setup
   
   # fetch values from package.xml

--- a/doc/howto/format2/installing_python.rst
+++ b/doc/howto/format2/installing_python.rst
@@ -63,7 +63,7 @@ layout, it looks like this::
 
   ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-  from distutils.core import setup
+  from setuptools import setup
   from catkin_pkg.python_setup import generate_distutils_setup
   
   # fetch values from package.xml

--- a/doc/user_guide/setup_dot_py.rst
+++ b/doc/user_guide/setup_dot_py.rst
@@ -12,11 +12,6 @@ packages define the installation files in a file called ``setup.py``
 in the project root. The setup.py file uses Python to describe the
 Python content of the stack.
 
-We recommend to prefer distutils package over setuptools/distribute,
-because with distutils we can avoid the creation of egg-info folders
-in the project source folder. The setup.cfg file of distutils2 is not
-supported by catkin.
-
 Catkin allows you to specify the installation of your python files in
 this setup.py and reuse some of the information in your CMakeLists.txt.
 
@@ -26,10 +21,10 @@ You can do so by including the line::
 
 in the CMakeLists.txt of your project.
 
-catkin will execute setup.py with a hot-patched version of distutils
-to read the arguments to set up the devel space, and execute setup.py
-with suitable arguments to install to the catkin install space under
-``CMAKE_INSTALL_PREFIX``.
+catkin will execute setup.py with a hot-patched version of distutils or
+setuptools to read the arguments to set up the devel space, and execute
+setup.py with suitable arguments to install to the catkin install space
+under ``CMAKE_INSTALL_PREFIX``.
 
 This means that if you execute your
 setup.py using::
@@ -50,7 +45,7 @@ pypi is not very useful for ROS nodes.
 For the develspace, the following setup.py arguments to setup() will
 be used by catkin::
 
-  from distutils.core import setup
+  from setuptools import setup
 
   setup(
       version='...',
@@ -101,7 +96,7 @@ Writing a setup.py file without duplicating information contained in
 the package.xml is possible using a catkin_pkg convenience function
 like this::
 
-  from distutils.core import setup
+  from setuptools import setup
   from catkin_pkg.python_setup import generate_distutils_setup
 
   d = generate_distutils_setup(
@@ -130,7 +125,7 @@ one distributes to pypi.
 .. note::
 
   See the note in previous section about the otherwise useful
-  field ``requires`` that's usually a part of distutils setup.
+  field ``requires`` that's usually a part of setuptools setup.
   *Do not use it* in ROS.
 
 

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,10 @@
   <depend condition="$ROS_PYTHON_VERSION == 3">python3-empy</depend>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
+
   <buildtool_export_depend>cmake</buildtool_export_depend>
+  <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_export_depend>
 
   <build_export_depend>google-mock</build_export_depend>
   <build_export_depend>gtest</build_export_depend>

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <depend condition="$ROS_PYTHON_VERSION == 3">python3-empy</depend>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <buildtool_export_depend>cmake</buildtool_export_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
This is a follow up to https://github.com/ros/genmsg/pull/90#issuecomment-575702761

Currently catkin requires `distutils` and optionally supports `setuptools`; however, `distutils` for Python 3 requires a dependency on `python3-distutils` in Ubuntu Focal and Debian Buster. This PR makes catkin prefer setuptools and optionally support distutils when using Python 3.

* catkin itself uses setuptools in its own setup.py
* When interrogating another package's `setup.py`, don't fail if `distutils.core` can't be imported
* When using Python 3, add a `buildtool_export_depend` on `setuptools` since something like it must be available downstream
* Update documentation to use `setuptools` instead of `distutils.core`.

With this PR I think the effect on Python 2 ROS distros is `python-setuptools` would be installed where it wasn't before, but no downstream changes are required. The effect on Noetic is downstream packages depending on `catkin` either need to depend on `python3-distutils` or use `setuptools` instead.