### PR TITLE
[noetic-devel][Windows] Fix file COPY cannot read symlink

### DIFF
--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -40,7 +40,10 @@ function(catkin_install_python signature)
         file(MAKE_DIRECTORY ${rewritten_file})
         # even though the content of the file is overwritten
         # the copy makes sure the file has the right permissions
-        file(COPY ${source_file} DESTINATION ${rewritten_file} USE_SOURCE_PERMISSIONS)
+        if(NOT IS_SYMLINK ${source_file} AND WIN32)
+          # file copying is not supported on Windows symlinks by CMake
+          file(COPY ${source_file} DESTINATION ${rewritten_file} USE_SOURCE_PERMISSIONS)
+        endif()
         set(rewritten_file "${rewritten_file}/${filename}")
         file(WRITE ${rewritten_file} "${data}")
       else()

--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -40,8 +40,8 @@ function(catkin_install_python signature)
         file(MAKE_DIRECTORY ${rewritten_file})
         # even though the content of the file is overwritten
         # the copy makes sure the file has the right permissions
-        if(NOT IS_SYMLINK ${source_file} AND WIN32)
-          # file copying is not supported on Windows symlinks by CMake
+        if(NOT WIN32 OR NOT IS_SYMLINK "${source_file}")
+          # CMake doesn't support copying symlinks on Windows
           file(COPY ${source_file} DESTINATION ${rewritten_file} USE_SOURCE_PERMISSIONS)
         endif()
         set(rewritten_file "${rewritten_file}/${filename}")


### PR DESCRIPTION
A recent change from #1100 introduced an usage of `file(COPY)` and unfortunately this idiom has some limitation on Windows. For example, `CMake` doesn't support the case where the source file is a symlink, due to the absent of [`ReadSymlink`](https://gitlab.kitware.com/cmake/cmake/-/issues/20994#note_802160) implementation on Windows.

And when the conditions are met, it will render as errors like below:

```
-- rospy_tutorials: 2 messages, 2 services
CMake Error at C:/opt/ros/melodic/x64/share/catkin/cmake/catkin_install_python.cmake:45 (file):
  file COPY cannot read symlink
  "C:/workspace/rospy_ws/src/ros_tutorials/rospy_tutorials/001_talker_listener/listener"
  to duplicate at
  "C:/workspace/rospy_ws/build_isolated/rospy_tutorials/catkin_generated/installspace/listener":
  No error.
Call Stack (most recent call first):
  CMakeLists.txt:14 (catkin_install_python)
```

This pull request is to make the file copying conditional and unblock any build breaks due to the limitation. And please consider to back-port to `kinetic-devel` as well.