### PR TITLE
Import setuptools before distutils

### DIFF
--- a/cmake/interrogate_setup_dot_py.py
+++ b/cmake/interrogate_setup_dot_py.py
@@ -40,14 +40,14 @@ from argparse import ArgumentParser
 setup_modules = []
 
 try:
-    import distutils.core
-    setup_modules.append(distutils.core)
+    import setuptools
+    setup_modules.append(setuptools)
 except ImportError:
     pass
 
 try:
-    import setuptools
-    setup_modules.append(setuptools)
+    import distutils.core
+    setup_modules.append(distutils.core)
 except ImportError:
     pass
 


### PR DESCRIPTION
Setuptools wants to be imported before distutils, and prints a warning if it is not. Starting with a recent version (>57.2, <=61.2), not following this rule causes catkin's own monkey patching to fail. This commit reverses the import order to fix the warning and patching issue.