### PR TITLE
Set egg-base for setuptools packages

### DIFF
--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -31,29 +31,6 @@ function(catkin_python_setup)
     message(FATAL_ERROR "catkin_python_setup() called without 'setup.py' in project folder ' ${${PROJECT_NAME}_SOURCE_DIR}'")
   endif()
 
-  assert(PYTHON_INSTALL_DIR)
-  set(INSTALL_CMD_WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR})
-  if(NOT WIN32)
-    set(INSTALL_SCRIPT
-      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.sh)
-    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.sh.in
-      ${INSTALL_SCRIPT}
-      @ONLY)
-  else()
-    # need to convert install prefix to native path for python setuptools --prefix (its fussy about \'s)
-    file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} PYTHON_INSTALL_PREFIX)
-    set(INSTALL_SCRIPT
-      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.bat)
-    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.bat.in
-      ${INSTALL_SCRIPT}
-      @ONLY)
-  endif()
-
-  # generate python script which gets executed at install time
-  configure_file(${catkin_EXTRAS_DIR}/templates/safe_execute_install.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
-  install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
-
   # interrogate setup.py
   stamp(${${PROJECT_NAME}_SOURCE_DIR}/setup.py)
   assert(CATKIN_ENV)
@@ -163,6 +140,34 @@ function(catkin_python_setup)
       TARGET_NAME ${PROJECT_NAME}_${name}_exec_install
       DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
   endforeach()
+
+  if(${PROJECT_NAME}_SETUP_PY_SETUP_MODULE STREQUAL setuptools)
+    message(STATUS "Appending egg base")
+    set(SETUPTOOLS_EGG_INFO "egg_info --egg-base ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}")
+  endif()
+
+  assert(PYTHON_INSTALL_DIR)
+  set(INSTALL_CMD_WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR})
+  if(NOT WIN32)
+    set(INSTALL_SCRIPT
+      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.sh)
+    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.sh.in
+      ${INSTALL_SCRIPT}
+      @ONLY)
+  else()
+    # need to convert install prefix to native path for python setuptools --prefix (its fussy about \'s)
+    file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} PYTHON_INSTALL_PREFIX)
+    set(INSTALL_SCRIPT
+      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.bat)
+    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.bat.in
+      ${INSTALL_SCRIPT}
+      @ONLY)
+  endif()
+
+  # generate python script which gets executed at install time
+  configure_file(${catkin_EXTRAS_DIR}/templates/safe_execute_install.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
+  install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
 endfunction()
 
 stamp(${catkin_EXTRAS_DIR}/interrogate_setup_dot_py.py)

--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -141,12 +141,13 @@ function(catkin_python_setup)
       DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
   endforeach()
 
-  if(${PROJECT_NAME}_SETUP_PY_SETUP_MODULE STREQUAL setuptools)
-    message(STATUS "Appending egg base")
+  assert(PYTHON_INSTALL_DIR)
+  if(${PROJECT_NAME}_SETUP_PY_SETUP_MODULE STREQUAL "setuptools")
     set(SETUPTOOLS_EGG_INFO "egg_info --egg-base ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}")
+  else()
+    set(SETUPTOOLS_EGG_INFO "")
   endif()
 
-  assert(PYTHON_INSTALL_DIR)
   set(INSTALL_CMD_WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR})
   if(NOT WIN32)
     set(INSTALL_SCRIPT

--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -92,19 +92,21 @@ def _get_locations(pkgs, package_dir):
     return locations
 
 
-def generate_cmake_file(setup_module, package_name, version, scripts, package_dir, pkgs, modules):
+def generate_cmake_file(package_name, version, scripts, package_dir, pkgs, modules, setup_module=None):
     """
     Generate lines to add to a cmake file which will set variables.
 
     :param version: str, format 'int.int.int'
     :param scripts: [list of str]: relative paths to scripts
     :param package_dir: {modulename: path}
-    :pkgs: [list of str] python_packages declared in catkin package
-    :modules: [list of str] python modules
+    :param pkgs: [list of str] python_packages declared in catkin package
+    :param modules: [list of str] python modules
+    :param setup_module: str, setuptools or distutils
     """
     prefix = '%s_SETUP_PY' % package_name
     result = []
-    result.append(r'set(%s_SETUP_MODULE "%s")' % (prefix, setup_module))
+    if setup_module:
+        result.append(r'set(%s_SETUP_MODULE "%s")' % (prefix, setup_module))
     result.append(r'set(%s_VERSION "%s")' % (prefix, version))
     result.append(r'set(%s_SCRIPTS "%s")' % (prefix, ';'.join(scripts)))
 
@@ -198,13 +200,13 @@ def _create_mock_setup_function(setup_module, package_name, outfile):
         if used_unsupported_args:
             sys.stderr.write('*** Arguments %s to setup() not supported in catkin devel space in setup.py of %s\n' % (used_unsupported_args, package_name))
 
-        result = generate_cmake_file(setup_module=setup_module,
-                                     package_name=package_name,
+        result = generate_cmake_file(package_name=package_name,
                                      version=version,
                                      scripts=scripts,
                                      package_dir=package_dir,
                                      pkgs=pkgs,
-                                     modules=modules)
+                                     modules=modules,
+                                     setup_module=setup_module)
         with open(outfile, 'w') as out:
             out.write('\n'.join(result))
 

--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -26,6 +26,7 @@ echo_and_run /usr/bin/env \
     CATKIN_BINARY_DIR="@CMAKE_BINARY_DIR@" \
     "@PYTHON_EXECUTABLE@" \
     "@CMAKE_CURRENT_SOURCE_DIR@/setup.py" \
+    @SETUPTOOLS_EGG_INFO@ \
     build --build-base "@CMAKE_CURRENT_BINARY_DIR@" \
     install \
     --root="${DESTDIR-/}" \

--- a/test/unit_tests/test_interrogate_setup.py
+++ b/test/unit_tests/test_interrogate_setup.py
@@ -16,46 +16,55 @@ from interrogate_setup_dot_py import generate_cmake_file  # noqa: E402
 class InterrogateSetupTest(unittest.TestCase):
 
     def test_generate_cmake_file(self):
-        cmake_lines = (generate_cmake_file(setup_module='setuptools',
-                                           package_name='pack1',
+        cmake_lines = (generate_cmake_file(package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={'': 'foopath'},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
-                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "foopath/foo;foopath/bar")',
                           'set(pack1_SETUP_PY_MODULES "")',
                           'set(pack1_SETUP_PY_MODULE_DIRS "")'],
                          cmake_lines)
-        cmake_lines = (generate_cmake_file(setup_module='setuptools',
-                                           package_name='pack1',
+        cmake_lines = (generate_cmake_file(package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
-                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "foo;bar")',
                           'set(pack1_SETUP_PY_MODULES "")',
                           'set(pack1_SETUP_PY_MODULE_DIRS "")'],
                          cmake_lines)
-        cmake_lines = (generate_cmake_file(setup_module='setuptools',
-                                           package_name='pack1',
+        cmake_lines = (generate_cmake_file(package_name='pack1',
                                            version='0.0.1',
                                            scripts=['bin/foo', 'nodes/bar'],
                                            package_dir={},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
+        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
+                          'set(pack1_SETUP_PY_SCRIPTS "bin/foo;nodes/bar")',
+                          'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
+                          'set(pack1_SETUP_PY_PACKAGE_DIRS "foo;bar")',
+                          'set(pack1_SETUP_PY_MODULES "")',
+                          'set(pack1_SETUP_PY_MODULE_DIRS "")'],
+                         cmake_lines)
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=[],
+                                           package_dir={},
+                                           pkgs=['foo', 'bar', 'bar.sub'],
+                                           modules=[],
+                                           setup_module='setuptools'))
         self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
                           'set(pack1_SETUP_PY_VERSION "0.0.1")',
-                          'set(pack1_SETUP_PY_SCRIPTS "bin/foo;nodes/bar")',
+                          'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "foo;bar")',
                           'set(pack1_SETUP_PY_MODULES "")',
@@ -74,16 +83,14 @@ class InterrogateSetupTest(unittest.TestCase):
                          _get_locations(['foo.bar'], {'foo': 'src'}))
 
     def test_generate_cmake_file_noallprefix(self):
-        cmake_lines = (generate_cmake_file(setup_module='setuptools',
-                                           package_name='pack1',
+        cmake_lines = (generate_cmake_file(package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={'foo': 'src',
                                                         'bar': 'lib'},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
-                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "src;lib")',
@@ -92,8 +99,7 @@ class InterrogateSetupTest(unittest.TestCase):
                          cmake_lines)
 
     def test_generate_cmake_file_msg_srv(self):
-        cmake_lines = (generate_cmake_file(setup_module='setuptools',
-                                           package_name='pack1',
+        cmake_lines = (generate_cmake_file(package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={'foo.msg': 'msg',
@@ -101,8 +107,7 @@ class InterrogateSetupTest(unittest.TestCase):
                                                         '': 'src'},
                                            pkgs=['foo.msg', 'foo.srv', 'foo'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
-                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "src/foo")',
@@ -113,7 +118,6 @@ class InterrogateSetupTest(unittest.TestCase):
     def test_generate_cmake_file_invalid(self):
         self.assertRaises(RuntimeError,
                           generate_cmake_file,
-                          setup_module='setuptools',
                           package_name='pack1',
                           version='0.0.1',
                           scripts=[],

--- a/test/unit_tests/test_interrogate_setup.py
+++ b/test/unit_tests/test_interrogate_setup.py
@@ -16,39 +16,45 @@ from interrogate_setup_dot_py import generate_cmake_file  # noqa: E402
 class InterrogateSetupTest(unittest.TestCase):
 
     def test_generate_cmake_file(self):
-        cmake_lines = (generate_cmake_file(package_name='pack1',
+        cmake_lines = (generate_cmake_file(setup_module='setuptools',
+                                           package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={'': 'foopath'},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
+                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "foopath/foo;foopath/bar")',
                           'set(pack1_SETUP_PY_MODULES "")',
                           'set(pack1_SETUP_PY_MODULE_DIRS "")'],
                          cmake_lines)
-        cmake_lines = (generate_cmake_file(package_name='pack1',
+        cmake_lines = (generate_cmake_file(setup_module='setuptools',
+                                           package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
+                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "foo;bar")',
                           'set(pack1_SETUP_PY_MODULES "")',
                           'set(pack1_SETUP_PY_MODULE_DIRS "")'],
                          cmake_lines)
-        cmake_lines = (generate_cmake_file(package_name='pack1',
+        cmake_lines = (generate_cmake_file(setup_module='setuptools',
+                                           package_name='pack1',
                                            version='0.0.1',
                                            scripts=['bin/foo', 'nodes/bar'],
                                            package_dir={},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
+                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "bin/foo;nodes/bar")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "foo;bar")',
@@ -68,14 +74,16 @@ class InterrogateSetupTest(unittest.TestCase):
                          _get_locations(['foo.bar'], {'foo': 'src'}))
 
     def test_generate_cmake_file_noallprefix(self):
-        cmake_lines = (generate_cmake_file(package_name='pack1',
+        cmake_lines = (generate_cmake_file(setup_module='setuptools',
+                                           package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={'foo': 'src',
                                                         'bar': 'lib'},
                                            pkgs=['foo', 'bar', 'bar.sub'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
+                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "src;lib")',
@@ -84,7 +92,8 @@ class InterrogateSetupTest(unittest.TestCase):
                          cmake_lines)
 
     def test_generate_cmake_file_msg_srv(self):
-        cmake_lines = (generate_cmake_file(package_name='pack1',
+        cmake_lines = (generate_cmake_file(setup_module='setuptools',
+                                           package_name='pack1',
                                            version='0.0.1',
                                            scripts=[],
                                            package_dir={'foo.msg': 'msg',
@@ -92,7 +101,8 @@ class InterrogateSetupTest(unittest.TestCase):
                                                         '': 'src'},
                                            pkgs=['foo.msg', 'foo.srv', 'foo'],
                                            modules=[]))
-        self.assertEqual(['set(pack1_SETUP_PY_VERSION "0.0.1")',
+        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
+                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
                           'set(pack1_SETUP_PY_SCRIPTS "")',
                           'set(pack1_SETUP_PY_PACKAGES "foo")',
                           'set(pack1_SETUP_PY_PACKAGE_DIRS "src/foo")',
@@ -103,6 +113,7 @@ class InterrogateSetupTest(unittest.TestCase):
     def test_generate_cmake_file_invalid(self):
         self.assertRaises(RuntimeError,
                           generate_cmake_file,
+                          setup_module='setuptools',
                           package_name='pack1',
                           version='0.0.1',
                           scripts=[],
@@ -116,14 +127,15 @@ class InterrogateSetupTest(unittest.TestCase):
         try:
             rootdir = tempfile.mkdtemp()
             outfile = os.path.join(rootdir, 'out.cmake')
-            fake_setup = _create_mock_setup_function('foo', outfile)
+            fake_setup = _create_mock_setup_function('setuptools', 'foo', outfile)
             self.assertRaises(RuntimeError, fake_setup, package_dir={'': 'src'})
             # simple setup
             fake_setup(version='0.1.1', package_dir={'': 'src'})
             self.assertTrue(os.path.isfile(outfile))
             with open(outfile, 'r') as fhand:
                 contents = fhand.read()
-            self.assertEqual("""set(foo_SETUP_PY_VERSION "0.1.1")
+            self.assertEqual("""set(foo_SETUP_PY_SETUP_MODULE "setuptools")
+set(foo_SETUP_PY_VERSION "0.1.1")
 set(foo_SETUP_PY_SCRIPTS "")
 set(foo_SETUP_PY_PACKAGES "")
 set(foo_SETUP_PY_PACKAGE_DIRS "")
@@ -135,7 +147,8 @@ set(foo_SETUP_PY_MODULE_DIRS "")""", contents)
             self.assertTrue(os.path.isfile(outfile))
             with open(outfile, 'r') as fhand:
                 contents = fhand.read()
-            self.assertEqual("""set(foo_SETUP_PY_VERSION "0.1.1")
+            self.assertEqual("""set(foo_SETUP_PY_SETUP_MODULE "setuptools")
+set(foo_SETUP_PY_VERSION "0.1.1")
 set(foo_SETUP_PY_SCRIPTS "bin/foo;nodes/bar")
 set(foo_SETUP_PY_PACKAGES "foo;bar")
 set(foo_SETUP_PY_PACKAGE_DIRS "foo;bar")
@@ -147,7 +160,8 @@ set(foo_SETUP_PY_MODULE_DIRS "")""", contents)
             self.assertTrue(os.path.isfile(outfile))
             with open(outfile, 'r') as fhand:
                 contents = fhand.read()
-            self.assertEqual("""set(foo_SETUP_PY_VERSION "0.1.1")
+            self.assertEqual("""set(foo_SETUP_PY_SETUP_MODULE "setuptools")
+set(foo_SETUP_PY_VERSION "0.1.1")
 set(foo_SETUP_PY_SCRIPTS "")
 set(foo_SETUP_PY_PACKAGES "foo;bar")
 set(foo_SETUP_PY_PACKAGE_DIRS "src;lib")


### PR DESCRIPTION
Addresses #1069.

Based on @sloretz's [suggestion](https://github.com/ros/catkin/pull/1048#discussion_r392337794) of setting `--egg-base`, with some code loosely adapted from @mikepurvis's [suggestion](https://github.com/ros/catkin/pull/1048#discussion_r392345260).

Tested on Melodic with each tool on both a distutils and a setuptools package:
```
catkin_make
catkin_make install
catkin_make_isolated
catkin_make_isolated --install
catkin config --no-install; catkin build
catkin config --install; catkin build
colcon build
colcon build --merge-install
```

I haven't had a chance to test this with Python 3, would appreciate help there.