### PR TITLE
use single quote for cached environment values without old values

### DIFF
--- a/python/catkin/environment_cache.py
+++ b/python/catkin/environment_cache.py
@@ -82,9 +82,9 @@ def generate_environment_script(env_script):
         (old_value, new_value) = modified[key]
         if new_value.endswith(os.pathsep + old_value):
             variable = ('$%s' if _is_not_windows() else '%%%s%%') % key
-            _set_variable(code, key, new_value[:-len(old_value)] + variable)
+            _set_variable(code, key, new_value[:-len(old_value)] + variable, single_quote=False)
         else:
-            _set_variable(code, key, new_value)
+            _set_variable(code, key, new_value, single_quote=True)
 
     return code
 
@@ -111,8 +111,12 @@ def _append_comment(code, value):
     code.append('%s %s' % (comment_prefix, value))
 
 
-def _set_variable(code, key, value):
+def _set_variable(code, key, value, single_quote=False):
+    if single_quote:
+        quote = '\''
+    else:
+        quote = '"'
     if _is_not_windows():
-        code.append('export %s="%s"' % (key, value))
+        code.append('export %s=%s%s%s' % (key, quote, value, quote))
     else:
         code.append('set %s=%s' % (key, value))

--- a/python/catkin/environment_cache.py
+++ b/python/catkin/environment_cache.py
@@ -74,7 +74,7 @@ def generate_environment_script(env_script):
     code.append('')
     _append_comment(code, 'new environment variables')
     for key in sorted(added.keys()):
-        _set_variable(code, key, added[key])
+        _set_variable(code, key, added[key], single_quote=True)
 
     code.append('')
     _append_comment(code, 'modified environment variables')

--- a/test/unit_tests/test_environment_cache.py
+++ b/test/unit_tests/test_environment_cache.py
@@ -44,7 +44,7 @@ class PlatformTest(unittest.TestCase):
         _set_variable(code, 'foo', 'bar')
         self.assertEqual(['export foo="bar"'], code)
         code = []
-        _set_variable(code, 'foo', 'bar', single_quote=True)
+        _set_variable(code, 'foo', 'bar')
         self.assertEqual(['export foo=\'bar\''], code)
 
     def test_appends_windows(self):

--- a/test/unit_tests/test_environment_cache.py
+++ b/test/unit_tests/test_environment_cache.py
@@ -42,10 +42,10 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(['# foo'], code)
         code = []
         _set_variable(code, 'foo', 'bar')
-        self.assertEqual(['export foo="bar"'], code)
+        self.assertEqual(["export foo='bar'"], code)
         code = []
-        _set_variable(code, 'foo', 'bar')
-        self.assertEqual(['export foo=\'bar\''], code)
+        _set_variable(code, 'foo', '"bar"')
+        self.assertEqual(['export foo="bar"'], code)
 
     def test_appends_windows(self):
         catkin.environment_cache.platform = self.winplatform
@@ -83,10 +83,10 @@ exec \"$@\"""")
             os.chmod(env_file, mode | stat.S_IXUSR)
             result = generate_environment_script(env_file)
             self.assertTrue('export FOO="/foo:$FOO"' in result, result)
-            self.assertTrue('export TRICK=\'/usr/lib\'' in result, result)
-            self.assertTrue('export BAR=\'/bar\'' in result, result)
-            self.assertTrue('export BOO=\'boo\'' in result, result)
-            self.assertTrue('export BAZ=\'${dollar}\'' in result, result)
+            self.assertTrue("export TRICK='/usr/lib'" in result, result)
+            self.assertTrue("export BAR='/bar'" in result, result)
+            self.assertTrue("export BOO='boo'" in result, result)
+            self.assertTrue("export BAZ='${dollar}'" in result, result)
             self.assertEqual('#!/usr/bin/env sh', result[0])
         finally:
             os.environ = old_environ

--- a/test/unit_tests/test_environment_cache.py
+++ b/test/unit_tests/test_environment_cache.py
@@ -76,13 +76,17 @@ class PlatformTest(unittest.TestCase):
 export FOO=/foo:/bar
 export TRICK=/usr/lib
 export BAR=/bar
+export BOO=boo
+export BAZ='${dollar}'
 exec \"$@\"""")
             mode = os.stat(env_file).st_mode
             os.chmod(env_file, mode | stat.S_IXUSR)
             result = generate_environment_script(env_file)
             self.assertTrue('export FOO="/foo:$FOO"' in result, result)
-            self.assertTrue('export TRICK="/usr/lib"' in result, result)
-            self.assertTrue('export BAR="/bar"' in result, result)
+            self.assertTrue('export TRICK=\'/usr/lib\'' in result, result)
+            self.assertTrue('export BAR=\'/bar\'' in result, result)
+            self.assertTrue('export BOO=\'boo\'' in result, result)
+            self.assertTrue('export BAZ=\'${dollar}\'' in result, result)
             self.assertEqual('#!/usr/bin/env sh', result[0])
         finally:
             os.environ = old_environ

--- a/test/unit_tests/test_environment_cache.py
+++ b/test/unit_tests/test_environment_cache.py
@@ -43,6 +43,9 @@ class PlatformTest(unittest.TestCase):
         code = []
         _set_variable(code, 'foo', 'bar')
         self.assertEqual(['export foo="bar"'], code)
+        code = []
+        _set_variable(code, 'foo', 'bar', single_quote=True)
+        self.assertEqual(['export foo=\'bar\''], code)
 
     def test_appends_windows(self):
         catkin.environment_cache.platform = self.winplatform


### PR DESCRIPTION
Closes #1107 

By applying this pull request, exported values of environment variables are quoted using single quote sign.
For variables for paths with old values, double quote sign is used as before.