### PR TITLE
[Noetic] Global python in develspace

### DIFF
--- a/cmake/catkin_generate_environment.cmake
+++ b/cmake/catkin_generate_environment.cmake
@@ -57,6 +57,12 @@ function(catkin_generate_environment)
         @ONLY)
     endforeach()
 
+    # Not windows? There might be multiple python major versions installed
+    # Generate symlink to python so tests in devel space use correct version
+    get_filename_component(absolute_python_executable "${PYTHON_EXECUTABLE}" ABSOLUTE)
+    file(MAKE_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}")
+    _catkin_create_symlink("${absolute_python_executable}" "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}/python")
+
   else()
     # windows
     # generate env

--- a/cmake/symlink_install/catkin_symlink_install.cmake.in
+++ b/cmake/symlink_install/catkin_symlink_install.cmake.in
@@ -266,33 +266,8 @@ function(_catkin_symlink_install_create_symlink absolute_file symlink)
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/symlink_install_manifest.txt"
     "${symlink}\n")
 
-  # avoid any work if correct symlink is already in place
-  if(EXISTS "${symlink}" AND IS_SYMLINK "${symlink}")
-    get_filename_component(destination "${symlink}" REALPATH)
-    get_filename_component(real_absolute_file "${absolute_file}" REALPATH)
-    if(destination STREQUAL real_absolute_file)
-      message(STATUS "Up-to-date symlink: ${symlink}")
-      return()
-    endif()
-  endif()
-
-  message(STATUS "Symlinking: ${symlink}")
-  if(EXISTS "${symlink}" OR IS_SYMLINK "${symlink}")
-    file(REMOVE "${symlink}")
-  endif()
-
-  execute_process(
-    COMMAND "@CMAKE_COMMAND@" "-E" "create_symlink"
-      "${absolute_file}"
-      "${symlink}"
-  )
-  # the CMake command does not provide a return code so check manually
-  if(NOT EXISTS "${symlink}" OR NOT IS_SYMLINK "${symlink}")
-    get_filename_component(destination "${symlink}" REALPATH)
-    message(FATAL_ERROR
-      "Could not create symlink '${symlink}' pointing to '${absolute_file}'")
-  endif()
-endfunction()
+  _catkin_create_symlink("${absolute_file}" "${symlink}")
+endfunction
 
 # end of template
 


### PR DESCRIPTION
Fixes ros/ros_comm#1830

This provides `python` in `$PATH` when the devel space is sourced by creating a symlink to `python` in `CATKIN_DEVEL_PREFIX/CATKIN_GLOBAL_BIN_DESTINATION`. I haven't seen unit tests run using python 2 with this fix.

Using `catkin_make` this creates a single symlink `<your-ws>/devel/bin/python`. With `catkin_make_isolated` this creates a symlink in `<your-ws>/devel_isolated/<package>/bin/python`, which I think means `$PATH` has more entries because every package now has a global bin destination. I have not yet tested with `catkin-tools`.

I've tested using `catkin_make_isolated` to build a Noetic workspace and run tests. I've also sourced that `devel_isolated` workspace and built an overlay using `catkin_make`. I have not yet tested with an overlay of an install space.

I moved some symlink creation code into a new function `_catkin_create_symlink` so it could be reused. The only change to it is `@CMAKE_COMMAND@` became `${CMAKE_COMMAND}` to avoid a [CMP0053 warning](https://cmake.org/cmake/help/v3.1/policy/CMP0053.html).