### PR TITLE
bump CMake minimum version to use new behavior of CMP0048

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
-cmake_policy(SET CMP0048 NEW)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(catkin_EXTRAS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
+cmake_policy(SET CMP0048 NEW)
 
 set(catkin_EXTRAS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
CMP0048 NEW behavior sets PROJECT_VERSION variables to empty strings if
project() is called with no VERSION argument. This could be a problem
for packages that set VERSION variables prior to project() because
project() would then clear them, but catkin does not do this.

**edit:** This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Fixes this CMake warning: http://build.ros.org/job/Npr__catkin__ubuntu_focal_amd64/4/warnings2Result/new/