### PR TITLE
[noetic-devel][Windows] Fix some devel space is not captured in the context of catkin_make run_tests 

### DIFF
--- a/cmake/all.cmake
+++ b/cmake/all.cmake
@@ -182,6 +182,15 @@ set(CATKIN_GLOBAL_LIBEXEC_DESTINATION lib)
 set(CATKIN_GLOBAL_PYTHON_DESTINATION ${PYTHON_INSTALL_DIR})
 set(CATKIN_GLOBAL_SHARE_DESTINATION share)
 
+# create the placeholder directories required for _setup_util.py
+if(WIN32)
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/bin)
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/lib)
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/share)
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/etc)
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
+endif()
+
 # undefine CATKIN_ENV since it might be set in the cache from a previous build
 set(CATKIN_ENV "" CACHE INTERNAL "catkin environment" FORCE)
 


### PR DESCRIPTION
### The Problem

This is manifesting when running `catkin_make run_tests` and I saw some shared libraries are not found when `rostest` runs the ROS nodes in my workspace. It tuned out that `<catkin_ws>\devel\bin` (where the DLL lives) should be captured by `catkin/python/catkin/environment_cache.py` in `setup_cached.bat` and later pass to the processes running `rostest`, but it didn't.

So, as I trace upward, I found when `generate_cached_setup.py` gets invoked, at that moment devel space is empty but only contains the common files (`env.*` and `setup.*`) added by `catkin`. Therefore, as this particular [logic](https://github.com/ros/catkin/pull/777) gets exercised inside the call stack from `generate_cached_setup.py`, it will skip adding the `bin` and `lib` subfolder to the `%PATH%`, because those subfolders doesn't yet exist. As a result, the `<catkin_ws>\devel\bin` doesn't get added and passed to `rostest` later.

Why is it not a problem to Linux? On Linux, there is a concept or `RPATH\RUNPATH` ,which is backed inside the binaries, for the loader to know where to search the shared objects. On Windows, the shared library search-order system is different and by the convention we used in ROS, the search path needs to be added to `%PATH%`.

### Proposal Solution

I believe there is a reason to keep this [check](https://github.com/ros/catkin/pull/777), so I go another route to force the basic [layout](https://www.ros.org/reps/rep-0122.html#directory-layout) to be created ahead in the devel space, so later they will be added by `_setup_util.py`.

And please consider to back-port to `kinetic-devel`. Thanks!