### PR TITLE
Remove usage of NO_CMAKE_FIND_ROOT_PATH to enable cross compilation.

### DIFF
--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -157,7 +157,7 @@ foreach(library ${libraries})
     foreach(path @PKG_CONFIG_LIB_PATHS@)
       find_library(lib ${library}
         PATHS ${path}
-        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+        NO_DEFAULT_PATH)
       if(lib)
         set(lib_path ${path})
         break()


### PR DESCRIPTION
It's not fully clear to me why `NO_CMAKE_FIND_ROOT_PATH` was used. I think it was done for consistency, since it's used everywhere in the same way. I believe this option is not needed, and even should not be there.

The option not being used has these advantages:
- Less code in the cmake files
- Cross compilation works as expected when using a sysroot folder