### PR TITLE
Update utils.py to fix python3.8 failure

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -74,7 +74,7 @@ def create_catkin_workspace(pth):
     # avoid copying tmp, as that may contain all of ros core
 
     def notest(folder, contents):
-        if folder.endswith('test'):
+        if str(folder).endswith('test'):
             return ['tmp']
         return []
     shutil.copytree(CATKIN_DIR, catkin_dir, symlinks=True, ignore=notest)


### PR DESCRIPTION
Example of failure:
```
/usr/bin/ctest --force-new-ctest-process -j4
Test project /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu
    Start 1: _ctest_catkin_nosetests_test.local_tests
    Start 2: _ctest_catkin_nosetests_test.unit_tests
1/2 Test #1: _ctest_catkin_nosetests_test.local_tests ...***Failed    0.28 sec
EEEEE
======================================================================
ERROR: test_catkin_only (test_with_mock_workspace.MockTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 140, in setUp
    self.setupWorkspaceContents()
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 143, in setupWorkspaceContents
    create_catkin_workspace(self.workspacedir)
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 80, in create_catkin_workspace
    shutil.copytree(CATKIN_DIR, catkin_dir, symlinks=True, ignore=notest)
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 486, in _copytree
    copytree(srcobj, dstname, symlinks, ignore, copy_function,
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 445, in _copytree
    ignored_names = ignore(src, {x.name for x in entries})
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 77, in notest
    if folder.endswith('test'):
AttributeError: 'posix.DirEntry' object has no attribute 'endswith'

======================================================================
ERROR: test_env_cached_static (test_with_mock_workspace.MockTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 140, in setUp
    self.setupWorkspaceContents()
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 143, in setupWorkspaceContents
    create_catkin_workspace(self.workspacedir)
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 80, in create_catkin_workspace
    shutil.copytree(CATKIN_DIR, catkin_dir, symlinks=True, ignore=notest)
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 486, in _copytree
    copytree(srcobj, dstname, symlinks, ignore, copy_function,
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 445, in _copytree
    ignored_names = ignore(src, {x.name for x in entries})
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 77, in notest
    if folder.endswith('test'):
AttributeError: 'posix.DirEntry' object has no attribute 'endswith'

======================================================================
ERROR: test_linker_options_propagation (test_with_mock_workspace.MockTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 140, in setUp
    self.setupWorkspaceContents()
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 143, in setupWorkspaceContents
    create_catkin_workspace(self.workspacedir)
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 80, in create_catkin_workspace
    shutil.copytree(CATKIN_DIR, catkin_dir, symlinks=True, ignore=notest)
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 486, in _copytree
    copytree(srcobj, dstname, symlinks, ignore, copy_function,
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 445, in _copytree
    ignored_names = ignore(src, {x.name for x in entries})
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 77, in notest
    if folder.endswith('test'):
AttributeError: 'posix.DirEntry' object has no attribute 'endswith'

======================================================================
ERROR: test_nolang (test_with_mock_workspace.MockTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 140, in setUp
    self.setupWorkspaceContents()
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 143, in setupWorkspaceContents
    create_catkin_workspace(self.workspacedir)
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 80, in create_catkin_workspace
    shutil.copytree(CATKIN_DIR, catkin_dir, symlinks=True, ignore=notest)
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 486, in _copytree
    copytree(srcobj, dstname, symlinks, ignore, copy_function,
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 445, in _copytree
    ignored_names = ignore(src, {x.name for x in entries})
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 77, in notest
    if folder.endswith('test'):
AttributeError: 'posix.DirEntry' object has no attribute 'endswith'

======================================================================
ERROR: test_noproject (test_with_mock_workspace.MockTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 140, in setUp
    self.setupWorkspaceContents()
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 143, in setupWorkspaceContents
    create_catkin_workspace(self.workspacedir)
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 80, in create_catkin_workspace
    shutil.copytree(CATKIN_DIR, catkin_dir, symlinks=True, ignore=notest)
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 486, in _copytree
    copytree(srcobj, dstname, symlinks, ignore, copy_function,
  File "/usr/lib/python3.8/shutil.py", line 548, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 445, in _copytree
    ignored_names = ignore(src, {x.name for x in entries})
  File "/<<PKGBUILDDIR>>/test/local_tests/../../test/utils.py", line 77, in notest
    if folder.endswith('test'):
AttributeError: 'posix.DirEntry' object has no attribute 'endswith'

----------------------------------------------------------------------
Ran 5 tests in 0.016s

FAILED (errors=5)
-- run_tests.py: execute commands
  "/usr/bin/cmake" -E make_directory /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/test_results/catkin
  /usr/bin/nosetests3 -P --process-timeout=60 --where=/<<PKGBUILDDIR>>/test/local_tests --with-xunit --xunit-file=/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/test_results/catkin/nosetests-test.local_tests.xml
-- run_tests.py: verify result "/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/test_results/catkin/nosetests-test.local_tests.xml"
```