### PR TITLE
Also rewrite shebang lines with whitespace in catkin_install_python

### DIFF
--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -27,7 +27,7 @@ function(catkin_install_python signature)
       stamp(${source_file})
       # read file and check shebang line
       file(READ ${source_file} data)
-      set(regex "^#!/([^\r\n]+)/env python([\r\n])")
+      set(regex "^#![ \t]*/([^\r\n]+)/env[ \t]+python([\r\n])")
       string(REGEX MATCH "${regex}" shebang_line "${data}")
       string(LENGTH "${shebang_line}" length)
       string(SUBSTRING "${data}" 0 ${length} prefix)


### PR DESCRIPTION
The current implementation of `catkin_install_python()` only rewrites shebang lines of Python scripts if they match the regular expression
```
^#!/([^\r\n]+)/env python([\r\n])
```

This regular expression does not match if there is additional whitespace after the shebang `#!` or between `env` and `python`. The first case is not uncommon in ROS packages and even in the [documentation of catkin itself](https://github.com/ros/catkin/blob/abb6aa81bb26d984e25c6f0a165a51a0ddd992ee/doc/howto/format2/installing_python.rst):

```sh
~/ros_melodic_ws/src$ grep '#! /usr/bin/env' . -R
./dynamic_reconfigure/cmake/dynamic_reconfigure/parameter_generator.py:#! /usr/bin/env python
./dynamic_reconfigure/cmake/gendeps:#! /usr/bin/env python
./dynamic_reconfigure/scripts/dynparam:#! /usr/bin/env python
./dynamic_reconfigure/scripts/reconfigure_gui:#! /usr/bin/env python
./dynamic_reconfigure/test/testserver.py:#! /usr/bin/env python
./dynamic_reconfigure/test/testserver_multiple_ns.py:#! /usr/bin/env python
./xacro/scripts/xacro:#! /usr/bin/env python
./xacro/test/test_xacro.py:#! /usr/bin/env python
./xacro/xacro.py:#! /usr/bin/env python
./catkin/doc/howto/format2/installing_python.rst:  #! /usr/bin/env python
./catkin/doc/howto/format1/installing_python.rst:  #! /usr/bin/env python
./catkin/test/unit_tests/test_environment_cache.py:#! /usr/bin/env sh
./common_msgs/actionlib_msgs/scripts/genaction.py:#! /usr/bin/env python
./diagnostics/diagnostic_updater/src/diagnostic_updater/__init__.py:#! /usr/bin/env python
./common_tutorials/actionlib_tutorials/scripts/fibonacci_client.py:#! /usr/bin/env python
./common_tutorials/actionlib_tutorials/scripts/fibonacci_server.py:#! /usr/bin/env python
./rqt_launch/src/rqt_launch/status_indicator.py:#! /usr/bin/env python
./rqt_launch/src/rqt_launch/node_controller.py:#! /usr/bin/env python
./rqt_launch/src/rqt_launch/name_surrogate.py:#! /usr/bin/env python
./ros/roslib/src/roslib/manifest.py:#! /usr/bin/env python
./ros/roslib/src/roslib/manifestlib.py:#! /usr/bin/env python
./ros/roslib/src/roslib/stack_manifest.py:#! /usr/bin/env python
./ros/roslib/src/roslib/stacks.py:#! /usr/bin/env python
./ros/roslib/src/roslib/launcher.py:#! /usr/bin/env python
./ros/roslib/src/roslib/gentools.py:#! /usr/bin/env python
./ros/roslib/scripts/gendeps:#! /usr/bin/env python
./ros/rosmake/src/rosmake/gcc_output_parse.py:#! /usr/bin/env python
./ros/rosmake/src/rosmake/parallel_build.py:#! /usr/bin/env python
./ros/rosmake/src/rosmake/package_stats.py:#! /usr/bin/env python
./ros/rosmake/src/rosmake/engine.py:#! /usr/bin/env python
./ros/rosmake/scripts/rosmake:#! /usr/bin/env python
./ros/rosbash/test/test_rosbash.bash:#! /usr/bin/env bash
./ros/rosbash/test/test_roszsh.zsh:#! /usr/bin/env zsh
./actionlib/src/actionlib/simple_action_server.py:#! /usr/bin/env python
./actionlib/src/actionlib/exceptions.py:#! /usr/bin/env python
./actionlib/src/actionlib/goal_id_generator.py:#! /usr/bin/env python
./actionlib/src/actionlib/simple_action_client.py:#! /usr/bin/env python
./actionlib/src/actionlib/action_server.py:#! /usr/bin/env python
./actionlib/src/actionlib/action_client.py:#! /usr/bin/env python
./actionlib/test/simple_action_server_deadlock_companion.py:#! /usr/bin/env python
./actionlib/test/mock_simple_server.py:#! /usr/bin/env python
./actionlib/test/simple_python_client_test.py:#! /usr/bin/env python
./actionlib/test/test_ref_action_server.py:#! /usr/bin/env python
./actionlib/test/test_ref_simple_action_server.py:#! /usr/bin/env python
./actionlib/test/exercise_simple_client.py:#! /usr/bin/env python
./actionlib/test/test_simple_action_server_deadlock.py:#! /usr/bin/env python
./nodelet_core/nodelet_topic_tools/cfg/NodeletThrottle.cfg:#! /usr/bin/env python
./nodelet_core/nodelet/scripts/list_nodelets:#! /usr/bin/env python
```

For a non-default Python 3 installation of ROS Melodic (following http://wiki.ros.org/UsingPython3/BuildUsingPython3) for example `rosrun xacro xacro` is broken, because [`catkin_install_python(PROGRAMS scripts/xacro DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})`](https://github.com/ros/xacro/blob/d9c98c52c72eeab5ae9a224f2cd0126ba1c71d88/CMakeLists.txt#L15) is not effective due to the space character in [scripts/xacro](https://github.com/ros/xacro/blob/d9c98c52c72eeab5ae9a224f2cd0126ba1c71d88/scripts/xacro#L1) and the shebang line is not rewritten on installation. Another example is [rosrun nodelet list_nodelets](https://github.com/ros/nodelet_core/blob/c833c6e64f7f228de2c2bd56a7c60d279b6910f4/nodelet/scripts/list_nodelets#L1).

If accepted, please consider backporting of this patch to ROS Kinetic and Melodic.
