### PR TITLE
Stops catkin from trying to find C++ libraries if not needed

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -1,6 +1,9 @@
 _generate_function_if_testing_is_disabled(
   "catkin_add_gtest"
   "catkin_add_gmock")
+_generate_function_if_no_cxx_language(
+  "catkin_add_gtest"
+  "catkin_add_gmock")
 
 #
 # Add a GTest based test target.
@@ -299,6 +302,12 @@ function(catkin_find_google_test_source gtest_path googletest_path
     endif()
   endif()
 endfunction()
+
+get_property(ENABLED_LANGUAGES_LIST GLOBAL PROPERTY ENABLED_LANGUAGES)
+list(FIND ENABLED_LANGUAGES_LIST "CXX" _cxx_index)
+if ("${_cxx_index}" EQUAL -1) # if C++ isn't an enabled language
+  return()
+endif()
 
 find_package(GMock QUIET)
 find_package(GTest QUIET)

--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -1,9 +1,15 @@
 _generate_function_if_testing_is_disabled(
   "catkin_add_gtest"
-  "catkin_add_gmock")
+  "catkin_add_gmock"
+  "catkin_add_executable_with_gtest"
+  "catkin_add_executable_with_gmock"
+  "catkin_find_google_test_source")
 _generate_function_if_no_cxx_language(
   "catkin_add_gtest"
-  "catkin_add_gmock")
+  "catkin_add_gmock"
+  "catkin_add_executable_with_gtest"
+  "catkin_add_executable_with_gmock"
+  "catkin_find_google_test_source")
 
 #
 # Add a GTest based test target.
@@ -302,12 +308,6 @@ function(catkin_find_google_test_source gtest_path googletest_path
     endif()
   endif()
 endfunction()
-
-get_property(ENABLED_LANGUAGES_LIST GLOBAL PROPERTY ENABLED_LANGUAGES)
-list(FIND ENABLED_LANGUAGES_LIST "CXX" _cxx_index)
-if ("${_cxx_index}" EQUAL -1) # if C++ isn't an enabled language
-  return()
-endif()
 
 find_package(GMock QUIET)
 find_package(GTest QUIET)

--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -36,7 +36,7 @@ macro(_generate_function_if_no_cxx_language)
       function(${_arg})
         message(FATAL_ERROR
           "${tmp_func_name}() is not available when the CXX language isn't enabled. "
-          "Try adding \"project(project_name LANGUAGES CXX)\" to your cmake.")
+          "Check the `LANGUAGES` argument of the `project()` function to make sure `CXX` is not excluded.")
       endfunction()
     endforeach()
     return()

--- a/cmake/test/tests.cmake
+++ b/cmake/test/tests.cmake
@@ -26,6 +26,23 @@ macro(_generate_function_if_testing_is_disabled)
   endif()
 endmacro()
 
+# creates dummy functions in case C++ is not a language specified, which outputs an error
+macro(_generate_function_if_no_cxx_language)
+  get_property(ENABLED_LANGUAGES_LIST GLOBAL PROPERTY ENABLED_LANGUAGES)
+  list(FIND ENABLED_LANGUAGES_LIST "CXX" _cxx_index)
+  if ("${_cxx_index}" EQUAL -1) # if C++ isn't an enabled language
+    foreach(_arg ${ARGN})
+      set(tmp_func_name ${_arg})
+      function(${_arg})
+        message(FATAL_ERROR
+          "${tmp_func_name}() is not available when the CXX language isn't enabled. "
+          "Try adding \"project(project_name LANGUAGES CXX)\" to your cmake.")
+      endfunction()
+    endforeach()
+    return()
+  endif()
+endmacro()
+
 # checks if a function has been called while testing is skipped
 # and outputs a warning message
 macro(_warn_if_skip_testing funcname)

--- a/cmake/tools/rt.cmake
+++ b/cmake/tools/rt.cmake
@@ -31,7 +31,9 @@
 # message("CMAKE_SYSTEM_LIBRARY_PATH: ${CMAKE_SYSTEM_LIBRARY_PATH}")
 # message("CMAKE_VERSION=${CMAKE_VERSION}")
 
-if(NOT (APPLE OR WIN32 OR MINGW OR ANDROID))
+get_property(ENABLED_LANGUAGES_LIST GLOBAL PROPERTY ENABLED_LANGUAGES)
+list(FIND ENABLED_LANGUAGES_LIST "CXX" _cxx_index)
+if(NOT (APPLE OR WIN32 OR MINGW OR ANDROID) AND "${_cxx_index}" GREATER -1)
   if (${CMAKE_VERSION} VERSION_LESS 2.8.4)
     # cmake later than 2.8.0 appears to have a better find_library
     # that knows about the ABI of the compiler.  For lucid we just


### PR DESCRIPTION
Specifically, when CXX is not in the `ENABLED_LANGUAGES` global
property.

Addresses https://github.com/ros/catkin/issues/1080.