### PR TITLE
[Windows] execute the output of _setup_util.py in place

### DIFF
--- a/cmake/templates/setup.bat.in
+++ b/cmake/templates/setup.bat.in
@@ -39,30 +39,8 @@ if not "!_PYTHON_FOUND!" == "!_PYTHON!" (
 )
 endlocal & set PATH=%PATH%
 
-REM generate pseudo random temporary filename
-:GenerateTempFilename
-REM replace leading space of time with zero
-set _SETUP_TMP=%Time: =0%
-REM remove time delimiters
-set _SETUP_TMP=%_SETUP_TMP::=%
-set _SETUP_TMP=%_SETUP_TMP:.=%
-set _SETUP_TMP=%_SETUP_TMP:,=%
-set _SETUP_TMP=%Temp%\setup.%_SETUP_TMP%.bat
-if EXIST %_SETUP_TMP% do goto GenerateTempFilename
-type NUL > "%_SETUP_TMP%"
-if NOT EXIST %_SETUP_TMP% (
-  echo "Could not create temporary file: %_SETUP_TMP%"
-  exit 1
-)
-
 REM invoke Python script to generate necessary exports of environment variables
-%_PYTHON% "%_SETUP_UTIL%" %* > %_SETUP_TMP%
-if NOT EXIST %_SETUP_TMP% (
-  echo "Could not create temporary file: %_SETUP_TMP%"
-  return 1
-)
-call %_SETUP_TMP%
-del %_SETUP_TMP%
+FOR /F "delims=" %%i IN ('^"%_PYTHON% "%_SETUP_UTIL%" %*^"') DO call %%i
 
 REM source all environment hooks
 set _HOOK_COUNT=0
@@ -87,6 +65,5 @@ set _SETUP_UTIL=
 set _PYTHON=
 set _PYTHONEXE=
 set _PYTHON_FOUND=
-set _SETUP_TMP=
 set _CATKIN_ENVIRONMENT_HOOKS_COUNT=
 set _HOOK_COUNT=


### PR DESCRIPTION
When different isolated `setup.bat` are invoked at the same time (for example, when building in parallel with `colcon`), the `_SETUP_TMP` has chances to end up with the same file path (the file name is generated by `%Time: =0%` and it doesn't give a good quality for uniqueness). And in this case, the file write (creation) and deletion can race together and result in unexpected errors.

This pull request is to address this problem by removing the need of the intermediate temp file and execute the generated batch commands in place directly.

Also, please consider to back-port to kinetic-devel if it makes sense. Thanks!
