### PR TITLE
[kinetic][melodic] Backport set egg base #1073

### DIFF
--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -31,29 +31,6 @@ function(catkin_python_setup)
     message(FATAL_ERROR "catkin_python_setup() called without 'setup.py' in project folder ' ${${PROJECT_NAME}_SOURCE_DIR}'")
   endif()
 
-  assert(PYTHON_INSTALL_DIR)
-  set(INSTALL_CMD_WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR})
-  if(NOT WIN32)
-    set(INSTALL_SCRIPT
-      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.sh)
-    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.sh.in
-      ${INSTALL_SCRIPT}
-      @ONLY)
-  else()
-    # need to convert install prefix to native path for python setuptools --prefix (its fussy about \'s)
-    file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} PYTHON_INSTALL_PREFIX)
-    set(INSTALL_SCRIPT
-      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.bat)
-    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.bat.in
-      ${INSTALL_SCRIPT}
-      @ONLY)
-  endif()
-
-  # generate python script which gets executed at install time
-  configure_file(${catkin_EXTRAS_DIR}/templates/safe_execute_install.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
-  install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
-
   # interrogate setup.py
   stamp(${${PROJECT_NAME}_SOURCE_DIR}/setup.py)
   assert(CATKIN_ENV)
@@ -163,6 +140,35 @@ function(catkin_python_setup)
       TARGET_NAME ${PROJECT_NAME}_${name}_exec_install
       DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
   endforeach()
+
+  assert(PYTHON_INSTALL_DIR)
+  if(${PROJECT_NAME}_SETUP_PY_SETUP_MODULE STREQUAL "setuptools")
+    set(SETUPTOOLS_EGG_INFO "egg_info --egg-base ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}")
+  else()
+    set(SETUPTOOLS_EGG_INFO "")
+  endif()
+
+  set(INSTALL_CMD_WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR})
+  if(NOT WIN32)
+    set(INSTALL_SCRIPT
+      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.sh)
+    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.sh.in
+      ${INSTALL_SCRIPT}
+      @ONLY)
+  else()
+    # need to convert install prefix to native path for python setuptools --prefix (its fussy about \'s)
+    file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} PYTHON_INSTALL_PREFIX)
+    set(INSTALL_SCRIPT
+      ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/python_distutils_install.bat)
+    configure_file(${catkin_EXTRAS_DIR}/templates/python_distutils_install.bat.in
+      ${INSTALL_SCRIPT}
+      @ONLY)
+  endif()
+
+  # generate python script which gets executed at install time
+  configure_file(${catkin_EXTRAS_DIR}/templates/safe_execute_install.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
+  install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/catkin_generated/safe_execute_install.cmake)
 endfunction()
 
 stamp(${catkin_EXTRAS_DIR}/interrogate_setup_dot_py.py)

--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -26,6 +26,7 @@ echo_and_run /usr/bin/env \
     CATKIN_BINARY_DIR="@CMAKE_BINARY_DIR@" \
     "@PYTHON_EXECUTABLE@" \
     "@CMAKE_CURRENT_SOURCE_DIR@/setup.py" \
+    @SETUPTOOLS_EGG_INFO@ \
     build --build-base "@CMAKE_CURRENT_BINARY_DIR@" \
     install \
     --root="${DESTDIR-/}" \

--- a/test/unit_tests/test_interrogate_setup.py
+++ b/test/unit_tests/test_interrogate_setup.py
@@ -55,6 +55,21 @@ class InterrogateSetupTest(unittest.TestCase):
                           'set(pack1_SETUP_PY_MODULES "")',
                           'set(pack1_SETUP_PY_MODULE_DIRS "")'],
                          cmake_lines)
+        cmake_lines = (generate_cmake_file(package_name='pack1',
+                                           version='0.0.1',
+                                           scripts=[],
+                                           package_dir={},
+                                           pkgs=['foo', 'bar', 'bar.sub'],
+                                           modules=[],
+                                           setup_module='setuptools'))
+        self.assertEqual(['set(pack1_SETUP_PY_SETUP_MODULE "setuptools")',
+                          'set(pack1_SETUP_PY_VERSION "0.0.1")',
+                          'set(pack1_SETUP_PY_SCRIPTS "")',
+                          'set(pack1_SETUP_PY_PACKAGES "foo;bar")',
+                          'set(pack1_SETUP_PY_PACKAGE_DIRS "foo;bar")',
+                          'set(pack1_SETUP_PY_MODULES "")',
+                          'set(pack1_SETUP_PY_MODULE_DIRS "")'],
+                         cmake_lines)
 
     def test_get_locations(self):
         self.assertEqual({'foo': 'foo'}, _get_locations(['foo'], {}))
@@ -116,14 +131,15 @@ class InterrogateSetupTest(unittest.TestCase):
         try:
             rootdir = tempfile.mkdtemp()
             outfile = os.path.join(rootdir, 'out.cmake')
-            fake_setup = _create_mock_setup_function('foo', outfile)
+            fake_setup = _create_mock_setup_function('setuptools', 'foo', outfile)
             self.assertRaises(RuntimeError, fake_setup, package_dir={'': 'src'})
             # simple setup
             fake_setup(version='0.1.1', package_dir={'': 'src'})
             self.assertTrue(os.path.isfile(outfile))
             with open(outfile, 'r') as fhand:
                 contents = fhand.read()
-            self.assertEqual("""set(foo_SETUP_PY_VERSION "0.1.1")
+            self.assertEqual("""set(foo_SETUP_PY_SETUP_MODULE "setuptools")
+set(foo_SETUP_PY_VERSION "0.1.1")
 set(foo_SETUP_PY_SCRIPTS "")
 set(foo_SETUP_PY_PACKAGES "")
 set(foo_SETUP_PY_PACKAGE_DIRS "")
@@ -135,7 +151,8 @@ set(foo_SETUP_PY_MODULE_DIRS "")""", contents)
             self.assertTrue(os.path.isfile(outfile))
             with open(outfile, 'r') as fhand:
                 contents = fhand.read()
-            self.assertEqual("""set(foo_SETUP_PY_VERSION "0.1.1")
+            self.assertEqual("""set(foo_SETUP_PY_SETUP_MODULE "setuptools")
+set(foo_SETUP_PY_VERSION "0.1.1")
 set(foo_SETUP_PY_SCRIPTS "bin/foo;nodes/bar")
 set(foo_SETUP_PY_PACKAGES "foo;bar")
 set(foo_SETUP_PY_PACKAGE_DIRS "foo;bar")
@@ -147,7 +164,8 @@ set(foo_SETUP_PY_MODULE_DIRS "")""", contents)
             self.assertTrue(os.path.isfile(outfile))
             with open(outfile, 'r') as fhand:
                 contents = fhand.read()
-            self.assertEqual("""set(foo_SETUP_PY_VERSION "0.1.1")
+            self.assertEqual("""set(foo_SETUP_PY_SETUP_MODULE "setuptools")
+set(foo_SETUP_PY_VERSION "0.1.1")
 set(foo_SETUP_PY_SCRIPTS "")
 set(foo_SETUP_PY_PACKAGES "foo;bar")
 set(foo_SETUP_PY_PACKAGE_DIRS "src;lib")


### PR DESCRIPTION
This is a cherry-pick of #1073 onto the `kinetic-devel` branch. I confirmed #1069 affects those branches in both ROS Kinetic and Melodic docker images, and that this cherry-pick fixes the issue.

Test setup

* workspace with two packages and `src` set to be read only
   *  [`angles` at commit `fe974f2d84b719d3aa0593a4bf633183d75ba213`](https://github.com/ros/angles/tree/fe974f2d84b719d3aa0593a4bf633183d75ba213) which uses setuptools
   * a package `dist_angles` made by copying enough of `angles` to build a package, changing the name, and using `distutils.core` instead of `setuptools`
* Separate workspace with just `catkin` checked out this PR
* custom ROS Kinetic docker container
* custom ROS Melodic docker container

I confirmed using the latest release of catkin that #1069 is an issue using both `catkin_make install` and `catkin_make_isolated --install` in ROS Kinetic and Melodic. I did not try `catkin-tools` in either distro.

<details><summary>Kinetic `catkin_make install` permission denied error</summary>

```
creating src/angles.egg-info
error: could not create 'src/angles.egg-info': Permission denied
CMake Error at angles/angles/catkin_generated/safe_execute_install.cmake:4 (message):
  
  execute_process(/home/sloretz/ws/egginfo/build/angles/angles/catkin_generated/python_distutils_install.sh)
  returned error code
Call Stack (most recent call first):
  angles/angles/cmake_install.cmake:55 (include)
  cmake_install.cmake:129 (include)
```
</details>

<details><summary>Kinetic `catkin_make_isolated --install` permission denied error</summary>

```
creating src/angles.egg-info
error: could not create 'src/angles.egg-info': Permission denied
CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):
  
  execute_process(/home/sloretz/ws/egginfo/build_isolated/angles/catkin_generated/python_distutils_install.sh)
  returned error code
Call Stack (most recent call first):
  cmake_install.cmake:146 (include)
```
</details>

<details><summary>Melodic `catkin_make install` permission denied error</summary>

```
creating src/angles.egg-info
error: could not create 'src/angles.egg-info': Permission denied
CMake Error at angles/angles/catkin_generated/safe_execute_install.cmake:4 (message):
  
  execute_process(/home/sloretz/ws/egginfo/build/angles/angles/catkin_generated/python_distutils_install.sh)
  returned error code
Call Stack (most recent call first):
  angles/angles/cmake_install.cmake:60 (include)
  cmake_install.cmake:134 (include)

```
</details>

<details><summary>Melodic `catkin_make_isolated --install` permission denied error</summary>

```
creating src/angles.egg-info
error: could not create 'src/angles.egg-info': Permission denied
CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):
  
  execute_process(/home/sloretz/ws/egginfo/build_isolated/angles/catkin_generated/python_distutils_install.sh)
  returned error code
Call Stack (most recent call first):
  cmake_install.cmake:151 (include)
```
</details>

I deleted the `build`, `build_isolated`, `devel`, `devel_isolated`, `install`, `install_isolated` folders between each invocation. After this, I built the workspace with catkin from this PR, made sure `which catkin_make` showed this workspace, and repeated the same process in both containers. This time the builds all succeeded.


<details><summary>Kinetic `catkin_make install` build success</summary>

```
$ catkin_make install
Base path: /home/sloretz/ws/egginfo
Source space: /home/sloretz/ws/egginfo/src
Build space: /home/sloretz/ws/egginfo/build
Devel space: /home/sloretz/ws/egginfo/devel
Install space: /home/sloretz/ws/egginfo/install
####
#### Running command: "cmake /home/sloretz/ws/egginfo/src -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/egginfo/devel -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/egginfo/install -G Unix Makefiles" in "/home/sloretz/ws/egginfo/build"
####
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/sloretz/ws/egginfo/devel
-- Using CMAKE_PREFIX_PATH: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/kinetic
-- This workspace overlays: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/kinetic
-- Found PythonInterp: /usr/bin/python (found version "2.7.12") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/sloretz/ws/egginfo/build/test_results
-- Found gtest sources under '/usr/src/gmock': gtests will be built
-- Found gmock sources under '/usr/src/gmock': gmock will be built
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.23
-- BUILD_SHARED_LIBS is on
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 2 packages in topological order:
-- ~~  - angles
-- ~~  - dist_angles
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'angles'
-- ==> add_subdirectory(angles/angles)
-- +++ processing catkin package: 'dist_angles'
-- ==> add_subdirectory(dist_angles)
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sloretz/ws/egginfo/build
####
#### Running command: "make install -j8 -l8" in "/home/sloretz/ws/egginfo/build"
####
Install the project...
-- Install configuration: ""
-- Installing: /home/sloretz/ws/egginfo/install/_setup_util.py
-- Installing: /home/sloretz/ws/egginfo/install/env.sh
-- Installing: /home/sloretz/ws/egginfo/install/setup.bash
-- Installing: /home/sloretz/ws/egginfo/install/local_setup.bash
-- Installing: /home/sloretz/ws/egginfo/install/setup.sh
-- Installing: /home/sloretz/ws/egginfo/install/local_setup.sh
-- Installing: /home/sloretz/ws/egginfo/install/setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install/local_setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install/.rosinstall
-- Installing: /home/sloretz/ws/egginfo/install/lib/pkgconfig/angles.pc
-- Installing: /home/sloretz/ws/egginfo/install/share/angles/cmake/anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/angles/cmake/anglesConfig-version.cmake
-- Up-to-date: /home/sloretz/ws/egginfo/install/share/angles/package.xml
-- Up-to-date: /home/sloretz/ws/egginfo/install/include/angles
-- Up-to-date: /home/sloretz/ws/egginfo/install/include/angles/angles.h
+ cd /home/sloretz/ws/egginfo/src/angles/angles
+ mkdir -p /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build /usr/bin/python /home/sloretz/ws/egginfo/src/angles/angles/setup.py egg_info --egg-base /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages build --build-base /home/sloretz/ws/egginfo/build/angles/angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install --install-scripts=/home/sloretz/ws/egginfo/install/bin
running egg_info
creating /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info
writing /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/PKG-INFO
writing top-level names to /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/top_level.txt
writing dependency_links to /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/dependency_links.txt
writing manifest file '/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
reading manifest file '/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
writing manifest file '/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
running build
running build_py
creating /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7/angles
copying src/angles/__init__.py -> /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7/angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles
copying /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7/angles/__init__.py -> /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles
byte-compiling /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles/__init__.py to __init__.pyc
running install_egg_info
Copying /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info to /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles-1.9.13.egg-info
Skipping SOURCES.txt
running install_scripts
-- Installing: /home/sloretz/ws/egginfo/install/lib/pkgconfig/dist_angles.pc
-- Installing: /home/sloretz/ws/egginfo/install/share/dist_angles/cmake/dist_anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/dist_angles/cmake/dist_anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/dist_angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install/include/dist_angles
-- Installing: /home/sloretz/ws/egginfo/install/include/dist_angles/tada.h
+ cd /home/sloretz/ws/egginfo/src/dist_angles
+ mkdir -p /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build /usr/bin/python /home/sloretz/ws/egginfo/src/dist_angles/setup.py build --build-base /home/sloretz/ws/egginfo/build/dist_angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install --install-scripts=/home/sloretz/ws/egginfo/install/bin
running build
running build_py
creating /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7/dist_angles
copying src/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7/dist_angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles
copying /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles
byte-compiling /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles/__init__.py to __init__.pyc
running install_egg_info
Writing /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles-1.9.13.egg-info
```
</details>

<details><summary>Kinetic `catkin_make_isolated --install` build success</summary>

```
$ catkin_make_isolated --install
Base path: /home/sloretz/ws/egginfo
Source space: /home/sloretz/ws/egginfo/src
Build space: /home/sloretz/ws/egginfo/build_isolated
Devel space: /home/sloretz/ws/egginfo/devel_isolated
Install space: /home/sloretz/ws/egginfo/install_isolated
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~  traversing 2 packages in topological order:
~~  - angles
~~  - dist_angles
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
The packages or cmake arguments have changed, forcing cmake invocation

==> Processing catkin package: 'angles'
==> Creating build directory: 'build_isolated/angles'
==> cmake /home/sloretz/ws/egginfo/src/angles/angles -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/egginfo/devel_isolated/angles -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/egginfo/install_isolated -G Unix Makefiles in '/home/sloretz/ws/egginfo/build_isolated/angles'
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/sloretz/ws/egginfo/devel_isolated/angles
-- Using CMAKE_PREFIX_PATH: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/kinetic
-- This workspace overlays: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/kinetic
-- Found PythonInterp: /usr/bin/python (found version "2.7.12") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/sloretz/ws/egginfo/build_isolated/angles/test_results
-- Found gtest sources under '/usr/src/gmock': gtests will be built
-- Found gmock sources under '/usr/src/gmock': gmock will be built
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.23
-- BUILD_SHARED_LIBS is on
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sloretz/ws/egginfo/build_isolated/angles
==> make -j8 -l8 in '/home/sloretz/ws/egginfo/build_isolated/angles'
==> make install in '/home/sloretz/ws/egginfo/build_isolated/angles'
Install the project...
-- Install configuration: ""
-- Installing: /home/sloretz/ws/egginfo/install_isolated/_setup_util.py
-- Installing: /home/sloretz/ws/egginfo/install_isolated/env.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/.rosinstall
-- Installing: /home/sloretz/ws/egginfo/install_isolated/lib/pkgconfig/angles.pc
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/angles/cmake/anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/angles/cmake/anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/angles
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/angles/angles.h
+ cd /home/sloretz/ws/egginfo/src/angles/angles
+ mkdir -p /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build_isolated/angles/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build_isolated/angles /usr/bin/python /home/sloretz/ws/egginfo/src/angles/angles/setup.py egg_info --egg-base /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages build --build-base /home/sloretz/ws/egginfo/build_isolated/angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install_isolated --install-scripts=/home/sloretz/ws/egginfo/install_isolated/bin
running egg_info
creating /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info
writing /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/PKG-INFO
writing top-level names to /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/top_level.txt
writing dependency_links to /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/dependency_links.txt
writing manifest file '/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
reading manifest file '/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
writing manifest file '/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
running build
running build_py
creating /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7/angles
copying src/angles/__init__.py -> /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7/angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles
copying /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7/angles/__init__.py -> /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles
byte-compiling /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles/__init__.py to __init__.pyc
running install_egg_info
Copying /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info to /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles-1.9.13.egg-info
Skipping SOURCES.txt
running install_scripts
<== Finished processing package [1 of 2]: 'angles'

==> Processing catkin package: 'dist_angles'
==> Creating build directory: 'build_isolated/dist_angles'
==> Building with env: '/home/sloretz/ws/egginfo/install_isolated/env.sh'
==> cmake /home/sloretz/ws/egginfo/src/dist_angles -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/egginfo/devel_isolated/dist_angles -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/egginfo/install_isolated -G Unix Makefiles in '/home/sloretz/ws/egginfo/build_isolated/dist_angles'
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/sloretz/ws/egginfo/devel_isolated/dist_angles
-- Using CMAKE_PREFIX_PATH: /home/sloretz/ws/egginfo/install_isolated;/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/kinetic
-- This workspace overlays: /home/sloretz/ws/egginfo/install_isolated;/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/kinetic
-- Found PythonInterp: /usr/bin/python (found version "2.7.12") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/sloretz/ws/egginfo/build_isolated/dist_angles/test_results
-- Found gtest sources under '/usr/src/gmock': gtests will be built
-- Found gmock sources under '/usr/src/gmock': gmock will be built
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.23
-- BUILD_SHARED_LIBS is on
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sloretz/ws/egginfo/build_isolated/dist_angles
==> make -j8 -l8 in '/home/sloretz/ws/egginfo/build_isolated/dist_angles'
==> make install in '/home/sloretz/ws/egginfo/build_isolated/dist_angles'
Install the project...
-- Install configuration: ""
-- Installing: /home/sloretz/ws/egginfo/install_isolated/_setup_util.py
-- Installing: /home/sloretz/ws/egginfo/install_isolated/env.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/.rosinstall
-- Installing: /home/sloretz/ws/egginfo/install_isolated/lib/pkgconfig/dist_angles.pc
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/dist_angles/cmake/dist_anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/dist_angles/cmake/dist_anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/dist_angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/dist_angles
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/dist_angles/tada.h
+ cd /home/sloretz/ws/egginfo/src/dist_angles
+ mkdir -p /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build_isolated/dist_angles/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build_isolated/dist_angles /usr/bin/python /home/sloretz/ws/egginfo/src/dist_angles/setup.py build --build-base /home/sloretz/ws/egginfo/build_isolated/dist_angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install_isolated --install-scripts=/home/sloretz/ws/egginfo/install_isolated/bin
running build
running build_py
creating /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7/dist_angles
copying src/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7/dist_angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles
copying /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles
byte-compiling /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles/__init__.py to __init__.pyc
running install_egg_info
Writing /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles-1.9.13.egg-info
<== Finished processing package [2 of 2]: 'dist_angles'
```
</details>

<details><summary>Melodic `catkin_make install` build success</summary>

```
$ catkin_make install
Base path: /home/sloretz/ws/egginfo
Source space: /home/sloretz/ws/egginfo/src
Build space: /home/sloretz/ws/egginfo/build
Devel space: /home/sloretz/ws/egginfo/devel
Install space: /home/sloretz/ws/egginfo/install
####
#### Running command: "cmake /home/sloretz/ws/egginfo/src -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/egginfo/devel -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/egginfo/install -G Unix Makefiles" in "/home/sloretz/ws/egginfo/build"
####
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/sloretz/ws/egginfo/devel
-- Using CMAKE_PREFIX_PATH: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/melodic
-- This workspace overlays: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/melodic
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.15", minimum required is "2") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python2
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/sloretz/ws/egginfo/build/test_results
-- Found gtest sources under '/usr/src/googletest': gtests will be built
-- Found gmock sources under '/usr/src/googletest': gmock will be built
-- Found PythonInterp: /usr/bin/python2 (found version "2.7.15") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.23
-- BUILD_SHARED_LIBS is on
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 2 packages in topological order:
-- ~~  - angles
-- ~~  - dist_angles
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'angles'
-- ==> add_subdirectory(angles/angles)
-- +++ processing catkin package: 'dist_angles'
-- ==> add_subdirectory(dist_angles)
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sloretz/ws/egginfo/build
####
#### Running command: "make install -j8 -l8" in "/home/sloretz/ws/egginfo/build"
####
Install the project...
-- Install configuration: ""
-- Installing: /home/sloretz/ws/egginfo/install/_setup_util.py
-- Installing: /home/sloretz/ws/egginfo/install/env.sh
-- Installing: /home/sloretz/ws/egginfo/install/setup.bash
-- Installing: /home/sloretz/ws/egginfo/install/local_setup.bash
-- Installing: /home/sloretz/ws/egginfo/install/setup.sh
-- Installing: /home/sloretz/ws/egginfo/install/local_setup.sh
-- Installing: /home/sloretz/ws/egginfo/install/setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install/local_setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install/.rosinstall
-- Installing: /home/sloretz/ws/egginfo/install/lib/pkgconfig/angles.pc
-- Installing: /home/sloretz/ws/egginfo/install/share/angles/cmake/anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/angles/cmake/anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install/include/angles
-- Installing: /home/sloretz/ws/egginfo/install/include/angles/angles.h
+ cd /home/sloretz/ws/egginfo/src/angles/angles
+ mkdir -p /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build /usr/bin/python2 /home/sloretz/ws/egginfo/src/angles/angles/setup.py egg_info --egg-base /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages build --build-base /home/sloretz/ws/egginfo/build/angles/angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install --install-scripts=/home/sloretz/ws/egginfo/install/bin
running egg_info
creating /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info
writing /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/PKG-INFO
writing top-level names to /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/top_level.txt
writing dependency_links to /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/dependency_links.txt
writing manifest file '/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
reading manifest file '/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
writing manifest file '/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
running build
running build_py
creating /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7/angles
copying src/angles/__init__.py -> /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7/angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles
copying /home/sloretz/ws/egginfo/build/angles/angles/lib.linux-x86_64-2.7/angles/__init__.py -> /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles
byte-compiling /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles/__init__.py to __init__.pyc
running install_egg_info
Copying /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles.egg-info to /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/angles-1.9.13.egg-info
Skipping SOURCES.txt
running install_scripts
-- Installing: /home/sloretz/ws/egginfo/install/lib/pkgconfig/dist_angles.pc
-- Installing: /home/sloretz/ws/egginfo/install/share/dist_angles/cmake/dist_anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/dist_angles/cmake/dist_anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install/share/dist_angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install/include/dist_angles
-- Installing: /home/sloretz/ws/egginfo/install/include/dist_angles/tada.h
+ cd /home/sloretz/ws/egginfo/src/dist_angles
+ mkdir -p /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build /usr/bin/python2 /home/sloretz/ws/egginfo/src/dist_angles/setup.py build --build-base /home/sloretz/ws/egginfo/build/dist_angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install --install-scripts=/home/sloretz/ws/egginfo/install/bin
running build
running build_py
creating /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7/dist_angles
copying src/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7/dist_angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles
copying /home/sloretz/ws/egginfo/build/dist_angles/lib.linux-x86_64-2.7/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles
byte-compiling /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles/__init__.py to __init__.pyc
running install_egg_info
Writing /home/sloretz/ws/egginfo/install/lib/python2.7/dist-packages/dist_angles-1.9.13.egg-info
```
</details>

<details><summary>Melodic `catkin_make_isolated --install` build success</summary>

```
$ catkin_make_isolated --install
Base path: /home/sloretz/ws/egginfo
Source space: /home/sloretz/ws/egginfo/src
Build space: /home/sloretz/ws/egginfo/build_isolated
Devel space: /home/sloretz/ws/egginfo/devel_isolated
Install space: /home/sloretz/ws/egginfo/install_isolated
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~  traversing 2 packages in topological order:
~~  - angles
~~  - dist_angles
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
The packages or cmake arguments have changed, forcing cmake invocation

==> Processing catkin package: 'angles'
==> Creating build directory: 'build_isolated/angles'
==> cmake /home/sloretz/ws/egginfo/src/angles/angles -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/egginfo/devel_isolated/angles -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/egginfo/install_isolated -G Unix Makefiles in '/home/sloretz/ws/egginfo/build_isolated/angles'
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/sloretz/ws/egginfo/devel_isolated/angles
-- Using CMAKE_PREFIX_PATH: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/melodic
-- This workspace overlays: /home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/melodic
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.15", minimum required is "2") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python2
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/sloretz/ws/egginfo/build_isolated/angles/test_results
-- Found gtest sources under '/usr/src/googletest': gtests will be built
-- Found gmock sources under '/usr/src/googletest': gmock will be built
-- Found PythonInterp: /usr/bin/python2 (found version "2.7.15") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.23
-- BUILD_SHARED_LIBS is on
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sloretz/ws/egginfo/build_isolated/angles
==> make -j8 -l8 in '/home/sloretz/ws/egginfo/build_isolated/angles'
==> make install in '/home/sloretz/ws/egginfo/build_isolated/angles'
Install the project...
-- Install configuration: ""
-- Installing: /home/sloretz/ws/egginfo/install_isolated/_setup_util.py
-- Installing: /home/sloretz/ws/egginfo/install_isolated/env.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/.rosinstall
-- Installing: /home/sloretz/ws/egginfo/install_isolated/lib/pkgconfig/angles.pc
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/angles/cmake/anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/angles/cmake/anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/angles
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/angles/angles.h
+ cd /home/sloretz/ws/egginfo/src/angles/angles
+ mkdir -p /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build_isolated/angles/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build_isolated/angles /usr/bin/python2 /home/sloretz/ws/egginfo/src/angles/angles/setup.py egg_info --egg-base /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages build --build-base /home/sloretz/ws/egginfo/build_isolated/angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install_isolated --install-scripts=/home/sloretz/ws/egginfo/install_isolated/bin
running egg_info
creating /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info
writing /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/PKG-INFO
writing top-level names to /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/top_level.txt
writing dependency_links to /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/dependency_links.txt
writing manifest file '/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
reading manifest file '/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
writing manifest file '/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info/SOURCES.txt'
running build
running build_py
creating /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7/angles
copying src/angles/__init__.py -> /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7/angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles
copying /home/sloretz/ws/egginfo/build_isolated/angles/lib.linux-x86_64-2.7/angles/__init__.py -> /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles
byte-compiling /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles/__init__.py to __init__.pyc
running install_egg_info
Copying /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles.egg-info to /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/angles-1.9.13.egg-info
Skipping SOURCES.txt
running install_scripts
<== Finished processing package [1 of 2]: 'angles'

==> Processing catkin package: 'dist_angles'
==> Creating build directory: 'build_isolated/dist_angles'
==> Building with env: '/home/sloretz/ws/egginfo/install_isolated/env.sh'
==> cmake /home/sloretz/ws/egginfo/src/dist_angles -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/egginfo/devel_isolated/dist_angles -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/egginfo/install_isolated -G Unix Makefiles in '/home/sloretz/ws/egginfo/build_isolated/dist_angles'
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /home/sloretz/ws/egginfo/devel_isolated/dist_angles
-- Using CMAKE_PREFIX_PATH: /home/sloretz/ws/egginfo/install_isolated;/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/melodic
-- This workspace overlays: /home/sloretz/ws/egginfo/install_isolated;/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin;/opt/ros/melodic
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.15", minimum required is "2") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python2
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /home/sloretz/ws/egginfo/build_isolated/dist_angles/test_results
-- Found gtest sources under '/usr/src/googletest': gtests will be built
-- Found gmock sources under '/usr/src/googletest': gmock will be built
-- Found PythonInterp: /usr/bin/python2 (found version "2.7.15") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.23
-- BUILD_SHARED_LIBS is on
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sloretz/ws/egginfo/build_isolated/dist_angles
==> make -j8 -l8 in '/home/sloretz/ws/egginfo/build_isolated/dist_angles'
==> make install in '/home/sloretz/ws/egginfo/build_isolated/dist_angles'
Install the project...
-- Install configuration: ""
-- Installing: /home/sloretz/ws/egginfo/install_isolated/_setup_util.py
-- Installing: /home/sloretz/ws/egginfo/install_isolated/env.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.bash
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.sh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/local_setup.zsh
-- Installing: /home/sloretz/ws/egginfo/install_isolated/.rosinstall
-- Installing: /home/sloretz/ws/egginfo/install_isolated/lib/pkgconfig/dist_angles.pc
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/dist_angles/cmake/dist_anglesConfig.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/dist_angles/cmake/dist_anglesConfig-version.cmake
-- Installing: /home/sloretz/ws/egginfo/install_isolated/share/dist_angles/package.xml
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/dist_angles
-- Installing: /home/sloretz/ws/egginfo/install_isolated/include/dist_angles/tada.h
+ cd /home/sloretz/ws/egginfo/src/dist_angles
+ mkdir -p /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages
+ /usr/bin/env PYTHONPATH=/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/build_isolated/dist_angles/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages:/home/sloretz/ws/egginfo/catkin/devel_isolated/catkin/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages CATKIN_BINARY_DIR=/home/sloretz/ws/egginfo/build_isolated/dist_angles /usr/bin/python2 /home/sloretz/ws/egginfo/src/dist_angles/setup.py build --build-base /home/sloretz/ws/egginfo/build_isolated/dist_angles install --root=/ --install-layout=deb --prefix=/home/sloretz/ws/egginfo/install_isolated --install-scripts=/home/sloretz/ws/egginfo/install_isolated/bin
running build
running build_py
creating /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7
creating /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7/dist_angles
copying src/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7/dist_angles
running install
running install_lib
creating /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles
copying /home/sloretz/ws/egginfo/build_isolated/dist_angles/lib.linux-x86_64-2.7/dist_angles/__init__.py -> /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles
byte-compiling /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles/__init__.py to __init__.pyc
running install_egg_info
Writing /home/sloretz/ws/egginfo/install_isolated/lib/python2.7/dist-packages/dist_angles-1.9.13.egg-info
<== Finished processing package [2 of 2]: 'dist_angles'
```
</details>