### PR TITLE
count 'skipped' tests as skipped

### DIFF
--- a/python/catkin/test_results.py
+++ b/python/catkin/test_results.py
@@ -158,7 +158,7 @@ def _get_testsuite_stats(node):
     num_tests = int(node.attrib['tests'])
     num_errors = int(node.attrib['errors'])
     num_failures = int(node.attrib['failures'])
-    num_skipped = int(node.get('skip', '0')) + int(node.get('disabled', '0'))
+    num_skipped = int(node.get('skip', '0')) + int(node.get('skipped', '0')) + int(node.get('disabled', '0'))
     return (num_tests, num_errors, num_failures, num_skipped)
 
 

--- a/test/unit_tests/test_test_results.py
+++ b/test/unit_tests/test_test_results.py
@@ -48,6 +48,20 @@ class TestResultsTest(unittest.TestCase):
         finally:
             shutil.rmtree(rootdir)
 
+    def test_read_junit_skipped(self):
+        try:
+            rootdir = tempfile.mkdtemp()
+
+            result_file = os.path.join(rootdir, 'test1.xml')
+            with open(result_file, 'w') as fhand:
+                fhand.write('<testsuites tests="5" failures="3" errors="1" skipped="2" time="35" name="AllTests"></testsuites>')
+            (num_tests, num_errors, num_failures) = catkin_test_results.read_junit(result_file)
+            self.assertEqual((5, 1, 3), (num_tests, num_errors, num_failures))
+            (num_tests, num_errors, num_failures, num_skipped) = catkin_test_results.read_junit2(result_file)
+            self.assertEqual((5, 1, 3, 2), (num_tests, num_errors, num_failures, num_skipped))
+        finally:
+            shutil.rmtree(rootdir)
+
     def test_test_results(self):
         try:
             rootdir = tempfile.mkdtemp()


### PR DESCRIPTION
Previously only 'skip' and 'disabled' were counted as skipped tests.
However, junit format explicitly allows 'skipped' (cmp.
https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L196)

For reference, also see the same issue in colcon:
- Bug: https://github.com/colcon/colcon-test-result/issues/18
- PR: https://github.com/colcon/colcon-test-result/pull/19

This is based on noetic-devel, but applies to kinetic-devel as well (particularly, we are facing this issue under melodic and would appreciate a backport (or shall I create a new PR?))