### PR TITLE
Support use of gmake on FreeBSD

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -178,8 +178,9 @@ def main():
         if args.use_ninja:
             cmake_args += ['-G', 'Ninja']
         elif args.use_nmake:
-            cmake_args += ['-G', 'NMake Makefiles']
+            cmake_args += ['-G', 'NMake Makefiles']            
         else:
+            # no need to check for use_gmake, as it uses the same generator as make
             cmake_args += ['-G', 'Unix Makefiles']
     elif args.use_ninja or args.use_nmake:
         return fmt("@{rf}Error: either specify a generator using '-G...' or '--use-[ninja|nmake]' but not both")
@@ -211,6 +212,8 @@ def main():
             cmd = ['ninja', 'build.ninja']
         elif args.use_nmake:
             cmd = ['nmake', 'cmake_check_build_system']
+        elif args.use_gmake:
+            cmd = ['gmake', 'cmake_check_build_system']            
         else:
             cmd = ['make', 'cmake_check_build_system']
         try:
@@ -229,6 +232,8 @@ def main():
         cmd = ['ninja']
     elif args.use_nmake:
         cmd = ['nmake']
+    elif args.use_gmake:
+        cmd = ['gmake']        
     else:
         cmd = ['make']
     cmd.extend(handle_make_arguments(args.make_args, append_default_jobs_flags=not args.use_nmake))
@@ -268,6 +273,7 @@ def _parse_args(args=sys.argv[1:]):
     add('--build', help="The path to the build space (default 'workspace_base/build')")
     add('--use-ninja', action='store_true', help="Use 'ninja' instead of 'make'")
     add('--use-nmake', action='store_true', help="Use 'nmake' instead of 'make'")
+    add('--use-gmake', action='store_true', help="Use 'gmake' instead of 'make'")
     add('--force-cmake', action='store_true', help="Invoke 'cmake' even if it has been executed before")
     add('--no-color', action='store_true', help='Disables colored output (only for catkin_make and CMake)')
     add('--pkg', nargs='+', help="Invoke 'make' on specific packages only")

--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -178,7 +178,7 @@ def main():
         if args.use_ninja:
             cmake_args += ['-G', 'Ninja']
         elif args.use_nmake:
-            cmake_args += ['-G', 'NMake Makefiles']            
+            cmake_args += ['-G', 'NMake Makefiles']
         else:
             # no need to check for use_gmake, as it uses the same generator as make
             cmake_args += ['-G', 'Unix Makefiles']
@@ -213,7 +213,7 @@ def main():
         elif args.use_nmake:
             cmd = ['nmake', 'cmake_check_build_system']
         elif args.use_gmake:
-            cmd = ['gmake', 'cmake_check_build_system']            
+            cmd = ['gmake', 'cmake_check_build_system']
         else:
             cmd = ['make', 'cmake_check_build_system']
         try:
@@ -233,7 +233,7 @@ def main():
     elif args.use_nmake:
         cmd = ['nmake']
     elif args.use_gmake:
-        cmd = ['gmake']        
+        cmd = ['gmake']
     else:
         cmd = ['make']
     cmd.extend(handle_make_arguments(args.make_args, append_default_jobs_flags=not args.use_nmake))

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -47,6 +47,7 @@ def parse_args(args=None):
         help="Sets the target install space (default 'workspace_base/install_isolated')")
     add('--use-ninja', action='store_true', help="Use 'ninja' instead of 'make'")
     add('--use-nmake', action='store_true', help="Use 'nmake' instead of 'make'")
+    add('--use-gmake', action='store_true', help="Use 'gmake' instead of 'make'")    
     add('--install', action='store_true', default=False,
         help='Causes each catkin package to be installed.')
     add('--force-cmake', action='store_true', default=False,
@@ -158,6 +159,7 @@ def main():
         destdir=destdir,
         use_ninja=opts.use_ninja,
         use_nmake=opts.use_nmake,
+        use_gmake=opts.use_gmake,
         override_build_tool_check=opts.override_build_tool_check,
     )
 

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -47,7 +47,7 @@ def parse_args(args=None):
         help="Sets the target install space (default 'workspace_base/install_isolated')")
     add('--use-ninja', action='store_true', help="Use 'ninja' instead of 'make'")
     add('--use-nmake', action='store_true', help="Use 'nmake' instead of 'make'")
-    add('--use-gmake', action='store_true', help="Use 'gmake' instead of 'make'")    
+    add('--use-gmake', action='store_true', help="Use 'gmake' instead of 'make'")
     add('--install', action='store_true', default=False,
         help='Causes each catkin package to be installed.')
     add('--force-cmake', action='store_true', default=False,

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -409,7 +409,7 @@ def build_catkin_package(
         elif use_nmake:
             make_check_cmake_cmd = ['nmake', 'cmake_check_build_system']
         elif use_gmake:
-            make_check_cmake_cmd = ['gmake', 'cmake_check_build_system']            
+            make_check_cmake_cmd = ['gmake', 'cmake_check_build_system']
         else:
             make_check_cmake_cmd = ['make', 'cmake_check_build_system']
 
@@ -427,7 +427,7 @@ def build_catkin_package(
     elif use_nmake:
         make_executable = 'nmake'
     elif use_gmake:
-        make_executable = 'gmake'        
+        make_executable = 'gmake'
     else:
         make_executable = 'make'
 
@@ -629,7 +629,7 @@ def build_cmake_package(
         elif use_nmake:
             make_check_cmake_cmd = ['nmake', 'cmake_check_build_system']
         elif use_gmake:
-            make_check_cmake_cmd = ['gmake', 'cmake_check_build_system']            
+            make_check_cmake_cmd = ['gmake', 'cmake_check_build_system']
         else:
             make_check_cmake_cmd = ['make', 'cmake_check_build_system']
 
@@ -646,7 +646,7 @@ def build_cmake_package(
     elif use_nmake:
         make_executable = 'nmake'
     elif use_gmake:
-        make_executable = 'gmake'        
+        make_executable = 'gmake'
     else:
         make_executable = 'make'
     make_cmd = [make_executable]
@@ -867,7 +867,7 @@ def build_workspace_isolated(
     :param destdir: define DESTDIR for cmake/invocation, ``string``
     :param use_ninja: if True, use ninja instead of make, ``bool``
     :param use_nmake: if True, use nmake instead of make, ``bool``
-    :param use_gmake: if True, use gmake instead of make, ``bool``    
+    :param use_gmake: if True, use gmake instead of make, ``bool``
     :param override_build_tool_check: if True, build even if a space was built
         by another tool previously.
     '''

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -458,8 +458,9 @@ def has_make_target(path, target, use_ninja=False, use_nmake=False, use_gmake=Fa
         output = run_command(['ninja', '-t', 'targets'], path, quiet=True)
     elif use_nmake:
         output = run_command(['nmake', '/PNC'], path, quiet=True)
+    elif use_gmake:
+        output = run_command(['gmake', '-pn'], path, quiet=True)
     else:
-        # no need to check for use_gmake, as it accepts the same arguments as make
         output = run_command(['make', '-pn'], path, quiet=True)
     lines = output.splitlines()
     # strip nanja warnings since they look similar to targets

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -342,7 +342,7 @@ def build_catkin_package(
     path, package,
     workspace, buildspace, develspace, installspace,
     install, force_cmake, quiet, last_env, cmake_args, make_args,
-    destdir=None, use_ninja=False, use_nmake=False
+    destdir=None, use_ninja=False, use_nmake=False, use_gmake=False
 ):
     cprint(
         "Processing @{cf}catkin@| package: '@!@{bf}" +
@@ -408,6 +408,8 @@ def build_catkin_package(
             make_check_cmake_cmd = ['ninja', 'build.ninja']
         elif use_nmake:
             make_check_cmake_cmd = ['nmake', 'cmake_check_build_system']
+        elif use_gmake:
+            make_check_cmake_cmd = ['gmake', 'cmake_check_build_system']            
         else:
             make_check_cmake_cmd = ['make', 'cmake_check_build_system']
 
@@ -424,6 +426,8 @@ def build_catkin_package(
         make_executable = 'ninja'
     elif use_nmake:
         make_executable = 'nmake'
+    elif use_gmake:
+        make_executable = 'gmake'        
     else:
         make_executable = 'make'
 
@@ -437,7 +441,7 @@ def build_catkin_package(
     # Make install
     # NMake doesn't have an option to list target so try it anyway
     if install or use_nmake:
-        if has_make_target(build_dir, 'install', use_ninja=use_ninja, use_nmake=use_nmake):
+        if has_make_target(build_dir, 'install', use_ninja=use_ninja, use_nmake=use_nmake, use_gmake=use_gmake):
             make_install_cmd = [make_executable, 'install']
             isolation_print_command(' '.join(make_install_cmd), build_dir)
             if last_env is not None:
@@ -449,12 +453,13 @@ def build_catkin_package(
                 % make_executable))
 
 
-def has_make_target(path, target, use_ninja=False, use_nmake=False):
+def has_make_target(path, target, use_ninja=False, use_nmake=False, use_gmake=False):
     if use_ninja:
         output = run_command(['ninja', '-t', 'targets'], path, quiet=True)
     elif use_nmake:
         output = run_command(['nmake', '/PNC'], path, quiet=True)
     else:
+        # no need to check for use_gmake, as it accepts the same arguments as make
         output = run_command(['make', '-pn'], path, quiet=True)
     lines = output.splitlines()
     # strip nanja warnings since they look similar to targets
@@ -576,7 +581,7 @@ def build_cmake_package(
     path, package,
     workspace, buildspace, develspace, installspace,
     install, force_cmake, quiet, last_env, cmake_args, make_args,
-    destdir=None, use_ninja=False, use_nmake=False
+    destdir=None, use_ninja=False, use_nmake=False, use_gmake=False
 ):
     # Notify the user that we are processing a plain cmake package
     cprint(
@@ -622,6 +627,8 @@ def build_cmake_package(
             make_check_cmake_cmd = ['ninja', 'build.ninja']
         elif use_nmake:
             make_check_cmake_cmd = ['nmake', 'cmake_check_build_system']
+        elif use_gmake:
+            make_check_cmake_cmd = ['gmake', 'cmake_check_build_system']            
         else:
             make_check_cmake_cmd = ['make', 'cmake_check_build_system']
 
@@ -637,6 +644,8 @@ def build_cmake_package(
         make_executable = 'ninja'
     elif use_nmake:
         make_executable = 'nmake'
+    elif use_gmake:
+        make_executable = 'gmake'        
     else:
         make_executable = 'make'
     make_cmd = [make_executable]
@@ -723,7 +732,7 @@ def build_package(
     path, package,
     workspace, buildspace, develspace, installspace,
     install, force_cmake, quiet, last_env, cmake_args, make_args, catkin_make_args,
-    destdir=None, use_ninja=False, use_nmake=False,
+    destdir=None, use_ninja=False, use_nmake=False, use_gmake=False,
     number=None, of=None
 ):
     if platform.system() in ['Linux', 'Darwin'] and sys.stdout.isatty():
@@ -740,7 +749,7 @@ def build_package(
             path, package,
             workspace, buildspace, develspace, installspace,
             install, force_cmake, quiet, last_env, cmake_args, make_args + catkin_make_args,
-            destdir=destdir, use_ninja=use_ninja, use_nmake=use_nmake
+            destdir=destdir, use_ninja=use_ninja, use_nmake=use_nmake, use_gmake=use_gmake
         )
         if not os.path.exists(new_last_env):
             raise RuntimeError(
@@ -754,7 +763,7 @@ def build_package(
             path, package,
             workspace, buildspace, develspace, installspace,
             install, force_cmake, quiet, last_env, cmake_args, make_args,
-            destdir=destdir, use_ninja=use_ninja, use_nmake=use_nmake
+            destdir=destdir, use_ninja=use_ninja, use_nmake=use_nmake, use_gmake=use_gmake
         )
     else:
         sys.exit('Can not build package with unknown build_type')
@@ -819,6 +828,7 @@ def build_workspace_isolated(
     destdir=None,
     use_ninja=False,
     use_nmake=False,
+    use_gmake=False,
     override_build_tool_check=False
 ):
     '''
@@ -856,6 +866,7 @@ def build_workspace_isolated(
     :param destdir: define DESTDIR for cmake/invocation, ``string``
     :param use_ninja: if True, use ninja instead of make, ``bool``
     :param use_nmake: if True, use nmake instead of make, ``bool``
+    :param use_gmake: if True, use gmake instead of make, ``bool``    
     :param override_build_tool_check: if True, build even if a space was built
         by another tool previously.
     '''
@@ -933,6 +944,7 @@ def build_workspace_isolated(
         elif use_nmake:
             cmake_args += ['-G', 'NMake Makefiles']
         else:
+            # no need to check for use_gmake, as it uses the same generator as make
             cmake_args += ['-G', 'Unix Makefiles']
     elif use_ninja or use_nmake:
         print(colorize_line("Error: either specify a generator using '-G...' or '--use-[ninja|nmake]' but not both"))
@@ -1048,7 +1060,7 @@ def build_workspace_isolated(
                     workspace, buildspace, pkg_develspace, installspace,
                     install, force_cmake,
                     quiet, last_env, cmake_args, make_args, catkin_make_args,
-                    destdir=destdir, use_ninja=use_ninja, use_nmake=use_nmake,
+                    destdir=destdir, use_ninja=use_ninja, use_nmake=use_nmake, use_gmake=use_gmake,
                     number=index + 1, of=len(ordered_packages)
                 )
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
FreeBSD `make` is not GNU `make`, and doesn't support certain commands used by `catkin` (specifically, `-l` and `-p`).

GNU `make` is available in the FreeBSD ports tree as `gmake`.

This PR makes the changes necessary to specify `--use-gmake` for `catkin_make` and `catkin_make_isolated`.

See #1047 