### PR TITLE
Migrate away from PythonInterp CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12.0)
 
 set(catkin_EXTRAS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,7 +1,13 @@
 # the CMake variable PYTHON_INSTALL_DIR has the same value as the Python function catkin.builder.get_python_install_dir()
 
 set(PYTHON_VERSION "$ENV{ROS_PYTHON_VERSION}" CACHE STRING "Specify specific Python version to use ('major.minor' or 'major')")
-find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+find_package(Python ${PYTHON_VERSION} REQUIRED)
+
+# Set these legacy variables for compatibility with what PythonInterp used to do
+set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+set(PYTHON_VERSION_MAJOR ${Python_VERSION_MAJOR})
+set(PYTHON_VERSION_MINOR ${Python_VERSION_MINOR})
+set(PYTHON_VERSION_PATCH ${Python_VERSION_PATCH})
 
 message(STATUS "Using PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
 


### PR DESCRIPTION
Without this change, every catkin package built spams this into the log:

```
CMake Warning (dev) at /home/mikepurvis/roslib_ws/install/share/catkin/cmake/python.cmake:4 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /home/mikepurvis/roslib_ws/install/share/catkin/cmake/all.cmake:164 (include)
  /home/mikepurvis/roslib_ws/install/share/catkin/cmake/catkinConfig.cmake:20 (include)
  CMakeLists.txt:3 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

The new policy for CMake 3.27 is: https://cmake.org/cmake/help/latest/policy/CMP0148.html

The replacement FindPython module has been available since CMake 3.12, released in 2.18: https://cmake.org/cmake/help/latest/module/FindPython.html

ROS Noetic's stated minimum target is the CMake on Debian Buster, which is 3.13.4: https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025