### PR TITLE
error message python-empy -> python3-empy

### DIFF
--- a/cmake/empy.cmake
+++ b/cmake/empy.cmake
@@ -27,7 +27,7 @@ if(NOT EMPY_SCRIPT)
     # On OSX, there's an em.py, but not an executable empy script
     find_python_module(em)
     if(NOT PY_EM)
-      message(FATAL_ERROR "Unable to find either executable 'empy' or Python module 'em'... try installing the package 'python-empy'")
+      message(FATAL_ERROR "Unable to find either executable 'empy' or Python module 'em'... try installing the package 'python3-empy'")
     endif()
     # ensure to use cmake-style path separators on Windows
     file(TO_CMAKE_PATH "${PY_EM}" EMPY_SCRIPT)


### PR DESCRIPTION
In Noetic the rosdep key (and debian package name) to use is `python3-empy`.

Noticed in https://answers.ros.org/question/353111/following-installation-instructions-catkin_make-generates-a-cmake-error