### PR TITLE
Fix catkin install python shebang whitespace

### DIFF
--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -27,7 +27,7 @@ function(catkin_install_python signature)
       stamp(${source_file})
       # read file and check shebang line
       file(READ ${source_file} data)
-      set(regex "^#![ \t]*/([^\r\n]+)/env[ \t]+python(?=\s*?[\r\n])")
+      set(regex "^#![ \t]*/([^\r\n]+)/env[ \t]+python([ \t]*[\r\n])")
       string(REGEX MATCH "${regex}" shebang_line "${data}")
       string(LENGTH "${shebang_line}" length)
       string(SUBSTRING "${data}" 0 ${length} prefix)

--- a/cmake/catkin_install_python.cmake
+++ b/cmake/catkin_install_python.cmake
@@ -27,7 +27,7 @@ function(catkin_install_python signature)
       stamp(${source_file})
       # read file and check shebang line
       file(READ ${source_file} data)
-      set(regex "^#![ \t]*/([^\r\n]+)/env[ \t]+python([\r\n])")
+      set(regex "^#![ \t]*/([^\r\n]+)/env[ \t]+python(?=\s*?[\r\n])")
       string(REGEX MATCH "${regex}" shebang_line "${data}")
       string(LENGTH "${shebang_line}" length)
       string(SUBSTRING "${data}" 0 ${length} prefix)


### PR DESCRIPTION
Fixes the issue #1155 where a whitespace character prevents `catkin_install_python` function to update the shebang line with the correct python version. The regex searching for the shebang line has been updated to match the shebang line even if it is followed by multiple spaces and/or tabs.

The line must end with a new line and no other characters except a space and/or tabs are allowed between the shebang and the newline.

The spaces and/or tabs after the shebang are preserved in the converted file (lookahead in regex which would prevent it to be included [is not supported in cmake](https://cmake.org/Bug/view.php?id=15961)).