### PR TITLE
explicitly call project() in toplevel CMakeLists.txt

### DIFF
--- a/cmake/toplevel.cmake
+++ b/cmake/toplevel.cmake
@@ -3,6 +3,8 @@
 
 cmake_minimum_required(VERSION 3.0.2)
 
+project(Project)
+
 set(CATKIN_TOPLEVEL TRUE)
 
 # search for catkin within the workspace


### PR DESCRIPTION
To prevent a warning to be shown with CMake 3.15 and newer:

```
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.
```