### PR TITLE
[Windows] Use raw string literal to accommodate escape characters

### DIFF
--- a/cmake/templates/_setup_util.py.in
+++ b/cmake/templates/_setup_util.py.in
@@ -268,7 +268,7 @@ if __name__ == '__main__':
 
         if not args.local:
             # environment at generation time
-            CMAKE_PREFIX_PATH = '@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
+            CMAKE_PREFIX_PATH = r'@CMAKE_PREFIX_PATH_AS_IS@'.split(';')
         else:
             # don't consider any other prefix path than this one
             CMAKE_PREFIX_PATH = []


### PR DESCRIPTION
On Windows, CMake will use the backslash `\` as the default character to compose the prefix path. However, when it is passed to the template, the `\` means differently as the escape character in Python. Therefore, a wrong string will be used in such case.

Currently, to workaround it, one needs to explicitly define the prefix path like `set CMAKE_PREFIX_PATH=c:/opt/ros/noetic`.

This pull request is to use the raw string literal to remove the need of using forward slash in such case, so the default CMake would work directly with `catkin`.