### PR TITLE
Added --force-color flag to catkin_make and catkin_make_isolated

### DIFF
--- a/bin/catkin_make
+++ b/bin/catkin_make
@@ -33,9 +33,14 @@ def main():
     apply_platform_specific_defaults(args)
     cmake_args = args.cmake_args
 
-    # force --no-color if stdout is non-interactive
-    if not sys.stdout.isatty():
-        args.no_color = True
+    if not args.no_color:
+        # Use color if --force-color is set
+        if args.force_color:
+            args.no_color = False
+        # use --no-color as fallback if stdout is non-interactive
+        elif not sys.stdout.isatty():
+            args.no_color = True
+
     # disable colors if asked
     if args.no_color:
         disable_ANSI_colors()
@@ -277,7 +282,9 @@ def _parse_args(args=sys.argv[1:]):
     add('--use-nmake', action='store_true', help="Use 'nmake' instead of 'make'")
     add('--use-gmake', action='store_true', help="Use 'gmake' instead of 'make'")
     add('--force-cmake', action='store_true', help="Invoke 'cmake' even if it has been executed before")
-    add('--no-color', action='store_true', help='Disables colored output (only for catkin_make and CMake)')
+    add('--force-color', action='store_true', help='Enforces colored output (only for catkin_make and CMake)')
+    add('--no-color', action='store_true',
+        help='Disables colored output (only for catkin_make and CMake). Overrides --force-color.')
     add('--pkg', nargs='+', help="Invoke 'make' on specific packages only")
     add('--only-pkg-with-deps', nargs='+',
         help='Whitelist only the specified packages and their dependencies by '

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -123,13 +123,13 @@ def main():
     apply_platform_specific_defaults(opts)
     cmake_args, opts = handle_cmake_args(opts.cmake_args, opts)
 
-    if not args.no_color:
+    if not opts.no_color:
         # Use color if --force-color is set
-        if args.force_color:
-            args.no_color = False
+        if opts.force_color:
+            opts.no_color = False
         # use --no-color as fallback if stdout is non-interactive
         elif not sys.stdout.isatty():
-            args.no_color = True
+            opts.no_color = True
 
     # use PWD in order to work when being invoked in a symlinked location
     cwd = os.getenv('PWD', os.curdir)

--- a/bin/catkin_make_isolated
+++ b/bin/catkin_make_isolated
@@ -53,8 +53,10 @@ def parse_args(args=None):
         help='Causes each catkin package to be installed.')
     add('--force-cmake', action='store_true', default=False,
         help='Runs cmake explicitly for each catkin package.')
+    add('--force-color', action='store_true', default=False,
+        help='Enforces colored output (only for catkin_make and CMake)')
     add('--no-color', action='store_true', default=False,
-        help='Disables colored output (only for catkin_make and CMake)')
+        help='Disables colored output (only for catkin_make and CMake). Overrides --force-color.')
     pkg = parser.add_mutually_exclusive_group(required=False)
     pkg.add_argument('--pkg', nargs='+', metavar='PKGNAME', dest='packages',
                      help='Process only specific packages '
@@ -121,9 +123,13 @@ def main():
     apply_platform_specific_defaults(opts)
     cmake_args, opts = handle_cmake_args(opts.cmake_args, opts)
 
-    # force --no-color if stdout is non-interactive
-    if not sys.stdout.isatty():
-        opts.no_color = True
+    if not args.no_color:
+        # Use color if --force-color is set
+        if args.force_color:
+            args.no_color = False
+        # use --no-color as fallback if stdout is non-interactive
+        elif not sys.stdout.isatty():
+            args.no_color = True
 
     # use PWD in order to work when being invoked in a symlinked location
     cwd = os.getenv('PWD', os.curdir)


### PR DESCRIPTION
This can be used to enforce colored output even on non-interactive output. `--force-color` can still be overriden by `--no-color`.

This PR is for CI environments where the output is stored in a file but a colored output makes it easier for a user to read the log.