### PR TITLE
deduplicate dependency lists of exported code generation targets

### DIFF
--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -211,7 +211,7 @@ foreach(depend ${depends})
   _unpack_libraries_with_build_configuration(@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
 
   _list_append_unique(@PROJECT_NAME@_LIBRARY_DIRS ${${@PROJECT_NAME@_dep}_LIBRARY_DIRS})
-  _list_append_unique(@PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
+  _list_append_deduplicate(@PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
 endforeach()
 
 set(pkg_cfg_extras "@PKG_CFG_EXTRAS@")

--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -211,7 +211,7 @@ foreach(depend ${depends})
   _unpack_libraries_with_build_configuration(@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
 
   _list_append_unique(@PROJECT_NAME@_LIBRARY_DIRS ${${@PROJECT_NAME@_dep}_LIBRARY_DIRS})
-  list(APPEND @PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
+  _list_append_unique(@PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
 endforeach()
 
 set(pkg_cfg_extras "@PKG_CFG_EXTRAS@")


### PR DESCRIPTION
## TL;DR

deduplicate the list of `_EXPORTED_TARGETS` (from the comments I read this is about codegen targets).

## background

In one of our projects the cmake configure time recently increased significantly (10s → 2min) and memory consumption of cmake increased noticably.
With cmake's trace capabilities we found that in the `<ourproject>_EXPORTED_TARGETS` list took a lot of time to grow and by adding printout to the generated `<workspace>/devel/share/<ourproject>/cmake/<ourproject>Config.cmake` file, noticed that there were many many duplicate additions of

```
std_msgs_generate_messages_py
std_msgs_generate_messages_cpp
std_msgs_generate_messages_eus
std_msgs_generate_messages_lisp
std_msgs_generate_messages_nodejs
std_msgs_generate_messages_py
geometry_msgs_generate_messages_cpp
geometry_msgs_generate_messages_eus
geometry_msgs_generate_messages_lisp
geometry_msgs_generate_messages_nodejs
geometry_msgs_generate_messages_py
std_msgs_generate_messages_cpp
std_msgs_generate_messages_eus
std_msgs_generate_messages_lisp
std_msgs_generate_messages_nodejs
std_msgs_generate_messages_py
std_msgs_generate_messages_cpp
std_msgs_generate_messages_eus
std_msgs_generate_messages_lisp
std_msgs_generate_messages_nodejs
std_msgs_generate_messages_py
std_msgs_generate_messages_cpp
std_msgs_generate_messages_eus
std_msgs_generate_messages_lisp
std_msgs_generate_messages_nodejs
std_msgs_generate_messages_py
geometry_msgs_generate_messages_cpp
geometry_msgs_generate_messages_eus
geometry_msgs_generate_messages_lisp
geometry_msgs_generate_messages_nodejs
geometry_msgs_generate_messages_py
std_msgs_generate_messages_cpp
std_msgs_generate_messages_eus
std_msgs_generate_messages_lisp
std_msgs_generate_messages_nodejs
std_msgs_generate_messages_py
roscpp_generate_messages_cpp
```
It seemed to us that deduplication of the list of exported targets is desirable and changed the template, just like the deduplication is already done with the list of library dirs in the line before.

Configure time went down to O(10s) again and build and tests seem fine.

## second thoughts

I'm a bit suspicious though why deduplication isn't done already as the means to do so are there and even applied in the line before (and quickly glimpsing at the git history, _list_append_unique was already in that line when _EXPORTED_TARGETS got added).

For completeness sake, we're still have on our todo list to double check if we're seeing just a symptom of an underlying issue (potentially on our side) that causes these long duplications (I don't see a circular dependency in our stack). Also,we're using [catkin_simple](https://github.com/catkin/catkin_simple) as catkin frontend which handles message generation targets for us.