### PR TITLE
Always pass --root to setuptools install.

### DIFF
--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -9,7 +9,6 @@ if [ -n "$DESTDIR" ] ; then
             /bin/echo "otherwise python's distutils will bork things."
             exit 1
     esac
-    DESTDIR_ARG="--root=$DESTDIR"
 fi
 
 echo_and_run() { echo "+ $@" ; "$@" ; }
@@ -29,5 +28,5 @@ echo_and_run /usr/bin/env \
     "@CMAKE_CURRENT_SOURCE_DIR@/setup.py" \
     build --build-base "@CMAKE_CURRENT_BINARY_DIR@" \
     install \
-    $DESTDIR_ARG \
+    --root="${DESTDIR-/}" \
     @SETUPTOOLS_ARG_EXTRA@ --prefix="@CMAKE_INSTALL_PREFIX@" --install-scripts="@CMAKE_INSTALL_PREFIX@/@CATKIN_GLOBAL_BIN_DESTINATION@"


### PR DESCRIPTION
I believe this is the minimal change resolving #1060, which arises from the change made in #1048.

For the non-DESTDIR case:

```
$ cmake .. -DCMAKE_INSTALL_PREFIX=./install -DPYTHON_EXECUTABLE=/usr/bin/python3
$ make install
$ find install -name *.py -o -name *.pth
install/_setup_util.py
install/lib/python3/dist-packages/catkin/builder.py
install/lib/python3/dist-packages/catkin/terminal_color.py
install/lib/python3/dist-packages/catkin/package_version.py
install/lib/python3/dist-packages/catkin/environment_cache.py
install/lib/python3/dist-packages/catkin/__init__.py
install/lib/python3/dist-packages/catkin/test_results.py
install/lib/python3/dist-packages/catkin/workspace.py
install/lib/python3/dist-packages/catkin/init_workspace.py
install/lib/python3/dist-packages/catkin/cmake.py
install/lib/python3/dist-packages/catkin/find_in_workspaces.py
install/lib/python3/dist-packages/catkin/workspace_vcs.py
install/lib/python3/dist-packages/catkin/tidy_xml.py
install/share/catkin/cmake/parse_package_xml.py
install/share/catkin/cmake/order_paths.py
install/share/catkin/cmake/interrogate_setup_dot_py.py
install/share/catkin/cmake/test/download_checkmd5.py
install/share/catkin/cmake/test/remove_test_results.py
install/share/catkin/cmake/test/run_tests.py
```

For the DESTDIR case:

```
$ cmake .. -DCMAKE_INSTALL_PREFIX=/opt/ros/banana -DPYTHON_EXECUTABLE=/usr/bin/python3
$ DESTDIR=$(pwd)/install make install
$ find install -name *.py -o -name *.pth
install/opt/ros/banana/_setup_util.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/builder.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/terminal_color.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/package_version.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/environment_cache.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/__init__.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/test_results.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/workspace.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/init_workspace.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/cmake.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/find_in_workspaces.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/workspace_vcs.py
install/opt/ros/banana/lib/python3/dist-packages/catkin/tidy_xml.py
install/opt/ros/banana/share/catkin/cmake/parse_package_xml.py
install/opt/ros/banana/share/catkin/cmake/order_paths.py
install/opt/ros/banana/share/catkin/cmake/interrogate_setup_dot_py.py
install/opt/ros/banana/share/catkin/cmake/test/download_checkmd5.py
install/opt/ros/banana/share/catkin/cmake/test/remove_test_results.py
install/opt/ros/banana/share/catkin/cmake/test/run_tests.py
```

The non-DESTDIR case is what's currently broken in 0.8.0. It looks like this **without** the change proposed here— the shared `easy-install.pth` and `site.py` files are the core of the problem:

```
$ find install -name *.py -o -name *.pth
install/_setup_util.py
install/lib/python3/dist-packages/easy-install.pth
install/lib/python3/dist-packages/site.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/builder.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/terminal_color.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/package_version.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/environment_cache.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/__init__.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/test_results.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/workspace.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/init_workspace.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/cmake.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/find_in_workspaces.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/workspace_vcs.py
install/lib/python3/dist-packages/catkin-0.8.0-py3.5.egg/catkin/tidy_xml.py
install/share/catkin/cmake/parse_package_xml.py
install/share/catkin/cmake/order_paths.py
install/share/catkin/cmake/interrogate_setup_dot_py.py
install/share/catkin/cmake/test/download_checkmd5.py
install/share/catkin/cmake/test/remove_test_results.py
install/share/catkin/cmake/test/run_tests.py
```

I haven't made any alterations to the Windows version of this logic as I'm not sure if anything is needed there or how to properly test it.

FYI @dirk-thomas @sloretz 