### PR TITLE
Fix gtest_source_paths

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -238,7 +238,7 @@ function(catkin_find_google_test_source gtest_path googletest_path
 
   # Path to gtest from the googletest Debian package.
   list(APPEND _gtest_include_paths "${googletest_path}/googletest/include/gtest")
-  list(APPEND _gtest_source_paths "${googletest_path}/googletest/googletest/src")
+  list(APPEND _gtest_source_paths "${googletest_path}/googletest/src")
 
   if(CATKIN_TOPLEVEL)
     # Ensure current workspace is searched before system path


### PR DESCRIPTION
Since googletest_path is /usr/src/googletest, it resulted in /usr/src/googletest/googletest/googletest/src

Please, check if the fix is correct. For my Ubuntu18 it is.
And sorry, if I added the bugfix in wrong place (I don't know, maybe it should go to earlier branch..?).