### PR TITLE
[Windows] make more relocatable wrapper

### DIFF
--- a/cmake/templates/python_win32_wrapper.cpp.in
+++ b/cmake/templates/python_win32_wrapper.cpp.in
@@ -113,20 +113,16 @@ int main(int argc, char* argv[]) try
 
             // left trim extra characters.
             auto ltrim = firstLine.find_first_not_of(extra_chars);
-            while ((std::string::npos != ltrim) &&
-                   (0 != ltrim))
+            if (std::string::npos != ltrim)
             {
                 firstLine.erase(0, ltrim);
-                ltrim = firstLine.find_first_not_of(extra_chars);
             }
 
             // right trim extra characters.
             auto rtrim = firstLine.find_last_not_of(extra_chars);
-            while ((std::string::npos != rtrim) &&
-                   (firstLine.size() - 1 != rtrim))
+            if (std::string::npos != rtrim)
             {
                 firstLine.erase(rtrim + 1);
-                rtrim = firstLine.find_last_not_of(extra_chars);
             }
         }
 

--- a/cmake/templates/python_win32_wrapper.cpp.in
+++ b/cmake/templates/python_win32_wrapper.cpp.in
@@ -43,7 +43,12 @@
 #ifdef _WIN32
 
 #include <iostream>
+#include <fstream>
+#include <string>
+
 #include <windows.h>
+
+static const std::string SHEBANG = "#!";
 
 static std::string dirnameOf(const std::string& fname)
 {
@@ -87,20 +92,42 @@ int main(int argc, char* argv[]) try
         fprintf(stderr, "[DEBUG] Python script name: %s\n", scriptName.c_str());
 #endif
 
-        // use quoted string to ensure the correct path is used
-        return "\"" + scriptName + "\"";
+        return scriptName;
     };
 
-    const auto GetPythonExecutable = []() -> std::string
+    const auto GetPythonExecutable = [](const std::string& exeFullPath) -> std::string
     {
-        std::string pythonExecutable = "@PYTHON_EXECUTABLE@";
+        std::string scriptName;
+        scriptName += dirnameOf(exeFullPath);
+        scriptName += "\\@ARG_SCRIPT_NAME@";
+
+        std::ifstream infile(scriptName);
+
+        std::string firstLine;
+        if (std::getline(infile, firstLine) && firstLine.find(SHEBANG) == 0)
+        {
+            firstLine.erase(0, SHEBANG.size());
+        }
+
+        // Default to Python executable registered in runtime environment
+        std::string pythonExecutable = "python.exe";
+        if (!firstLine.empty() && 
+            (INVALID_FILE_ATTRIBUTES != GetFileAttributes(firstLine.c_str()))) // check file existence
+        {
+            pythonExecutable = firstLine;
+        }
 
 #if defined(DEBUG)
         fprintf(stderr, "[DEBUG] Python executable: %s\n", pythonExecutable.c_str());
 #endif
 
+        return pythonExecutable;
+    };
+
+    const auto GetDoubleQuotedString = [](const std::string &input) -> std::string
+    {
         // use quoted string to ensure the correct path is used
-        return "\"" + pythonExecutable + "\"";
+        return "\"" + input + "\"";
     };
 
     const auto ExecuteCommand = [](std::string command, bool printError = false) -> unsigned long
@@ -169,27 +196,9 @@ int main(int argc, char* argv[]) try
     }
 #endif
 
-    auto pythonExecutable = GetPythonExecutable();
-    try
-    {
-        // check if the Python executable specified at configure time could be found
-        ExecuteCommand(pythonExecutable + " -c \"import sys; sys.exit(0)\"");
-    }
-    catch (...)
-    {
-        if (::GetLastError() == ERROR_FILE_NOT_FOUND)
-        {
-            // Python executable cannot be found, fall back to use Python executable registered in runtime environment
-            pythonExecutable = "python";
-        }
-        else
-        {
-            throw;
-        }
-    }
-
+    const auto pythonExecutable = GetPythonExecutable(GetCurrentModuleName());
     const auto pythonScript = FindPythonScript(GetCurrentModuleName());
-    std::string command = pythonExecutable + " " + pythonScript;
+    std::string command = GetDoubleQuotedString(pythonExecutable) + " " + GetDoubleQuotedString(pythonScript);
     for (auto i = 1; i < argc; ++i)
     {
         command += " ";

--- a/cmake/templates/python_win32_wrapper.cpp.in
+++ b/cmake/templates/python_win32_wrapper.cpp.in
@@ -42,8 +42,8 @@
 
 #ifdef _WIN32
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
 #include <windows.h>
@@ -107,6 +107,13 @@ int main(int argc, char* argv[]) try
         if (std::getline(infile, firstLine) && firstLine.find(SHEBANG) == 0)
         {
             firstLine.erase(0, SHEBANG.size());
+
+            // trim extra spaces.
+            auto start = firstLine.find_first_not_of(" ");
+            if (std::string::npos != start)
+            {
+                firstLine.erase(0, start);
+            }
         }
 
         // Default to Python executable registered in runtime environment
@@ -196,8 +203,9 @@ int main(int argc, char* argv[]) try
     }
 #endif
 
-    const auto pythonExecutable = GetPythonExecutable(GetCurrentModuleName());
-    const auto pythonScript = FindPythonScript(GetCurrentModuleName());
+    const std::string exeFullPath = GetCurrentModuleName();
+    const auto pythonExecutable = GetPythonExecutable(exeFullPath);
+    const auto pythonScript = FindPythonScript(exeFullPath);
     std::string command = GetDoubleQuotedString(pythonExecutable) + " " + GetDoubleQuotedString(pythonScript);
     for (auto i = 1; i < argc; ++i)
     {

--- a/cmake/templates/python_win32_wrapper.cpp.in
+++ b/cmake/templates/python_win32_wrapper.cpp.in
@@ -108,11 +108,25 @@ int main(int argc, char* argv[]) try
         {
             firstLine.erase(0, SHEBANG.size());
 
-            // trim extra spaces.
-            auto start = firstLine.find_first_not_of(" ");
-            if (std::string::npos != start)
+            // spaces & tabs are considered as extra
+            std::string extra_chars(" \t");
+
+            // left trim extra characters.
+            auto ltrim = firstLine.find_first_not_of(extra_chars);
+            while ((std::string::npos != ltrim) &&
+                   (0 != ltrim))
             {
-                firstLine.erase(0, start);
+                firstLine.erase(0, ltrim);
+                ltrim = firstLine.find_first_not_of(extra_chars);
+            }
+
+            // right trim extra characters.
+            auto rtrim = firstLine.find_last_not_of(extra_chars);
+            while ((std::string::npos != rtrim) &&
+                   (firstLine.size() - 1 != rtrim))
+            {
+                firstLine.erase(rtrim + 1);
+                rtrim = firstLine.find_last_not_of(extra_chars);
             }
         }
 


### PR DESCRIPTION
This pull request is to remove a compile time variable dependency to `@PYTHON_EXECUTABLE@` variable. This is motivated by trying to relocate an existing ROS installation to a different location in Windows, where one can either use tool (e.g., `conda`) or its own script to patch the hard-coded paths for the plain-text files (e.g., `python` scripts, CMake files, `pkg-config` files, etc.)

However, it is challenging to patch the string literal baked in binary files. So I turned to see why it is not an issue for `setuptools` wrapper. By reading [the launcher code](https://github.com/pypa/setuptools/blob/master/launcher.c), I realized that it reads the SHEBANG line and use it as the hint of `Python` runtime location, and fallback to simply use `Python.exe` if none is specified or found. By this approach, the binary doesn't have the dependency to the compile time variable, and we can be more close to make `catkin` installation relocatable (at least with existing tools' help).