### PR TITLE
[Windows][noetic-devel] Generate executables without extension name.

### DIFF
--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -130,9 +130,12 @@ function(add_python_executable)
   endif()
 
   if(WIN32)
+    get_filename_component(WRAPPER_NAME
+      "${ARG_TARGET_NAME}"
+      NAME_WLE)
     set(
       WRAPPER_SOURCE
-      "${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/add_python_executable/${ARG_TARGET_NAME}/${ARG_SCRIPT_NAME}.cpp")
+      "${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/add_python_executable/${ARG_TARGET_NAME}/${WRAPPER_NAME}.cpp")
     configure_file(
       "${catkin_EXTRAS_DIR}/templates/python_win32_wrapper.cpp.in"
       "${WRAPPER_SOURCE}"
@@ -140,10 +143,10 @@ function(add_python_executable)
 
     add_executable(${ARG_TARGET_NAME} "${WRAPPER_SOURCE}")
 
-    # The actual file name of the executable built on Windows will be ${ARG_SCRIPT_NAME}.exe according to OUTPUT_NAME
+    # The actual file name of the executable built on Windows will be ${WRAPPER_NAME}.exe according to OUTPUT_NAME
     set_target_properties(
       ${ARG_TARGET_NAME} PROPERTIES
-      OUTPUT_NAME "${ARG_SCRIPT_NAME}"
+      OUTPUT_NAME "${WRAPPER_NAME}"
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/windows_wrappers/${ARG_TARGET_NAME}")
 
     install(

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -132,7 +132,7 @@ function(add_python_executable)
   if(WIN32)
     get_filename_component(WRAPPER_NAME
       "${ARG_TARGET_NAME}"
-      NAME_WLE)
+      NAME_WE)
     set(
       WRAPPER_SOURCE
       "${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/add_python_executable/${ARG_TARGET_NAME}/${WRAPPER_NAME}.cpp")

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -131,7 +131,7 @@ function(add_python_executable)
 
   if(WIN32)
     get_filename_component(WRAPPER_NAME
-      "${ARG_TARGET_NAME}"
+      "${ARG_SCRIPT_NAME}"
       NAME_WE)
     set(
       WRAPPER_SOURCE


### PR DESCRIPTION
For scripts ending with `.py`, `add_python_executable` will take the full filename (e.g., `abc.py`) and produce the executable ending with `.py.exe` (e.g., `abc.py.exe`) and which is not the expected script alias.

The pull request is proposing to extract the filename without the last extension by using [`NAME_WLE`](https://cmake.org/cmake/help/v3.14/command/get_filename_component.html) first and then generate the correct executable with the name without the extra `.py`.

And it would be great this can be backport to `kinetic` branch. Thanks!