### PR TITLE
Default to number of usable CPUs if possible

### DIFF
--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -322,7 +322,14 @@ def handle_make_arguments(input_make_args, append_default_jobs_flags=True):
             elif append_default_jobs_flags:
                 # Else Use the number of CPU cores
                 try:
-                    jobs = multiprocessing.cpu_count()
+                    if "sched_getaffinity" in dir(os):
+                        # Using sched_getaffinity we get the number of usable CPUs but
+                        # it's not available on all platforms
+                        jobs = len(os.sched_getaffinity(0))
+                    else:
+                        # cpu_count returns the number of all CPUs (available or not)
+                        jobs = multiprocessing.cpu_count()
+
                     make_args.append('-j{0}'.format(jobs))
                     make_args.append('-l{0}'.format(jobs))
                 except NotImplementedError:

--- a/python/catkin/builder.py
+++ b/python/catkin/builder.py
@@ -327,7 +327,7 @@ def handle_make_arguments(input_make_args, append_default_jobs_flags=True):
                         # it's not available on all platforms
                         jobs = len(os.sched_getaffinity(0))
                     else:
-                        # cpu_count returns the number of all CPUs (available or not)
+                        # cpu_count returns the number of CPUs (usable or not)
                         jobs = multiprocessing.cpu_count()
 
                     make_args.append('-j{0}'.format(jobs))


### PR DESCRIPTION
`multiprocessing.cpu_count()` returns the number of CPUs, usable or not. While in most situations this is good enough it fails when not all CPUs are usable. An example using docker:

1. Start a container: `docker run -it --rm --cpuset-cpus="0" ros:melodic-perception-bionic python3`
2. Run:
```
import multiprocessing
multiprocessing.cpu_count()
```

It will return the number of CPUs of the whole system instead of `1`, the number of CPUs that are available.
Consequently, when using `catkin_make` it tries to use more CPUs than the ones available and the build ends up failing.

Expected behavior is:
```
import os
len(os.sched_getaffinity(0))
```
Returns `1`.