### PR TITLE
Fix handling of multiple namespaced python packages in devel space

### DIFF
--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -80,11 +80,17 @@ function(catkin_python_setup)
       if(NOT ("${pkg}" STREQUAL "${name}"))
         message(FATAL_ERROR "The package name '${pkg}' differs from the basename of the path '${pkg_dir}' in project '${PROJECT_NAME}'")
       endif()
+      # Retrieve PACKAGE_PYTHONPATH from existing __init__.py
+      set(target_init_file ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/${pkg}/__init__.py)
+      if(EXISTS ${target_init_file})
+        file(READ ${target_init_file} file_content)
+        string(REGEX MATCH "__extended_path *= *'(.*)'\\.split" _ "${file_content}")
+        set(PACKAGE_PYTHONPATH ${CMAKE_MATCH_1})
+      endif()
+      # Extend PACKAGE_PYTHONPATH with current pkg's path
       get_filename_component(path ${pkg_dir} PATH)
-      set(PACKAGE_PYTHONPATH ${CMAKE_CURRENT_SOURCE_DIR}/${path})
-      configure_file(${catkin_EXTRAS_DIR}/templates/__init__.py.in
-        ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/${pkg}/__init__.py
-        @ONLY)
+      list(APPEND PACKAGE_PYTHONPATH ${CMAKE_CURRENT_SOURCE_DIR}/${path})
+      configure_file(${catkin_EXTRAS_DIR}/templates/__init__.py.in ${target_init_file} @ONLY)
     endforeach()
   endif()
 

--- a/cmake/catkin_python_setup.cmake
+++ b/cmake/catkin_python_setup.cmake
@@ -89,7 +89,7 @@ function(catkin_python_setup)
       endif()
       # Extend PACKAGE_PYTHONPATH with current pkg's path
       get_filename_component(path ${pkg_dir} PATH)
-      list(APPEND PACKAGE_PYTHONPATH ${CMAKE_CURRENT_SOURCE_DIR}/${path})
+      list_append_deduplicate(PACKAGE_PYTHONPATH ${CMAKE_CURRENT_SOURCE_DIR}/${path})
       configure_file(${catkin_EXTRAS_DIR}/templates/__init__.py.in ${target_init_file} @ONLY)
     endforeach()
   endif()


### PR DESCRIPTION
If there are multiple python packages to be installed below a [common namespace](https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages), only the last one installed is found in devel space, because the path extension is always overwritten.
This PR augments the existing `__extended_path` instead of overriding it.
We need this feature for MoveIt, which has multiple python packages to be installed in the common namespace `moveit`.