### PR TITLE
Use the newer unittest.mock from standard library on Python 3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,7 +40,6 @@
   <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-nose</build_export_depend>
 
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-mock</test_depend>
-  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-mock</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-nose</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-nose</test_depend>
 

--- a/test/unit_tests/test_environment_cache.py
+++ b/test/unit_tests/test_environment_cache.py
@@ -4,7 +4,10 @@ import stat
 import tempfile
 import unittest
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 try:
     import catkin.environment_cache

--- a/test/unit_tests/test_find_in_workspace.py
+++ b/test/unit_tests/test_find_in_workspace.py
@@ -3,7 +3,10 @@ import shutil
 import tempfile
 import unittest
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 try:
     import catkin

--- a/test/unit_tests/test_parse_package_xml.py
+++ b/test/unit_tests/test_parse_package_xml.py
@@ -4,7 +4,10 @@ import shutil
 import tempfile
 import unittest
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 imp.load_source('parse_package_xml',
                 os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.