### PR TITLE
Prepend $DESTDIR to --egg-base argument

### DIFF
--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -143,7 +143,7 @@ function(catkin_python_setup)
 
   assert(PYTHON_INSTALL_DIR)
   if(${PROJECT_NAME}_SETUP_PY_SETUP_MODULE STREQUAL "setuptools")
-    set(SETUPTOOLS_EGG_INFO "egg_info --egg-base ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}")
+    set(SETUPTOOLS_EGG_INFO "egg_info --egg-base $DESTDIR${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}")
   else()
     set(SETUPTOOLS_EGG_INFO "")
   endif()


### PR DESCRIPTION
Attempt to fix #1087.

The generated egg files seem a little useless to me since it includes the absolute install path and lists the contents of the catkin sources:

```
$ cat install/opt/ros/my_noetic/lib/python3.8/site-packages/catkin.egg-info/SOURCES.txt 
README.rst
setup.py
/home/hermann/src/rosws/inst/opt/ros/my_noetic/lib/python3.8/site-packages/catkin.egg-info/PKG-INFO
/home/hermann/src/rosws/inst/opt/ros/my_noetic/lib/python3.8/site-packages/catkin.egg-info/SOURCES.txt
/home/hermann/src/rosws/inst/opt/ros/my_noetic/lib/python3.8/site-packages/catkin.egg-info/dependency_links.txt
/home/hermann/src/rosws/inst/opt/ros/my_noetic/lib/python3.8/site-packages/catkin.egg-info/top_level.txt
bin/catkin_find
bin/catkin_init_workspace
bin/catkin_make
bin/catkin_make_isolated
bin/catkin_test_results
bin/catkin_topological_order
python/catkin/__init__.py
python/catkin/builder.py
python/catkin/cmake.py
python/catkin/environment_cache.py
python/catkin/find_in_workspaces.py
python/catkin/init_workspace.py
python/catkin/package_version.py
python/catkin/terminal_color.py
python/catkin/test_results.py
python/catkin/tidy_xml.py
python/catkin/workspace.py
python/catkin/workspace_vcs.py
```

According to https://setuptools.readthedocs.io/en/latest/formats.html#sources-txt-source-files-manifest, `SOURCES.txt` are for source distributions only, so it doesen't really matter here.