### PR TITLE
Evaluate <depend> conditions in CMake variables

### DIFF
--- a/cmake/parse_package_xml.py
+++ b/cmake/parse_package_xml.py
@@ -33,6 +33,7 @@
 from __future__ import print_function
 
 import argparse
+import os
 import sys
 from collections import OrderedDict
 
@@ -82,7 +83,7 @@ def _get_output(package):
 
 def _get_dependency_values(key, depends):
     values = OrderedDict()
-    values[key] = ' '.join(['"%s"' % str(d) for d in depends])
+    values[key] = ' '.join(['"%s"' % str(d) for d in depends if d.evaluated_condition is not False])
     for d in depends:
         comparisons = ['version_lt', 'version_lte', 'version_eq', 'version_gte', 'version_gt']
         for comp in comparisons:
@@ -99,6 +100,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('outfile')
     args = parser.parse_args(argv)
     package = parse_package(args.package_xml)
+    package.evaluate_conditions(os.environ)
 
     # Force utf8 encoding for python3.
     # This way unicode files can still be processed on non-unicode locales.

--- a/cmake/parse_package_xml.py
+++ b/cmake/parse_package_xml.py
@@ -83,13 +83,14 @@ def _get_output(package):
 
 def _get_dependency_values(key, depends):
     values = OrderedDict()
-    values[key] = ' '.join(['"%s"' % str(d) for d in depends if d.evaluated_condition is not False])
-    for d in depends:
+    filtered_deps = [d for d in depends if d.evaluated_condition is not False]
+    values[key] = ' '.join(['"%s"' % d.name for d in filtered_deps])
+    for d in filtered_deps:
         comparisons = ['version_lt', 'version_lte', 'version_eq', 'version_gte', 'version_gt']
         for comp in comparisons:
             value = getattr(d, comp, None)
             if value is not None:
-                values['%s_%s_%s' % (key, str(d), comp.upper())] = '"%s"' % value
+                values['%s_%s_%s' % (key, d.name, comp.upper())] = '"%s"' % value
     return values
 
 

--- a/test/unit_tests/test_parse_package_xml.py
+++ b/test/unit_tests/test_parse_package_xml.py
@@ -17,19 +17,28 @@ from parse_package_xml import main  # noqa: E402
 class ParsePackageXmlTest(unittest.TestCase):
 
     def test_get_output(self):
+        class MockDependency(object):
+            __slots__ = [
+                'name',
+                'evaluated_condition',
+            ]
+            def __init__(self, name):
+                self.name = name
+                self.evaluated_condition = None
+
         pack = Mock()
         pack.package_format = 2
         pack.name = 'foopack'
         pack.version = '0.1.2'
         pack.maintainers = ['m1', 'm2']
-        pack.build_depends = ['bd1', 'bd2']
-        pack.buildtool_depends = ['catkin']
-        pack.build_export_depends = ['bed1', 'bed2']
-        pack.buildtool_export_depends = ['bted1', 'bted2']
-        pack.exec_depends = ['ed1', 'ed2']
-        pack.run_depends = ['rd1', 'rd2']
-        pack.test_depends = ['td1', 'td2']
-        pack.doc_depends = ['dd1', 'dd2']
+        pack.build_depends = [MockDependency(name) for name in ['bd1', 'bd2']]
+        pack.buildtool_depends = [MockDependency(name) for name in ['catkin']]
+        pack.build_export_depends = [MockDependency(name) for name in ['bed1', 'bed2']]
+        pack.buildtool_export_depends = [MockDependency(name) for name in ['bted1', 'bted2']]
+        pack.exec_depends = [MockDependency(name) for name in ['ed1', 'ed2']]
+        pack.run_depends = [MockDependency(name) for name in ['rd1', 'rd2']]
+        pack.test_depends = [MockDependency(name) for name in ['td1', 'td2']]
+        pack.doc_depends = [MockDependency(name) for name in ['dd1', 'dd2']]
         pack.urls = []
         pack.exports = []
         result = _get_output(pack)


### PR DESCRIPTION
Adds support for the `condition` attribute for `<*depend>` tags in package.xml format 3 ([REP014](https://www.ros.org/reps/rep-0149.html#id20))

#1038 added support for the `condition` attribute to the `<build_type>` tag, but it was never added to the other `<*depend>` tags.

### Without this change:
In Noetic (py3), package.xml containing 
```
  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-whatever</exec_depend>
  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-whatever</exec_depend>
```
yields CMake variable: `${PROJECT_NAME}_EXEC_DEPENDS = "python-whatever;python3-whatever"`

### After this change:
The same package.xml yields CMake variable: `${PROJECT_NAME}_EXEC_DEPENDS = "python3-whatever"`

---

If approved, I would also like this to be considered for backport to kinetic & melodic.