### PR TITLE
Add native support to fish shell

### DIFF
--- a/cmake/catkin_generate_environment.cmake
+++ b/cmake/catkin_generate_environment.cmake
@@ -48,7 +48,7 @@ function(catkin_generate_environment)
       ${CATKIN_DEVEL_PREFIX}/env.sh
       @ONLY)
     # generate setup for various shells
-    foreach(shell bash sh zsh)
+    foreach(shell bash sh zsh fish)
       atomic_configure_file(${catkin_EXTRAS_DIR}/templates/setup.${shell}.in
         ${CATKIN_DEVEL_PREFIX}/setup.${shell}
         @ONLY)
@@ -101,7 +101,7 @@ function(catkin_generate_environment)
 
   # initialize shell support per platform.
   set(CATKIN_ENV_SHELL sh)
-  set(CATKIN_SETUP_SHELL bash sh zsh)
+  set(CATKIN_SETUP_SHELL bash sh zsh fish)
   if(WIN32)
     set(CATKIN_ENV_SHELL bat)
     set(CATKIN_SETUP_SHELL bat)

--- a/cmake/templates/local_setup.fish.in
+++ b/cmake/templates/local_setup.fish.in
@@ -1,0 +1,14 @@
+#!/usr/bin/env fish
+# generated from catkin/cmake/template/local_setup.fish.in
+
+# since this file is sourced either use the provided _CATKIN_SETUP_DIR
+# or fall back to the destination set at configure time
+
+if test -z $_CATKIN_SETUP_DIR
+    set _CATKIN_SETUP_DIR @SETUP_DIR@
+end
+
+set CATKIN_SETUP_UTIL_ARGS "--extend --local"
+source "$_CATKIN_SETUP_DIR/setup.fish"
+
+set -e CATKIN_SETUP_UTIL_ARGS

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -68,7 +68,7 @@ if test $status -ne 0 -o ! -f "$_SETUP_TMP"
     exit 1
 end
 
-set CATKIN_SHELL "$CATKIN_SHELL" "$_SETUP_UTIL" "$argv" "$CATKIN_SETUP_UTIL_ARGS" >>"$_SETUP_TMP"
+CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" "$argv" "$CATKIN_SETUP_UTIL_ARGS" >> "$_SETUP_TMP"
 set _RC $status
 
 if test $_RC -ne 0

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -1,0 +1,110 @@
+#!/usr/bin/env fish
+# generated from catkin/cmake/template/setup.fish.in
+
+# Sets various environment variables and sources additional environment hooks.
+# It tries it's best to undo changes from a previously sourced setup file before.
+# Supported command line options:
+# --extend: skips the undoing of changes from a previously sourced setup file
+# --local: only considers this workspace but not the chained ones
+# In plain sh shell which doesn't support arguments for sourced scripts you can
+# set the environment variable `CATKIN_SETUP_UTIL_ARGS=--extend/--local` instead.
+
+# since this file is sourced either use the provided _CATKIN_SETUP_DIR
+# or fall back to the destination set at configure time
+
+if test -z $_CATKIN_SETUP_DIR
+    set _CATKIN_SETUP_DIR @SETUP_DIR@
+end
+
+set _SETUP_UTIL "$_CATKIN_SETUP_DIR/_setup_util.py"
+set -e _CATKIN_SETUP_DIR
+
+if not test -f "$_SETUP_UTIL"
+    echo "Missing Python script: $_SETUP_UTIL"
+    exit 22
+end
+
+# detect if running on Darwin platform
+set _UNAME (uname -s)
+set _IS_DARWIN test "$_UNAME" -eq Darwin
+
+if test "$_UNAME" = Darwin
+    set _IS_DARWIN 1
+end
+
+set -e _UNAME
+
+# make sure to export all environment variables
+set -x CMAKE_PREFIX_PATH
+if test $_IS_DARWIN -eq 0
+    set -x LD_LIBRARY_PATH
+else
+    set -x DYLD_LIBRARY_PATH
+end
+
+set -e _IS_DARWIN
+set -x PATH
+set -x PKG_CONFIG_PATH
+set -x PYTHONPATH
+
+# remember type of shell if not already set
+if test -z "$CATKIN_SHELL"
+    set CATKIN_SHELL fish
+end
+
+# invoke Python script to generate necessary exports of environment variables
+# use TMPDIR if it exists, otherwise fall back to /tmp
+if test -d "$TMPDIR"
+    set _TMPDIR "$TMPDIR"
+else
+    set _TMPDIR /tmp
+end
+
+set _SETUP_TMP (mktemp "$_TMPDIR/setup.fish.XXXXXXXXXX")
+set -e _TMPDIR
+
+if test $status -ne 0 -o ! -f "$_SETUP_TMP"
+    echo "Could not create temporary file: $_SETUP_TMP"
+    exit 1
+end
+
+set CATKIN_SHELL "$CATKIN_SHELL" "$_SETUP_UTIL" "$argv" "$CATKIN_SETUP_UTIL_ARGS" >>"$_SETUP_TMP"
+set _RC $status
+
+if test $_RC -ne 0
+    if test $_RC -eq 2
+        then
+        echo "Could not write the output of '$_SETUP_UTIL' to temporary file '$_SETUP_TMP': may be the disk if full?"
+    else
+        echo "Failed to run '\"$_SETUP_UTIL\" $argv': return code $_RC"
+    end
+    set -e _RC
+    set -e _SETUP_UTIL
+    rm -f "$_SETUP_TMP"
+    set -e _SETUP_TMP
+    exit 1
+end
+
+set -e _RC
+set -e _SETUP_UTIL
+source "$_SETUP_TMP"
+rm -f "$_SETUP_TMP"
+set -e _SETUP_TMP
+
+# source all environment hooks
+set _i 0
+while test $_i -lt $_CATKIN_ENVIRONMENT_HOOKS_COUNT
+    eval set _envfile \$_CATKIN_ENVIRONMENT_HOOKS_$_i
+    set -e _CATKIN_ENVIRONMENT_HOOKS_$_i
+    eval set _envfile_workspace \$_CATKIN_ENVIRONMENT_HOOKS_$_i_WORKSPACE
+    set -e _CATKIN_ENVIRONMENT_HOOKS_$_i_WORKSPACE
+
+    # set workspace for environment hook
+    set CATKIN_ENV_HOOK_WORKSPACE $_envfile_workspace
+    source "$_envfile"
+    set -e CATKIN_ENV_HOOK_WORKSPACE
+    set _i (math $_i + 1)
+end
+set -e _i
+
+set -e _CATKIN_ENVIRONMENT_HOOKS_COUNT

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -12,6 +12,11 @@
 # since this file is sourced either use the provided _CATKIN_SETUP_DIR
 # or fall back to the destination set at configure time
 
+if not type -q bass
+    echo "Missing required fish plugin: bass. See https://github.com/edc/bass"
+    exit 22
+end
+
 if test -z $_CATKIN_SETUP_DIR
     set _CATKIN_SETUP_DIR @SETUP_DIR@
 end
@@ -104,7 +109,18 @@ while test $_i -lt $_CATKIN_ENVIRONMENT_HOOKS_COUNT
 
     # set workspace for environment hook
     set CATKIN_ENV_HOOK_WORKSPACE $_envfile_workspace
-    source "$_envfile"
+
+    # non ideal: some packages register bash scripts as fish env hooks
+    # it is needed to perform an extension check for backwards compatibility
+    # if the script ends with .sh, .bash or .zsh, run it with bass
+    set IS_SH_SCRIPT (string match -r '\.(sh|bash|zsh)$' "$_envfile")
+    if test -n "$IS_SH_SCRIPT"
+        bass source "$_envfile"
+    else
+        source "$_envfile"
+    end
+
+    set -e IS_SH_SCRIPT
     set -e CATKIN_ENV_HOOK_WORKSPACE
     set _i (math $_i + 1)
 end

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -26,7 +26,7 @@ end
 
 # detect if running on Darwin platform
 set _UNAME (uname -s)
-set _IS_DARWIN test "$_UNAME" -eq Darwin
+set _IS_DARWIN 0
 
 if test "$_UNAME" = Darwin
     set _IS_DARWIN 1

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -74,7 +74,7 @@ set _RC $status
 if test $_RC -ne 0
     if test $_RC -eq 2
         then
-        echo "Could not write the output of '$_SETUP_UTIL' to temporary file '$_SETUP_TMP': may be the disk if full?"
+        echo "Could not write the output of '$_SETUP_UTIL' to temporary file '$_SETUP_TMP': maybe the disk is full?"
     else
         echo "Failed to run '\"$_SETUP_UTIL\" $argv': return code $_RC"
     end

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -35,17 +35,17 @@ end
 set -e _UNAME
 
 # make sure to export all environment variables
-set -x CMAKE_PREFIX_PATH
+set -x CMAKE_PREFIX_PATH $CMAKE_PREFIX_PATH
 if test $_IS_DARWIN -eq 0
-    set -x LD_LIBRARY_PATH
+    set -x LD_LIBRARY_PATH $LD_LIBRARY_PATH
 else
-    set -x DYLD_LIBRARY_PATH
+    set -x DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH
 end
 
 set -e _IS_DARWIN
-set -x PATH
-set -x PKG_CONFIG_PATH
-set -x PYTHONPATH
+set -x PATH $PATH
+set -x PKG_CONFIG_PATH $PKG_CONFIG_PATH
+set -x PYTHONPATH $PYTHONPATH
 
 # remember type of shell if not already set
 if test -z "$CATKIN_SHELL"

--- a/cmake/templates/setup.fish.in
+++ b/cmake/templates/setup.fish.in
@@ -94,6 +94,9 @@ set -e _SETUP_TMP
 # source all environment hooks
 set _i 0
 while test $_i -lt $_CATKIN_ENVIRONMENT_HOOKS_COUNT
+    # fish doesn't allow use of ${} to delimit variables within a string
+    set _i_WORKSPACE (string join "" "$i" "_WORKSPACE")
+
     eval set _envfile \$_CATKIN_ENVIRONMENT_HOOKS_$_i
     set -e _CATKIN_ENVIRONMENT_HOOKS_$_i
     eval set _envfile_workspace \$_CATKIN_ENVIRONMENT_HOOKS_$_i_WORKSPACE

--- a/cmake/templates/setup.sh.in
+++ b/cmake/templates/setup.sh.in
@@ -62,7 +62,7 @@ CATKIN_SHELL=$CATKIN_SHELL "$_SETUP_UTIL" $@ ${CATKIN_SETUP_UTIL_ARGS:-} >> "$_S
 _RC=$?
 if [ $_RC -ne 0 ]; then
   if [ $_RC -eq 2 ]; then
-    echo "Could not write the output of '$_SETUP_UTIL' to temporary file '$_SETUP_TMP': may be the disk if full?"
+    echo "Could not write the output of '$_SETUP_UTIL' to temporary file '$_SETUP_TMP': maybe the disk is full?"
   else
     echo "Failed to run '\"$_SETUP_UTIL\" $@': return code $_RC"
   fi

--- a/test/local_tests/test_with_mock_workspace.py
+++ b/test/local_tests/test_with_mock_workspace.py
@@ -31,7 +31,8 @@ class MockTest(AbstractCatkinWorkspaceTest):
         assert_exists(self.installdir,
                       'env.sh',
                       'setup.sh',
-                      'setup.zsh')
+                      'setup.zsh',
+                      'setup.fish')
 
     def test_linker_options_propagation(self):
         dstdir = os.path.join(self.workspacedir, 'linker_options')
@@ -43,7 +44,8 @@ class MockTest(AbstractCatkinWorkspaceTest):
         assert_exists(self.installdir,
                       'env.sh',
                       'setup.sh',
-                      'setup.zsh')
+                      'setup.zsh',
+                      'setup.fish')
 
     def test_nolang(self):
         dstdir = os.path.join(self.workspacedir, 'nolangs')

--- a/test/utils.py
+++ b/test/utils.py
@@ -95,7 +95,7 @@ def succeed(cmd, **kwargs):
     """
     print(">>>", cmd, kwargs)
     (r, out, err) = run(cmd, **kwargs)
-    print("<<<", out)
+    print("<<<", out.decode("utf-8"))
     assert r == 0, "cmd failed with result %s:\n %s " % (r, str(cmd))
     return out
 
@@ -106,7 +106,7 @@ def fail(cmd, **kwargs):
     """
     print(">>>", cmd, kwargs)
     (r, out, err) = run(cmd, withexitstatus=True, **kwargs)
-    print("<<<", out)
+    print("<<<", out.decode("utf-8"))
     assert 0 != r, """cmd succeeded, though should fail: %s
   result=%u\n  output=\n%s""" % (cmd, r, out)
     return out


### PR DESCRIPTION
The [fish shell](https://fishshell.com/) is an alternative shell to bash or zsh. It defines itself as a

> smart and user-friendly command line shell for Linux, macOS, and the rest of the family.

Fish is already kind of supported by catkin with use of the helper [bass](https://github.com/edc/bass), as documented in [rosbash](http://wiki.ros.org/rosbash) ROS wiki page. Specific support for it was already discussed in #921

This PR creates the files `setup.fish.in` and `local_setup.fish.in` to provide native setup scripts for fish users. The main benefit from this update is the possibility to use fish scripts as environment hooks in catkin workspaces.

For example, the script [rosfish](https://github.com/ros/ros/blob/noetic-devel/tools/rosbash/rosfish) (actual template [here](https://github.com/ros/ros/blob/noetic-devel/tools/rosbash/env-hooks/15.rosbash.fish.em)) is declared as [env hook](https://github.com/ros/ros/blob/noetic-devel/tools/rosbash/CMakeLists.txt#L32) in the package rosbash

Since `bass source setup.bash` runs a bash-like setup, this fish env hook is not loaded, so the usual sequence of commands to start a fish workspace is (as shown in [rosbash docs](http://wiki.ros.org/rosbash#fish))

```sh
bass source ~/catkin_ws/devel/setup.bash
source /opt/ros/noetic/share/rosbash/rosfish
```

With this PR, it becomes a simple

```sh
source ~/catkin_ws/devel/setup.fish
```

With the bonus that not only `rosfish` is loaded, but also any other fish-specific env hook in the workspace. It is particularly useful to extend packages like [ROS Workspace Scripts](https://github.com/tu-darmstadt-ros-pkg/workspace_scripts) to fish environments