### PR TITLE
Fix problem with Googletest's LIBRARY_OUTPUT_DIRECTORY

### DIFF
--- a/cmake/test/gtest.cmake
+++ b/cmake/test/gtest.cmake
@@ -382,15 +382,23 @@ if(FORCE_GTEST_GMOCK_FROM_SOURCE OR (NOT GMOCK_FOUND AND NOT GTEST_FOUND))
   if(base_dir)
     # overwrite CMake install command to skip install rules for gtest targets
     # which have been added in version 1.8.0
+    # Googletest 1.10 has a INSTALL_GTEST option that we can override,
+    # so we do that, too.
+    option(INSTALL_GTEST "This option must be turned OFF" OFF)
     _use_custom_install()
     set(_CATKIN_SKIP_INSTALL_RULES TRUE)
     add_subdirectory(${base_dir} ${gtest_lib_dir})
     set(_CATKIN_SKIP_INSTALL_RULES FALSE)
+    # Fix output directories, which conflict with Python's setup.py
     set_target_properties(${gtest_libs} ${gtest_main_libs}
-                          PROPERTIES EXCLUDE_FROM_ALL 1)
+                          PROPERTIES EXCLUDE_FROM_ALL 1
+                          LIBRARY_OUTPUT_DIRECTORY ${gtest_lib_dir}/lib
+                          ARCHIVE_OUTPUT_DIRECTORY ${gtest_lib_dir}/lib)
     if(gmock_found)
       set_target_properties(${gmock_libs} ${gmock_main_libs}
-                            PROPERTIES EXCLUDE_FROM_ALL 1)
+                            PROPERTIES EXCLUDE_FROM_ALL 1
+                            LIBRARY_OUTPUT_DIRECTORY ${gtest_lib_dir}/lib
+                            ARCHIVE_OUTPUT_DIRECTORY ${gtest_lib_dir}/lib)
     endif()
   endif()
 


### PR DESCRIPTION
The horribly maintained CMake files which are shipped with Googletest
override the library output directory to ${CMAKE_BINARY_DIR}/lib, which
points to the top-level build directory (it should have been
CMAKE_CURRENT_BINARY_DIR).

Unfortunately, that directory is used by setuptools as staging area for
Python modules, and `setup.py install` will happily install everything it
finds in the lib/ folder, including the libgtest.so binary. Among
others, this has bitten PR2/pr2_mechanism#343 and ros/geometry#223

This PR fixes the output location to something sane(ish).