### PR TITLE
Ignore generator expressions used in PKG_CONFIG_LIBRARIES

### DIFF
--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -118,7 +118,7 @@ endif()
 
 set(libraries "@PKG_CONFIG_LIBRARIES@")
 foreach(library ${libraries})
-  # keep build configuration keywords, target names and absolute libraries as-is
+  # keep build configuration keywords, generator expressions, target names, and absolute libraries as-is
   if("${library}" MATCHES "^(debug|optimized|general)$")
     list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
   elseif(${library} MATCHES "^-l")
@@ -146,6 +146,8 @@ foreach(library ${libraries})
       target_link_options("${interface_target_name}" INTERFACE "${library}")
     endif()
     list(APPEND @PROJECT_NAME@_LIBRARIES "${interface_target_name}")
+  elseif(${library} MATCHES "^\\$<")
+    list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
   elseif(TARGET ${library})
     list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
   elseif(IS_ABSOLUTE ${library})


### PR DESCRIPTION
Implements the suggestion of @sloretz in https://github.com/ros/urdf/issues/37#issuecomment-939183824
Fixes https://github.com/ros/urdf/issues/37