### PR TITLE
fix -egg-base path to point to the build space

### DIFF
--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -143,7 +143,7 @@ function(catkin_python_setup)
 
   assert(PYTHON_INSTALL_DIR)
   if(${PROJECT_NAME}_SETUP_PY_SETUP_MODULE STREQUAL "setuptools")
-    set(SETUPTOOLS_EGG_INFO "egg_info --egg-base ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}")
+    set(SETUPTOOLS_EGG_INFO "egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}")
   else()
     set(SETUPTOOLS_EGG_INFO "")
   endif()


### PR DESCRIPTION
Fixes #1087. Replaces #1089.

The egg-base is by default in the source space. It certainly shouldn't point to the install space. As in `colcon` pointing it to the build space is sufficient to not pollute the souce space but not affect the install space.