### PR TITLE
[kinetic] [Windows] Rename catkin scripts for parallel package parsing support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 from setuptools import setup
 
 import os
-import shutil
 
 catkin_scripts = [
         'bin/catkin_find',
@@ -15,17 +14,20 @@ catkin_scripts = [
     ]
 
 if os.name == 'nt':
-    # On Windows, Python scripts making use of multiprocessing
-    # have to meet several requirements to work.
-    # (catkin_pkg makes use of it to do parallel package parser.)
-    #
-    # One is that the scripts have to be ended with .py extension;
-    # Otherwise, it will manifest as ImportError.
-    if not os.path.isdir('build/bin'):
-        os.makedirs('build/bin')
-    for script in catkin_scripts:
-        shutil.copyfile(script, 'build/%s.py' % script)
-    catkin_scripts = ['build/%s.py' % script for script in catkin_scripts]
+    import sys
+    import shutil
+    if sys.version_info.major == 2:
+        # On Windows\Python2, Python scripts making use of multiprocessing
+        # have to meet several requirements to work.
+        # (catkin_pkg makes use of it to do parallel package parser.)
+        #
+        # One is that the scripts have to be ended with .py extension;
+        # Otherwise, it will manifest as ImportError.
+        if not os.path.isdir('build/bin'):
+            os.makedirs('build/bin')
+        for script in catkin_scripts:
+            shutil.copyfile(script, 'build/%s.py' % script)
+        catkin_scripts = ['build/%s.py' % script for script in catkin_scripts]
 
 d = generate_distutils_setup(
     packages=['catkin'],

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,35 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 from setuptools import setup
 
-d = generate_distutils_setup(
-    packages=['catkin'],
-    package_dir={'': 'python'},
-    scripts=[
+import os
+import shutil
+
+catkin_scripts = [
         'bin/catkin_find',
         'bin/catkin_init_workspace',
         'bin/catkin_make',
         'bin/catkin_make_isolated',
         'bin/catkin_test_results',
         'bin/catkin_topological_order',
-    ],
+    ]
+
+if os.name == 'nt':
+    # On Windows, Python scripts making use of multiprocessing
+    # have to meet several requirements to work.
+    # (catkin_pkg makes use of it to do parallel package parser.)
+    #
+    # One is that the scripts have to be ended with .py extension;
+    # Otherwise, it will manifest as ImportError.
+    if not os.path.isdir('build/bin'):
+        os.makedirs('build/bin')
+    for script in catkin_scripts:
+        shutil.copyfile(script, 'build/%s.py' % script)
+    catkin_scripts = ['build/%s.py' % script for script in catkin_scripts]
+
+d = generate_distutils_setup(
+    packages=['catkin'],
+    package_dir={'': 'python'},
+    scripts=catkin_scripts,
 )
 
 setup(**d)

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ from setuptools import setup
 import os
 
 catkin_scripts = [
-        'bin/catkin_find',
-        'bin/catkin_init_workspace',
-        'bin/catkin_make',
-        'bin/catkin_make_isolated',
-        'bin/catkin_test_results',
-        'bin/catkin_topological_order',
-    ]
+    'bin/catkin_find',
+    'bin/catkin_init_workspace',
+    'bin/catkin_make',
+    'bin/catkin_make_isolated',
+    'bin/catkin_test_results',
+    'bin/catkin_topological_order',
+]
 
 if os.name == 'nt':
     import sys


### PR DESCRIPTION
This is another attempt to solve the parallel packages parsing support: (Here are related attempts.)
* https://github.com/ros-infrastructure/catkin_pkg/pull/266
* https://github.com/ros-infrastructure/catkin_pkg/pull/250

Based on current investigation, on Windows\Python2, we have to make the scripts to be ended with `.py`; Otherwise, any usage of multiprocessing will result in `ImportError: No module named <catkin_script_name>`.

This attempt is to only do the renaming on Windows when `setup.py` runs, so the `<catkin_script>.py` will be installed in this case.

This fixes https://github.com/ms-iot/ROSOnWindows/issues/148.
