### PR TITLE
Fix CATKIN_SYMLINK_INSTALL with add_subdirectory()

### DIFF
--- a/cmake/symlink_install/catkin_symlink_install.cmake.in
+++ b/cmake/symlink_install/catkin_symlink_install.cmake.in
@@ -7,11 +7,14 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/symlink_install_manifest.txt")
 # Reimplement CMake install(DIRECTORY) command to use symlinks instead of
 # copying resources.
 #
+# :param CURRENT_SOURCE_DIR: the value of CMAKE_CURRENT_SOURCE_DIR from where
+#   this function is called
+# :type CURRENT_SOURCE_DIR: a path
 # :param ARGN: the same arguments as the CMake install command.
 # :type ARGN: various
 #
 function(catkin_symlink_install_directory)
-  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;CURRENT_SOURCE_DIR" "DIRECTORY;PATTERN;PATTERN_EXCLUDE" ${ARGN})
+  cmake_parse_arguments(ARG "OPTIONAL" "CURRENT_SOURCE_DIR;DESTINATION" "DIRECTORY;PATTERN;PATTERN_EXCLUDE" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "catkin_symlink_install_directory() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -104,11 +107,14 @@ endfunction()
 # Reimplement CMake install(FILES) command to use symlinks instead of copying
 # resources.
 #
+# :param CURRENT_SOURCE_DIR: the value of CMAKE_CURRENT_SOURCE_DIR from where
+#   this function is called
+# :type CURRENT_SOURCE_DIR: a path
 # :param ARGN: the same arguments as the CMake install command.
 # :type ARGN: various
 #
 function(catkin_symlink_install_files)
-  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;RENAME;CURRENT_SOURCE_DIR" "FILES" ${ARGN})
+  cmake_parse_arguments(ARG "OPTIONAL" "CURRENT_SOURCE_DIR;DESTINATION;RENAME" "FILES" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "catkin_symlink_install_files() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -159,11 +165,14 @@ endfunction()
 # Reimplement CMake install(PROGRAMS) command to use symlinks instead of copying
 # resources.
 #
+# :param CURRENT_SOURCE_DIR: the value of CMAKE_CURRENT_SOURCE_DIR from where
+#   this function is called
+# :type CURRENT_SOURCE_DIR: a path
 # :param ARGN: the same arguments as the CMake install command.
 # :type ARGN: various
 #
 function(catkin_symlink_install_programs)
-  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;CURRENT_SOURCE_DIR" "PROGRAMS" ${ARGN})
+  cmake_parse_arguments(ARG "OPTIONAL" "CURRENT_SOURCE_DIR;DESTINATION" "PROGRAMS" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "catkin_symlink_install_programs() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")

--- a/cmake/symlink_install/catkin_symlink_install.cmake.in
+++ b/cmake/symlink_install/catkin_symlink_install.cmake.in
@@ -11,7 +11,7 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/symlink_install_manifest.txt")
 # :type ARGN: various
 #
 function(catkin_symlink_install_directory)
-  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION" "DIRECTORY;PATTERN;PATTERN_EXCLUDE" ${ARGN})
+  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;CURRENT_SOURCE_DIR" "DIRECTORY;PATTERN;PATTERN_EXCLUDE" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "catkin_symlink_install_directory() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -34,7 +34,7 @@ function(catkin_symlink_install_directory)
   foreach(dir ${ARG_DIRECTORY})
     # make dir an absolute path
     if(NOT IS_ABSOLUTE "${dir}")
-      set(dir "@CMAKE_CURRENT_SOURCE_DIR@/${dir}")
+      set(dir "${ARG_CURRENT_SOURCE_DIR}/${dir}")
     endif()
 
     if(EXISTS "${dir}")
@@ -108,7 +108,7 @@ endfunction()
 # :type ARGN: various
 #
 function(catkin_symlink_install_files)
-  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;RENAME" "FILES" ${ARGN})
+  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;RENAME;CURRENT_SOURCE_DIR" "FILES" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "catkin_symlink_install_files() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -134,7 +134,7 @@ function(catkin_symlink_install_files)
   foreach(file ${ARG_FILES})
     # make file an absolute path
     if(NOT IS_ABSOLUTE "${file}")
-      set(file "@CMAKE_CURRENT_SOURCE_DIR@/${file}")
+      set(file "${ARG_CURRENT_SOURCE_DIR}/${file}")
     endif()
 
     if(EXISTS "${file}")
@@ -163,7 +163,7 @@ endfunction()
 # :type ARGN: various
 #
 function(catkin_symlink_install_programs)
-  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION" "PROGRAMS" ${ARGN})
+  cmake_parse_arguments(ARG "OPTIONAL" "DESTINATION;CURRENT_SOURCE_DIR" "PROGRAMS" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "catkin_symlink_install_programs() called with "
       "unused/unsupported arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -181,7 +181,7 @@ function(catkin_symlink_install_programs)
   foreach(file ${ARG_PROGRAMS})
     # make file an absolute path
     if(NOT IS_ABSOLUTE "${file}")
-      set(file "@CMAKE_CURRENT_SOURCE_DIR@/${file}")
+      set(file "${ARG_CURRENT_SOURCE_DIR}/${file}")
     endif()
 
     if(EXISTS "${file}")

--- a/cmake/symlink_install/catkin_symlink_install_directory.cmake
+++ b/cmake/symlink_install/catkin_symlink_install_directory.cmake
@@ -72,7 +72,7 @@ function(catkin_symlink_install_directory directory_keyword)
 
     string(REPLACE ";" "\" \"" argn_quoted "\"${argn}\"")
     catkin_symlink_install_append_install_code(
-      "catkin_symlink_install_directory(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY ${argn_quoted})"
+      "catkin_symlink_install_directory(CURRENT_SOURCE_DIR \"${CMAKE_CURRENT_SOURCE_DIR}\" DIRECTORY ${argn_quoted})"
       COMMENTS "install(DIRECTORY ${argn_quoted})"
     )
   endif()

--- a/cmake/symlink_install/catkin_symlink_install_directory.cmake
+++ b/cmake/symlink_install/catkin_symlink_install_directory.cmake
@@ -72,7 +72,7 @@ function(catkin_symlink_install_directory directory_keyword)
 
     string(REPLACE ";" "\" \"" argn_quoted "\"${argn}\"")
     catkin_symlink_install_append_install_code(
-      "catkin_symlink_install_directory(DIRECTORY ${argn_quoted})"
+      "catkin_symlink_install_directory(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY ${argn_quoted})"
       COMMENTS "install(DIRECTORY ${argn_quoted})"
     )
   endif()

--- a/cmake/symlink_install/catkin_symlink_install_files.cmake
+++ b/cmake/symlink_install/catkin_symlink_install_files.cmake
@@ -43,7 +43,7 @@ function(catkin_symlink_install_files files_keyword)
   if(index EQUAL -1)
     string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
     catkin_symlink_install_append_install_code(
-      "catkin_symlink_install_files(FILES ${argn_quoted})"
+      "catkin_symlink_install_files(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} FILES ${argn_quoted})"
       COMMENTS "install(FILES ${argn_quoted})"
     )
   endif()

--- a/cmake/symlink_install/catkin_symlink_install_files.cmake
+++ b/cmake/symlink_install/catkin_symlink_install_files.cmake
@@ -43,7 +43,7 @@ function(catkin_symlink_install_files files_keyword)
   if(index EQUAL -1)
     string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
     catkin_symlink_install_append_install_code(
-      "catkin_symlink_install_files(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} FILES ${argn_quoted})"
+      "catkin_symlink_install_files(CURRENT_SOURCE_DIR \"${CMAKE_CURRENT_SOURCE_DIR}\" FILES ${argn_quoted})"
       COMMENTS "install(FILES ${argn_quoted})"
     )
   endif()

--- a/cmake/symlink_install/catkin_symlink_install_programs.cmake
+++ b/cmake/symlink_install/catkin_symlink_install_programs.cmake
@@ -44,7 +44,7 @@ function(catkin_symlink_install_programs programs_keyword)
   if(index EQUAL -1)
     string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
     catkin_symlink_install_append_install_code(
-      "catkin_symlink_install_programs(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} PROGRAMS ${argn_quoted})"
+      "catkin_symlink_install_programs(CURRENT_SOURCE_DIR \"${CMAKE_CURRENT_SOURCE_DIR}\" PROGRAMS ${argn_quoted})"
       COMMENTS "install(PROGRAMS ${argn_quoted})"
     )
   endif()

--- a/cmake/symlink_install/catkin_symlink_install_programs.cmake
+++ b/cmake/symlink_install/catkin_symlink_install_programs.cmake
@@ -44,7 +44,7 @@ function(catkin_symlink_install_programs programs_keyword)
   if(index EQUAL -1)
     string(REPLACE ";" "\" \"" argn_quoted "\"${ARGN}\"")
     catkin_symlink_install_append_install_code(
-      "catkin_symlink_install_programs(PROGRAMS ${argn_quoted})"
+      "catkin_symlink_install_programs(CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} PROGRAMS ${argn_quoted})"
       COMMENTS "install(PROGRAMS ${argn_quoted})"
     )
   endif()


### PR DESCRIPTION
`catkin_symlink_install_files/directory/programs()` use generated functions that store the value of `CMAKE_CURRENT_SOURCE_DIR` at the time they are generated. This value is incorrect when `install(...)` is called from a directory using `add_subdirectory()` as [is the case in gencpp](https://github.com/ros/gencpp/blob/989e9315ea45867ad228e34b8645a04333cdf829/scripts/CMakeLists.txt#L1-L3). This fixes the issue by passing the current source directory to the generated functions at the time that they're called.

Noticed while reviewing #1100 and trying to build `gencpp` using

```
./src/catkin/bin/catkin_make_isolated --install --build-space buildi_noetic --devel-space develi_noetic --install-space installi_noetic --cmake-args -DCATKIN_SYMLINK_INSTALL=ON
```

```
==> make install in '/home/sloretz/ws/catkin/buildi_noetic/gencpp'
Install the project...
-- Install configuration: ""
-- Execute custom install script
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/_setup_util.py
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/env.sh
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/setup.bash
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/local_setup.bash
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/setup.sh
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/local_setup.sh
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/setup.zsh
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/local_setup.zsh
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/.rosinstall
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/lib/pkgconfig/gencpp.pc
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/share/gencpp/cmake/gencpp-extras.cmake
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/share/gencpp/cmake/gencppConfig.cmake
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/share/gencpp/cmake/gencppConfig-version.cmake
-- Symlinking: /home/sloretz/ws/catkin/install_noetic/share/gencpp/package.xml
CMake Error at catkin_symlink_install/catkin_symlink_install.cmake:151 (message):
  catkin_symlink_install_files() can't find
  '/home/sloretz/ws/catkin/src/gencpp/msg.h.template'
Call Stack (most recent call first):
  catkin_symlink_install/catkin_symlink_install.cmake:334 (catkin_symlink_install_files)
  cmake_install.cmake:41 (include)


make: *** [Makefile:86: install] Error 1
<== Failed to process package 'gencpp': 
  Command '['/home/sloretz/ws/catkin/install_noetic/env.sh', 'make', 'install']' returned non-zero exit status 2.

Reproduce this error by running:
==> cd /home/sloretz/ws/catkin/buildi_noetic/gencpp && /home/sloretz/ws/catkin/install_noetic/env.sh make install
```