### PR TITLE
cmake/python.cmake: Remove SETUPTOOLS_ARG_EXTRA for debian systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 
 set(catkin_EXTRAS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -16,7 +16,7 @@ option(SETUPTOOLS_DEB_LAYOUT "Enable debian style python package layout" ${enabl
 if(SETUPTOOLS_DEB_LAYOUT)
   message(STATUS "Using Debian Python package layout")
   set(PYTHON_PACKAGES_DIR dist-packages)
-  set(SETUPTOOLS_ARG_EXTRA "--install-layout=deb")
+  set(SETUPTOOLS_ARG_EXTRA "")
   # use major version only when installing 3.x with debian layout
   if("${PYTHON_VERSION_MAJOR}" STREQUAL "3")
     set(_PYTHON_PATH_VERSION_SUFFIX "${PYTHON_VERSION_MAJOR}")


### PR DESCRIPTION
Remove SETUPTOOLS_ARG_EXTRA since "--install-layout=deb" is not supported
on Ubuntu-18.04. Using this argument causes `make install` to fail.

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>