### PR TITLE
Build/install wheel for Python packages

### DIFF
--- a/cmake/templates/python_distutils_install.sh.in
+++ b/cmake/templates/python_distutils_install.sh.in
@@ -24,10 +24,25 @@ echo_and_run mkdir -p "$DESTDIR@CMAKE_INSTALL_PREFIX@/@PYTHON_INSTALL_DIR@"
 echo_and_run /usr/bin/env \
     PYTHONPATH="@CMAKE_INSTALL_PREFIX@/@PYTHON_INSTALL_DIR@:@CMAKE_BINARY_DIR@/@PYTHON_INSTALL_DIR@:$PYTHONPATH" \
     CATKIN_BINARY_DIR="@CMAKE_BINARY_DIR@" \
-    "@PYTHON_EXECUTABLE@" \
-    "@CMAKE_CURRENT_SOURCE_DIR@/setup.py" \
-    @SETUPTOOLS_EGG_INFO@ \
-    build --build-base "@CMAKE_CURRENT_BINARY_DIR@" \
-    install \
-    --root="${DESTDIR-/}" \
-    @SETUPTOOLS_ARG_EXTRA@ --prefix="@CMAKE_INSTALL_PREFIX@" --install-scripts="@CMAKE_INSTALL_PREFIX@/@CATKIN_GLOBAL_BIN_DESTINATION@"
+    "@PYTHON_EXECUTABLE@" "-m" "build" \
+    "--no-isolation" \
+    "--wheel" \
+    "--outdir" "@CMAKE_CURRENT_BINARY_DIR@/wheel" \
+    "@CMAKE_CURRENT_SOURCE_DIR@"
+
+# Use pip to install the whl archive into the workspace's install directory
+WHEELFILE=$(ls "@CMAKE_CURRENT_BINARY_DIR@"/wheel/*.whl)
+echo_and_run /usr/bin/env \
+    PYTHONPATH="@CMAKE_INSTALL_PREFIX@/@PYTHON_INSTALL_DIR@:@CMAKE_BINARY_DIR@/@PYTHON_INSTALL_DIR@:$PYTHONPATH" \
+    CATKIN_BINARY_DIR="@CMAKE_BINARY_DIR@" \
+    PYTHONUSERBASE="@CMAKE_INSTALL_PREFIX@" \
+    "@PYTHON_EXECUTABLE@" "-m" "pip" "install" \
+    "--root" "/" \
+    "--isolated" \
+    "--no-deps" \
+    "--no-index" \
+    "--progress-bar" "off" \
+    "--disable-pip-version-check" \
+    "--user" \
+    "--upgrade" \
+    "$WHEELFILE"

--- a/package.xml
+++ b/package.xml
@@ -30,9 +30,13 @@
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-build</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-wheel</buildtool_depend>
 
   <buildtool_export_depend>cmake</buildtool_export_depend>
   <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_export_depend>
+  <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-build</buildtool_export_depend>
+  <buildtool_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-wheel</buildtool_export_depend>
 
   <build_export_depend>google-mock</build_export_depend>
   <build_export_depend>gtest</build_export_depend>


### PR DESCRIPTION
Addresses another bit of spam we encountered migrating our ROS 1 codebase to Python 3.11:

```
/nix/store/yvhwsfbh4bc99vfvwpaa70m4yng4pvpz-python3-3.11.8/lib/python3.11/distutils/cmd.py:62: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
```

I don't expect this to be accepted as it's a pretty significant change in operations for catkin and possibly even breaks core functionality such as the develspace (though we don't care as we now use colcon everywhere anyway). I'm offering it largely as a conversation piece to understand from the community if there is any interest in "modernizing" catkin's interface to Python in this way, and if so is calling the CLI interface to pypa/build and pip the correct way to go about it, or are there programmatic APIs that would be more logical to use? If we only want to continue supporting setuptools, then we can obviously use `setuptools.build_meta`, but if we're going to pay the cost of a wheel round trip anyway, why not put us on the path to working with pyproject-only packages too?

On the colcon side, there's been some lively discussion going on for a while in https://github.com/colcon/colcon-core/issues/208 and https://github.com/colcon/colcon-core/issues/454.